### PR TITLE
Fixes for macOS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -28,7 +28,8 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
     sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${OS_PYTHON_VERSION} 10
   fi
 elif [[ "$OSTYPE" == "darwin"* ]]; then  # Mac OSX
-  brew install python3 gcc@7
+  [[ -x "$(type python3)" ]] || brew install python3 || echo "** Warning: failed 'brew install python3' -- continuing"
+  # [[ -x "${type g++-7)" ]] || brew install gcc@7 || echo "** Warning: failed 'brew install gcc@7' -- continuing"
   curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
   python3 get-pip.py
   pip3 install virtualenv
@@ -38,8 +39,12 @@ else
   exit 1
 fi
 
-git clone -b 'v2.2.4' --single-branch --depth 1 https://github.com/pybind/pybind11.git
+[[ -d "./pybind11" ]] || git clone -b 'v2.2.4' --single-branch --depth 1 https://github.com/pybind/pybind11.git
 # TODO: Point to the official  https://github.com/dds-bridge/dds.git
 # when pull requests are in
-git clone -b 'develop' --single-branch --depth 1 https://github.com/jblespiau/dds.git  open_spiel/games/bridge/double_dummy_solver
-git clone -b 'master' --single-branch --depth 1 https://github.com/abseil/abseil-cpp.git open_spiel/abseil-cpp
+[[ -d open_spiel/games/bridge/double_dummy_solver ]] || \
+  git clone -b 'develop' --single-branch --depth 1 https://github.com/jblespiau/dds.git  \
+  open_spiel/games/bridge/double_dummy_solver
+[[ -d open_spiel/abseil-cpp ]] || \
+  git clone -b 'master' --single-branch --depth 1 https://github.com/abseil/abseil-cpp.git \
+  open_spiel/abseil-cpp

--- a/open_spiel/CMakeLists.txt
+++ b/open_spiel/CMakeLists.txt
@@ -8,9 +8,9 @@ Any Python library found with CMake modules FindPython2/FindPython3 that \
 agrees  with the major version and is at least as high for minor version and \
 patch number is accepted. If the variable is not set, we use the FindPython \
 module which favours Python 3 over Python 2 if both are available.")
-set (CMAKE_CXX_COMPILER "/usr/bin/g++")
+# set (CMAKE_CXX_COMPILER "/usr/bin/g++")
 set (CMAKE_CXX_STANDARD 11)
-set (CMAKE_CXX_FLAGS "-Werror")
+set (CMAKE_CXX_FLAGS "-Werror -undefined dynamic_lookup")
 
 # Position-independent code is needed for Python extension modules.
 set (CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/open_spiel/python/CMakeLists.txt
+++ b/open_spiel/python/CMakeLists.txt
@@ -1,13 +1,13 @@
-if(${Python_TARGET_VERSION} STREQUAL "")
+if(Python_TARGET_VERSION STREQUAL "")
   find_package(Python COMPONENTS Development)
   include_directories(SYSTEM ${Python_INCLUDE_DIRS})
-elseif(${Python_TARGET_VERSION} VERSION_LESS "3.0.0")
+elseif(Python_TARGET_VERSION VERSION_LESS "3.0.0")
   message(FATAL_ERROR
     "Only Python 3 is supported, not ${Python_TARGET_VERSION}")
-elseif(${Python_TARGET_VERSION} VERSION_GREATER_EQUAL "3.0.0")
+elseif(Python_TARGET_VERSION VERSION_GREATER_EQUAL "3.0.0")
   find_package(Python3 COMPONENTS Development)
   include_directories(SYSTEM ${Python3_INCLUDE_DIRS})
-  if(${Python3_VERSION} VERSION_LESS ${Python_TARGET_VERSION})
+  if(Python3_VERSION VERSION_LESS Python_TARGET_VERSION)
     message(FATAL_ERROR
       "Python found ${Python3_VERSION} < ${Python_TARGET_VERSION}")
   endif()

--- a/open_spiel/scripts/build_and_run_tests.sh
+++ b/open_spiel/scripts/build_and_run_tests.sh
@@ -29,13 +29,14 @@ set -e  # exit when any command fails
 set -x
 
 CXX=g++
+NPROC=nproc
 if [[ "$OSTYPE" == "darwin"* ]]; then  # Mac OSX
-  alias nproc="sysctl -n hw.physicalcpu"
+  NPROC="sysctl -n hw.physicalcpu"
   CXX=/usr/local/bin/g++-7
 fi
 
-MAKE_NUM_PROCS=$(nproc)
-let TEST_NUM_PROCS=4*$(nproc)
+MAKE_NUM_PROCS=$(${NPROC})
+let TEST_NUM_PROCS=4*${MAKE_NUM_PROCS}
 
 PYVERSION=$(python3 -c 'import sys; print(sys.version.split(" ")[0])')
 PY_VERSION_MAJOR=$(python3 -c 'import sys; print(sys.version_info.major)')


### PR DESCRIPTION
* Only install dependencies if necessary.
* Continue on when possible to end of script. Fixes #2.
* Used patch from https://github.com/deepmind/open_spiel/issues/4#issuecomment-525551096 to fix open_spiel/CMakeLists.txt
* Ignore empty `Python_TARGET_VERSION` in `open_spiel/python/CMakeLists.txt`
* Don't use `nproc` alias -- just use substitution for right command