### PR TITLE
fixed terminal condition in connect_four

### DIFF
--- a/open_spiel/games/connect_four.cc
+++ b/open_spiel/games/connect_four.cc
@@ -119,8 +119,8 @@ bool ConnectFourState::HasLineFrom(int player, int row, int col) const {
 
 bool ConnectFourState::HasLineFromInDirection(int player, int row, int col,
                                               int drow, int dcol) const {
-  if (row + 4 * drow >= kRows || col + 4 * dcol >= kCols ||
-      row + 4 * drow < 0 || col + 4 * dcol < 0)
+  if (row + 3 * drow >= kRows || col + 3 * dcol >= kCols ||
+      row + 3 * drow < 0 || col + 3 * dcol < 0)
     return false;
   CellState c = PlayerToState(player);
   for (int i = 0; i < 4; ++i) {


### PR DESCRIPTION
There was an error in the terminal condition check in the C++ implementation of connect four. 

Short explanation: You only need to check 3 cells to the side of your initial checking point, to reach a connected length of 4, as the initial cell is also part of the connecting chain. This was not correctly implemented in the out-of-range checking before the actual connection check. Resulting behaviour was missing terminal state along edges.

This solves #25  