### PR TITLE
fix install osx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ build/
 open_spiel/abseil-cpp/
 open_spiel/games/bridge/double_dummy_solver/
 pybind11/
+
+# Install artifacts
+get-pip.py
+
+# IDE
+.idea/

--- a/install.sh
+++ b/install.sh
@@ -29,7 +29,7 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
   fi
 elif [[ "$OSTYPE" == "darwin"* ]]; then  # Mac OSX
   [[ -x "$(type python3)" ]] || brew install python3 || echo "** Warning: failed 'brew install python3' -- continuing"
-  # [[ -x "${type g++-7)" ]] || brew install gcc@7 || echo "** Warning: failed 'brew install gcc@7' -- continuing"
+  [[ -x "$(type g++-7)" ]] || brew install gcc@7 || echo "** Warning: failed 'brew install gcc@7' -- continuing"
   curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
   python3 get-pip.py
   pip3 install virtualenv


### PR DESCRIPTION
Fresh install fails, seems like `brew install gcc@7` was unintentionally removed from the install script.

```
$ ./open_spiel/scripts/build_and_run_tests.sh

+ CXX=g++
+ [[ darwin18 == \d\a\r\w\i\n* ]]
+ CXX=/usr/local/bin/g++-7
++ sysctl -n hw.physicalcpu
CMake Error at CMakeLists.txt:4 (project):
  The CMAKE_CXX_COMPILER:

    /usr/local/bin/g++-7

  is not a full path to an existing compiler tool.
```