### PR TITLE
changing build script command to "source"

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -18,7 +18,7 @@
 3.  Build and run tests to check everything works:
 
     ```bash
-    ./open_spiel/scripts/build_and_run_tests.sh
+    source open_spiel/scripts/build_and_run_tests.sh
     ```
 
 4.  Add


### PR DESCRIPTION
On MacOS I am getting the error "./open_spiel/scripts/build_and_run_tests.sh: line 38: nproc: command not found".  I think the way the script is run is messing with the aliasing (see [this SO post](https://stackoverflow.com/questions/15968053/using-alias-in-shell-script)).  I think running it with "source" should fix that issue.