### PR TITLE
Changed hash behavior for TicTacToe

### DIFF
--- a/swift/Sources/OpenSpiel/Spiel.swift
+++ b/swift/Sources/OpenSpiel/Spiel.swift
@@ -211,19 +211,15 @@ public extension StateProtocol {
   var legalActionsMaskAsTensor: Tensor<Double> {
     return Tensor(legalActionsMask.map { $0 ? 0 : -Double.infinity })
   }
-}
-
-public extension Equatable where Self: StateProtocol {
-  static func == (lhs: Self, rhs: Self) -> Bool {
-    return lhs.history == rhs.history
-  }
-}
-
-public extension Hashable where Self: StateProtocol {
+  
   /// Given a game instance, `State`s can be identified by their history.
   /// Some games (e.g., with cycles) may choose to override this.
   func hash(into hasher: inout Hasher) {
     hasher.combine(history)
+  }
+  
+  static func == (lhs: Self, rhs: Self) -> Bool {
+    return lhs.history == rhs.history
   }
 }
 


### PR DESCRIPTION
Current implementation of hash in Spiel.swift uses the sequential history of actions.
This causes an explosion of states for games, which typically is undesirable at least for TicTacToe and Go. The reason for this is that lots of different action sequences lead to the same board configurations.
AFAIK only current board configuration is considered to assess next action (not how the history of how which actions were used to arrive at that configuration). For TicTacToe, this reduces the state space from 255168 which are the number of ways to play a game, to 4520 which are the maximum number of board configurations.

Of the other games, at least Go seems to have a similar issue, and in that case it will cause an enormous state space.

Reservation: I only tested the change in Spiel.swift implementation on TicTacToe. Needed to do the changes to Spiel.swift in order to override hashing behavior (might be other ways to do it I'm not aware of).