### PR TITLE
Use type 'Player' instead of 'int' in as many places as possible.

### DIFF
--- a/open_spiel/algorithms/deterministic_policy.cc
+++ b/open_spiel/algorithms/deterministic_policy.cc
@@ -20,7 +20,7 @@ namespace open_spiel {
 namespace algorithms {
 
 DeterministicTabularPolicy::DeterministicTabularPolicy(
-    const Game& game, int player,
+    const Game& game, Player player,
     const std::unordered_map<std::string, Action> policy)
     : table_(), player_(player) {
   CreateTable(game, player);
@@ -32,7 +32,7 @@ DeterministicTabularPolicy::DeterministicTabularPolicy(
 }
 
 DeterministicTabularPolicy::DeterministicTabularPolicy(const Game& game,
-                                                       int player)
+                                                       Player player)
     : table_(), player_(player) {
   CreateTable(game, player);
 }
@@ -80,7 +80,7 @@ void DeterministicTabularPolicy::ResetDefaultPolicy() {
   }
 }
 
-void DeterministicTabularPolicy::CreateTable(const Game& game, int player) {
+void DeterministicTabularPolicy::CreateTable(const Game& game, Player player) {
   std::unordered_map<std::string, std::vector<Action>> legal_actions_map =
       GetLegalActionsMap(game, -1, player);
   for (const auto& info_state_actions : legal_actions_map) {

--- a/open_spiel/algorithms/deterministic_policy.h
+++ b/open_spiel/algorithms/deterministic_policy.h
@@ -62,12 +62,12 @@ class DeterministicTabularPolicy : public Policy {
  public:
   // Creates a deterministic policy and sets it to the specified policy.
   DeterministicTabularPolicy(
-      const Game& game, int player,
+      const Game& game, Player player,
       const std::unordered_map<std::string, Action> policy);
 
   // Creates a default deterministic policy, with all actions set to their first
   // legal action (index 0 in the legal actions list).
-  DeterministicTabularPolicy(const Game& game, int player);
+  DeterministicTabularPolicy(const Game& game, Player player);
 
   ActionsAndProbs GetStatePolicy(const std::string& info_state) const override;
   Action GetAction(const std::string& info_state) const;
@@ -98,10 +98,10 @@ class DeterministicTabularPolicy : public Policy {
   std::string ToString(const std::string& delimiter) const;
 
  private:
-  void CreateTable(const Game& game, int player);
+  void CreateTable(const Game& game, Player player);
 
   std::unordered_map<std::string, LegalsWithIndex> table_;
-  int player_;
+  Player player_;
 };
 
 }  // namespace algorithms

--- a/open_spiel/algorithms/deterministic_policy_test.cc
+++ b/open_spiel/algorithms/deterministic_policy_test.cc
@@ -26,13 +26,13 @@ void KuhnDeterministicPolicyTest() {
   int p0_policies = 1;
   int p1_policies = 1;
 
-  DeterministicTabularPolicy p0_policy(kuhn_game, 0);
+  DeterministicTabularPolicy p0_policy(kuhn_game, Player{0});
   while (p0_policy.NextPolicy()) {
     p0_policies += 1;
   }
   SPIEL_CHECK_EQ(p0_policies, 64);  // 2^6
 
-  DeterministicTabularPolicy p1_policy(kuhn_game, 1);
+  DeterministicTabularPolicy p1_policy(kuhn_game, Player{1});
   while (p1_policy.NextPolicy()) {
     p1_policies += 1;
   }

--- a/open_spiel/algorithms/evaluate_bots.cc
+++ b/open_spiel/algorithms/evaluate_bots.cc
@@ -28,11 +28,11 @@ std::vector<double> EvaluateBots(State* state, const std::vector<Bot*>& bots,
       state->ApplyAction(
           SampleChanceOutcome(state->ChanceOutcomes(), uniform(rng)));
     } else if (state->IsSimultaneousNode()) {
-      for (int i = 0; i < num_players; ++i) {
-        if (state->LegalActions(i).empty()) {
-          joint_actions[i] = kInvalidAction;
+      for (auto p = Player{0}; p < num_players; ++p) {
+        if (state->LegalActions(p).empty()) {
+          joint_actions[p] = kInvalidAction;
         } else {
-          joint_actions[i] = bots[i]->Step(*state).second;
+          joint_actions[p] = bots[p]->Step(*state).second;
         }
       }
       state->ApplyActions(joint_actions);

--- a/open_spiel/algorithms/evaluate_bots_test.cc
+++ b/open_spiel/algorithms/evaluate_bots_test.cc
@@ -21,8 +21,8 @@ namespace {
 
 void BotTest_RandomVsRandom() {
   auto game = LoadGame("kuhn_poker");
-  auto bot0 = MakeUniformRandomBot(*game, /*player_id=*/0, /*seed=*/1234);
-  auto bot1 = MakeUniformRandomBot(*game, /*player_id=*/1, /*seed=*/4321);
+  auto bot0 = MakeUniformRandomBot(*game, Player{0}, /*seed=*/1234);
+  auto bot1 = MakeUniformRandomBot(*game, Player{1}, /*seed=*/4321);
   constexpr int num_players = 2;
   std::vector<double> average_results(num_players);
   constexpr int num_iters = 100000;
@@ -30,12 +30,12 @@ void BotTest_RandomVsRandom() {
     auto this_results =
         EvaluateBots(game->NewInitialState().get(), {bot0.get(), bot1.get()},
                      /*seed=*/iteration);
-    for (int i = 0; i < num_players; ++i) {
-      average_results[i] += this_results[i];
+    for (auto p = Player{0}; p < num_players; ++p) {
+      average_results[p] += this_results[p];
     }
   }
-  for (int i = 0; i < num_players; ++i) {
-    average_results[i] /= num_iters;
+  for (auto p = Player{0}; p < num_players; ++p) {
+    average_results[p] /= num_iters;
   }
 
   SPIEL_CHECK_FLOAT_NEAR(average_results[0], 0.125, 0.01);

--- a/open_spiel/algorithms/expected_returns.cc
+++ b/open_spiel/algorithms/expected_returns.cc
@@ -30,7 +30,7 @@ namespace {
 // information state.
 std::vector<double> ExpectedReturnsImpl(
     const State& state,
-    const std::function<ActionsAndProbs(int, const std::string&)>& policy_func,
+    const std::function<ActionsAndProbs(Player, const std::string&)>& policy_func,
     int depth_limit) {
   if (state.IsTerminal() || depth_limit == 0) {
     return state.Rewards();
@@ -44,7 +44,7 @@ std::vector<double> ExpectedReturnsImpl(
       std::unique_ptr<State> child = state.Child(action_and_prob.first);
       std::vector<double> child_values =
           ExpectedReturnsImpl(*child, policy_func, depth_limit - 1);
-      for (int p = 0; p < num_players; ++p) {
+      for (auto p = Player{0}; p < num_players; ++p) {
         values[p] += action_and_prob.second * child_values[p];
       }
     }
@@ -55,7 +55,7 @@ std::vector<double> ExpectedReturnsImpl(
     auto smstate = dynamic_cast<const SimMoveState*>(&state);
     SPIEL_CHECK_TRUE(smstate != nullptr);
     std::vector<ActionsAndProbs> state_policies(num_players);
-    for (int p = 0; p < num_players; ++p) {
+    for (auto p = Player{0}; p < num_players; ++p) {
       state_policies[p] = policy_func(p, state.InformationState(p));
       if (state_policies[p].empty()) {
         SpielFatalError("Error in ExpectedReturnsImpl; infostate not found.");
@@ -65,7 +65,7 @@ std::vector<double> ExpectedReturnsImpl(
       std::vector<Action> actions =
           smstate->FlatJointActionToActions(flat_action);
       double joint_action_prob = 1.0;
-      for (int p = 0; p < num_players; ++p) {
+      for (auto p = Player{0}; p < num_players; ++p) {
         double player_action_prob = GetProb(state_policies[p], actions[p]);
         SPIEL_CHECK_GE(player_action_prob, 0.0);
         SPIEL_CHECK_LE(player_action_prob, 1.0);
@@ -80,14 +80,14 @@ std::vector<double> ExpectedReturnsImpl(
         child->ApplyActions(actions);
         std::vector<double> child_values =
             ExpectedReturnsImpl(*child, policy_func, depth_limit - 1);
-        for (int p = 0; p < num_players; ++p) {
+        for (auto p = Player{0}; p < num_players; ++p) {
           values[p] += joint_action_prob * child_values[p];
         }
       }
     }
   } else {
     // Turn-based decision node.
-    int player = state.CurrentPlayer();
+    Player player = state.CurrentPlayer();
     ActionsAndProbs state_policy =
         policy_func(player, state.InformationState());
     if (state_policy.empty()) {
@@ -102,7 +102,7 @@ std::vector<double> ExpectedReturnsImpl(
       if (action_prob > 0.0) {
         std::vector<double> child_values =
             ExpectedReturnsImpl(*child, policy_func, depth_limit - 1);
-        for (int p = 0; p < num_players; ++p) {
+        for (auto p = Player{0}; p < num_players; ++p) {
           values[p] += action_prob * child_values[p];
         }
       }
@@ -118,7 +118,7 @@ std::vector<double> ExpectedReturns(const State& state,
                                     int depth_limit) {
   return ExpectedReturnsImpl(
       state,
-      [&policies](int player, const std::string& info_state) {
+      [&policies](Player player, const std::string& info_state) {
         return policies[player]->GetStatePolicy(info_state);
       },
       depth_limit);
@@ -129,7 +129,7 @@ std::vector<double> ExpectedReturns(const State& state,
                                     int depth_limit) {
   return ExpectedReturnsImpl(
       state,
-      [&joint_policy](int player, const std::string& info_state) {
+      [&joint_policy](Player player, const std::string& info_state) {
         return joint_policy.GetStatePolicy(info_state);
       },
       depth_limit);

--- a/open_spiel/algorithms/external_sampling_mccfr.cc
+++ b/open_spiel/algorithms/external_sampling_mccfr.cc
@@ -37,7 +37,7 @@ ExternalSamplingMCCFRSolver::ExternalSamplingMCCFRSolver(const Game& game,
 void ExternalSamplingMCCFRSolver::RunIteration() { RunIteration(rng_.get()); }
 
 void ExternalSamplingMCCFRSolver::RunIteration(std::mt19937* rng) {
-  for (int p = 0; p < game_->NumPlayers(); ++p) {
+  for (auto p = Player{0}; p < game_->NumPlayers(); ++p) {
     UpdateRegrets(*game_->NewInitialState(), p, rng);
   }
 
@@ -48,7 +48,7 @@ void ExternalSamplingMCCFRSolver::RunIteration(std::mt19937* rng) {
 }
 
 double ExternalSamplingMCCFRSolver::UpdateRegrets(const State& state,
-                                                  int player,
+                                                  Player player,
                                                   std::mt19937* rng) {
   if (state.IsTerminal()) {
     return state.PlayerReturn(player);
@@ -61,7 +61,7 @@ double ExternalSamplingMCCFRSolver::UpdateRegrets(const State& state,
         "TurnBasedSimultaneousGame to convert the game first.");
   }
 
-  int cur_player = state.CurrentPlayer();
+  Player cur_player = state.CurrentPlayer();
   std::string is_key = state.InformationState(cur_player);
   std::vector<Action> legal_actions = state.LegalActions();
 
@@ -131,7 +131,7 @@ void ExternalSamplingMCCFRSolver::FullUpdateAverage(
   double sum = std::accumulate(reach_probs.begin(), reach_probs.end(), 0.0);
   if (sum == 0.0) return;
 
-  int cur_player = state.CurrentPlayer();
+  Player cur_player = state.CurrentPlayer();
   std::string is_key = state.InformationState(cur_player);
   std::vector<Action> legal_actions = state.LegalActions();
 

--- a/open_spiel/algorithms/external_sampling_mccfr.h
+++ b/open_spiel/algorithms/external_sampling_mccfr.h
@@ -70,7 +70,7 @@ class ExternalSamplingMCCFRSolver {
   }
 
  private:
-  double UpdateRegrets(const State& state, int player, std::mt19937* rng);
+  double UpdateRegrets(const State& state, Player player, std::mt19937* rng);
   void FullUpdateAverage(const State& state,
                          const std::vector<double>& reach_probs);
 

--- a/open_spiel/algorithms/get_legal_actions_map.cc
+++ b/open_spiel/algorithms/get_legal_actions_map.cc
@@ -22,7 +22,7 @@ namespace {
 // search of all the subtrees to fill the map for all the information states.
 void FillMap(const State& state,
              std::unordered_map<std::string, std::vector<Action>>* map,
-             int depth_limit, int depth, int player) {
+             int depth_limit, int depth, Player player) {
   if (state.IsTerminal()) {
     return;
   }
@@ -35,7 +35,7 @@ void FillMap(const State& state,
     // Do nothing at chance nodes (no information states).
   } else if (state.IsSimultaneousNode()) {
     // Many players can play at this node.
-    for (int p = 0; p < state.NumPlayers(); ++p) {
+    for (auto p = Player{0}; p < state.NumPlayers(); ++p) {
       if (player == kInvalidPlayer || p == player) {
         std::string info_state = state.InformationState(p);
         if (map->find(info_state) == map->end()) {
@@ -67,7 +67,7 @@ void FillMap(const State& state,
 }  // namespace
 
 std::unordered_map<std::string, std::vector<Action>> GetLegalActionsMap(
-    const Game& game, int depth_limit, int player) {
+    const Game& game, int depth_limit, Player player) {
   std::unordered_map<std::string, std::vector<Action>> map;
   std::unique_ptr<State> initial_state = game.NewInitialState();
   FillMap(*initial_state, &map, depth_limit, 0, player);

--- a/open_spiel/algorithms/get_legal_actions_map.h
+++ b/open_spiel/algorithms/get_legal_actions_map.h
@@ -30,7 +30,7 @@ namespace algorithms {
 // bundle all the legal actions for all players in the same map, use
 // kInvalidPlayer.
 std::unordered_map<std::string, std::vector<Action>> GetLegalActionsMap(
-    const Game& game, int depth_limit, int player);
+    const Game& game, int depth_limit, Player player);
 
 }  // namespace algorithms
 }  // namespace open_spiel

--- a/open_spiel/algorithms/get_legal_actions_map_test.cc
+++ b/open_spiel/algorithms/get_legal_actions_map_test.cc
@@ -35,17 +35,17 @@ void KuhnTest() {
 
   LegalActionsMap map_p0 = algorithms::GetLegalActionsMap(game,
                                                           /*depth_limit=*/-1,
-                                                          /*player=*/0);
+                                                          open_spiel::Player{0});
   SPIEL_CHECK_EQ(map_p0.size(), kuhn_poker::kNumInfoStatesP0);
 
   LegalActionsMap map_p1 = algorithms::GetLegalActionsMap(game,
                                                           /*depth_limit=*/-1,
-                                                          /*player=*/1);
+                                                          open_spiel::Player{1});
   SPIEL_CHECK_EQ(map_p1.size(), kuhn_poker::kNumInfoStatesP1);
 
   LegalActionsMap map_both =
       algorithms::GetLegalActionsMap(game, /*depth_limit=*/-1,
-                                     /*player=*/open_spiel::kInvalidPlayer);
+                                     open_spiel::kInvalidPlayer);
   SPIEL_CHECK_EQ(map_both.size(),
                  kuhn_poker::kNumInfoStatesP0 + kuhn_poker::kNumInfoStatesP1);
   // They should all have two legal actions: pass and bet.
@@ -58,7 +58,7 @@ void LeducTest() {
   leduc_poker::LeducGame game({});
   LegalActionsMap map_both =
       algorithms::GetLegalActionsMap(game, /*depth_limit=*/-1,
-                                     /*player=*/open_spiel::kInvalidPlayer);
+                                     open_spiel::kInvalidPlayer);
   SPIEL_CHECK_EQ(map_both.size(), leduc_poker::kNumInfoStates);
 }
 
@@ -66,7 +66,7 @@ void GoofspielTest() {
   goofspiel::GoofspielGame game({{"num_cards", open_spiel::GameParameter(3)}});
   LegalActionsMap map_both =
       algorithms::GetLegalActionsMap(game, /*depth_limit=*/-1,
-                                     /*player=*/open_spiel::kInvalidPlayer);
+                                     open_spiel::kInvalidPlayer);
   SPIEL_CHECK_GT(map_both.size(), 0);
 }
 

--- a/open_spiel/algorithms/history_tree.h
+++ b/open_spiel/algorithms/history_tree.h
@@ -32,7 +32,7 @@ namespace algorithms {
 // history in the game.
 class HistoryNode {
  public:
-  HistoryNode(int player_id, std::unique_ptr<State> game_state);
+  HistoryNode(Player player_id, std::unique_ptr<State> game_state);
 
   State* GetState() { return state_.get(); }
 
@@ -77,7 +77,7 @@ class HistoryTree {
   // Builds a tree of histories. player_id is needed here as we view all chance
   // and terminal nodes from the viewpoint of player_id. Decision nodes are
   // viewed from the perspective of the player making the decision.
-  HistoryTree(std::unique_ptr<State> state, int player_id);
+  HistoryTree(std::unique_ptr<State> state, Player player_id);
 
   HistoryNode* Root() { return root_.get(); }
 
@@ -101,21 +101,21 @@ class HistoryTree {
 // actions, a probability of 1 for all of the best_responder's actions, and the
 // natural chance probabilty for all change actions. We return all infosets
 // (i.e. all sets of history nodes grouped by infostate) for the sub-game rooted
-// at state, from the perspective of the player with id best_responder_id.
+// at state, from the perspective of the player with id best_responder.
 std::unordered_map<std::string, std::vector<std::pair<HistoryNode*, double>>>
-GetAllInfoSets(std::unique_ptr<State> state, int best_responder_id,
+GetAllInfoSets(std::unique_ptr<State> state, Player best_responder,
                const Policy* policy, HistoryTree* tree);
 
 // For a given state, returns all successor states with accompanying
 // counter-factual probabilities.
 ActionsAndProbs GetSuccessorsWithProbs(const State& state,
-                                       int best_responder_id,
+                                       Player best_responder,
                                        const Policy* policy);
 
 // Returns all decision nodes, with accompanying counter-factual probabilities,
 // for the sub-game rooted at parent_state.
 std::vector<std::pair<std::unique_ptr<State>, double>> DecisionNodes(
-    const State& parent_state, int best_responder_id, const Policy* policy);
+    const State& parent_state, Player best_responder, const Policy* policy);
 
 }  // namespace algorithms
 }  // namespace open_spiel

--- a/open_spiel/algorithms/history_tree_test.cc
+++ b/open_spiel/algorithms/history_tree_test.cc
@@ -45,7 +45,7 @@ void TestGameTree() {
 
   for (const auto& game_name : game_names) {
     std::unique_ptr<Game> game = LoadGame(game_name);
-    for (int player_id : {0, 1}) {
+    for (Player player_id : {Player{0}, Player{1}}) {
       HistoryTree tree(game->NewInitialState(), player_id);
       if (tree.NumHistories() != num_histories[game_name]) {
         // TODO(b/126764761): Replace calls to SpielFatalError with more
@@ -131,9 +131,9 @@ void TestInfoSetsHaveRightNumberOfGameStates() {
   std::unique_ptr<Game> game = LoadGame("kuhn_poker");
   std::unique_ptr<State> state = game->NewInitialState();
   TabularPolicy policy = GetUniformPolicy(*game);
-  int best_responder_id = 0;
-  HistoryTree tree(game->NewInitialState(), best_responder_id);
-  auto infosets = GetAllInfoSets(game->NewInitialState(), best_responder_id,
+  auto best_responder = Player{0};
+  HistoryTree tree(game->NewInitialState(), best_responder);
+  auto infosets = GetAllInfoSets(game->NewInitialState(), best_responder,
                                  &policy, &tree);
   for (const auto& kv : infosets) {
     const std::string& infostate = kv.first;
@@ -162,9 +162,9 @@ void TestGetAllInfoSetsMatchesInfoStates() {
   std::unique_ptr<Game> game = LoadGame("kuhn_poker");
   std::unique_ptr<State> state = game->NewInitialState();
   TabularPolicy policy = GetUniformPolicy(*game);
-  for (const auto& best_responder_id : {0, 1}) {
-    HistoryTree tree(game->NewInitialState(), best_responder_id);
-    auto infosets = GetAllInfoSets(game->NewInitialState(), best_responder_id,
+  for (const auto& best_responder : {Player{0}, Player{1}}) {
+    HistoryTree tree(game->NewInitialState(), best_responder);
+    auto infosets = GetAllInfoSets(game->NewInitialState(), best_responder,
                                    &policy, &tree);
     for (const auto& kv : infosets) {
       const std::string& infostate = kv.first;
@@ -179,7 +179,7 @@ void TestGetAllInfoSetsMatchesInfoStates() {
         }
         State* node_state = node->GetState();
         std::string state_infostate =
-            node_state->InformationState(best_responder_id);
+            node_state->InformationState(best_responder);
         if (node_infostate != state_infostate) {
           SpielFatalError(
               absl::StrCat("infostate stored in node (", node_infostate, ") ",
@@ -187,18 +187,18 @@ void TestGetAllInfoSetsMatchesInfoStates() {
                            "stored in node (", state_infostate, ")."));
         }
         if (node->GetType() == StateType::kDecision) {
-          if (node_state->CurrentPlayer() != best_responder_id) {
+          if (node_state->CurrentPlayer() != best_responder) {
             SpielFatalError(
                 absl::StrCat("CurrentPlayer for state stored in node (",
                              node_state->CurrentPlayer(), ") does not match ",
-                             "best_responder_id (", best_responder_id, ")."));
+                             "best_responder (", best_responder, ")."));
           }
         } else if (node->GetType() == StateType::kDecision) {
-          if (node_state->CurrentPlayer() == best_responder_id) {
+          if (node_state->CurrentPlayer() == best_responder) {
             SpielFatalError(absl::StrCat(
                 "CurrentPlayer for state stored in node (",
-                node_state->CurrentPlayer(), ") matches best_responder_id (",
-                best_responder_id, ") but has type kDecision."));
+                node_state->CurrentPlayer(), ") matches best_responder (",
+                best_responder, ") but has type kDecision."));
           }
         }
         std::vector<Action> child_actions_vector = node->GetChildActions();
@@ -217,9 +217,9 @@ void TestGetAllInfoSetsMatchesInfoStates() {
             SpielFatalError("Legal action found that's not a child action.");
           }
           std::unique_ptr<State> child = node_state->Child(legal_action);
-          HistoryNode child_node = HistoryNode(0, std::move(child));
+          HistoryNode child_node = HistoryNode(Player{0}, std::move(child));
           if (node->GetType() != StateType::kChance) {
-            int child_player = child_node.GetState()->CurrentPlayer();
+            Player child_player = child_node.GetState()->CurrentPlayer();
             if (node_state->CurrentPlayer() == child_player) {
               SpielFatalError(absl::StrCat(
                   "Child and parent have the same current player (",
@@ -241,13 +241,13 @@ void TestHistoryTreeIsSubsetOfGetAllInfoSets() {
   std::unique_ptr<Game> game = LoadGame("kuhn_poker");
   std::unique_ptr<State> state = game->NewInitialState();
   TabularPolicy policy = GetUniformPolicy(*game);
-  for (const auto& best_responder_id : {0, 1}) {
-    HistoryTree tree(game->NewInitialState(), best_responder_id);
-    auto infosets = GetAllInfoSets(game->NewInitialState(), best_responder_id,
+  for (const auto& best_responder : {Player{0}, Player{1}}) {
+    HistoryTree tree(game->NewInitialState(), best_responder);
+    auto infosets = GetAllInfoSets(game->NewInitialState(), best_responder,
                                    &policy, &tree);
     for (const auto& history : tree.GetHistories()) {
       HistoryNode* node = tree.GetByHistory(history);
-      if (node->GetState()->CurrentPlayer() == best_responder_id &&
+      if (node->GetState()->CurrentPlayer() == best_responder &&
           node->GetType() != StateType::kTerminal &&
           infosets.count(node->GetInfoState()) == 0) {
         SpielFatalError(absl::StrCat("Infoset ", node->GetInfoState(),
@@ -260,14 +260,14 @@ void TestHistoryTreeIsSubsetOfGetAllInfoSets() {
 // This is a common test that we want to make. We want to validate the
 // counter-factual probabilities produced by this implementation against the
 // golden values produced by existing implementations.
-// best_responder_id is the player from who's view the infostate strings are
+// best_responder is the player from who's view the infostate strings are
 // calculated from, and represents the player for whom we are calculating a
 // best response as. It can be any value in the range [0, game.NumPlayers()).
 void CheckCounterFactualProbs(
     const Game& game, const TabularPolicy& policy,
     const std::unordered_map<std::string, double>& histories_and_probs,
-    int best_responder_id) {
-  HistoryTree tree(game.NewInitialState(), best_responder_id);
+    Player best_responder) {
+  HistoryTree tree(game.NewInitialState(), best_responder);
 
   // Infosets maps infostate strings to a list of all histories that map to that
   // same infostate, along with corresponding counter-factual reach
@@ -282,10 +282,10 @@ void CheckCounterFactualProbs(
   //   probability by the probability that player makes that decision (taken
   //   here from their policy).
   // Infostate strings here are assumed to be those that are returned from
-  // open_spiel::State::InformationState(best_responder_id), which are
+  // open_spiel::State::InformationState(best_responder), which are
   // equivalent to those returned by HistoryNode::GetInfoState.
   std::unordered_map<std::string, std::vector<std::pair<HistoryNode*, double>>>
-      infosets = GetAllInfoSets(game.NewInitialState(), best_responder_id,
+      infosets = GetAllInfoSets(game.NewInitialState(), best_responder,
                                 &policy, &tree);
 
   // We check this for every infoset in the game.
@@ -299,7 +299,7 @@ void CheckCounterFactualProbs(
       // failures (as the probability would be wrong at a different decision
       // node iff the probability is wrong at a decision node where the best
       // responder is playing).
-      if (node->GetState()->CurrentPlayer() != best_responder_id) continue;
+      if (node->GetState()->CurrentPlayer() != best_responder) continue;
       double prob = state_and_prob.second;
       auto it = histories_and_probs.find(node->GetHistory());
       if (it == histories_and_probs.end())
@@ -330,7 +330,7 @@ void TestGetAllInfoSetsHasRightCounterFactualProbsUniformPolicyPid0() {
   std::unique_ptr<Game> game = LoadGame("kuhn_poker");
   TabularPolicy policy = GetUniformPolicy(*game);
   CheckCounterFactualProbs(*game, policy, histories_and_probs,
-                           /*best_responder_id=*/0);
+                           /*best_responder=*/Player{0});
 }
 
 // Verifies that GetAllInfoSets returns the correct counter-factual
@@ -347,7 +347,7 @@ void TestGetAllInfoSetsHasRightCounterFactualProbsUniformPolicyPid1() {
   std::unique_ptr<Game> game = LoadGame("kuhn_poker");
   TabularPolicy policy = GetUniformPolicy(*game);
   CheckCounterFactualProbs(*game, policy, histories_and_probs,
-                           /*best_responder_id=*/1);
+                           /*best_responder=*/Player{1});
 }
 
 // Verifies that GetAllInfoSets returns the correct counter-factual
@@ -366,7 +366,7 @@ void TestGetAllInfoSetsHasRightCounterFactualProbsAlwaysFoldPid0() {
   std::unique_ptr<Game> game = LoadGame("kuhn_poker");
   TabularPolicy policy = GetFirstActionPolicy(*game);
   CheckCounterFactualProbs(*game, policy, histories_and_probs,
-                           /*best_responder_id=*/0);
+                           /*best_responder=*/Player{0});
 }
 
 // Verifies that GetAllInfoSets returns the correct counter-factual
@@ -383,7 +383,7 @@ void TestGetAllInfoSetsHasRightCounterFactualProbsAlwaysFoldPid1() {
   std::unique_ptr<Game> game = LoadGame("kuhn_poker");
   TabularPolicy policy = GetFirstActionPolicy(*game);
   CheckCounterFactualProbs(*game, policy, histories_and_probs,
-                           /*best_responder_id=*/1);
+                           /*best_responder=*/Player{1});
 }
 
 // The optimal Kuhn policy is taken directly from the Python implementation in
@@ -426,7 +426,7 @@ void TestGetAllInfoSetsHasRightCounterFactualProbsOptimalPid0() {
   std::unique_ptr<Game> game = LoadGame("kuhn_poker");
   TabularPolicy policy = GetOptimalKuhnPolicy(/*alpha=*/0.2);
   CheckCounterFactualProbs(*game, policy, histories_and_probs,
-                           /*best_responder_id=*/0);
+                           /*best_responder=*/Player{0});
 }
 
 // Verifies that GetAllInfoSets returns the correct counter-factual
@@ -443,7 +443,7 @@ void TestGetAllInfoSetsHasRightCounterFactualProbsOptimalPid1() {
   std::unique_ptr<Game> game = LoadGame("kuhn_poker");
   TabularPolicy policy = GetOptimalKuhnPolicy(/*alpha=*/0.2);
   CheckCounterFactualProbs(*game, policy, histories_and_probs,
-                           /*best_responder_id=*/1);
+                           /*best_responder=*/Player{1});
 }
 
 }  // namespace

--- a/open_spiel/algorithms/matrix_game_utils_test.cc
+++ b/open_spiel/algorithms/matrix_game_utils_test.cc
@@ -30,8 +30,8 @@ void ConvertToMatrixGameTest() {
   SPIEL_CHECK_EQ(matrix_blotto->NumCols(), 66);
   std::cout << "Blotto 0,13 = " << matrix_blotto->RowActionName(0) << " vs "
             << matrix_blotto->ColActionName(13)
-            << " -> utils: " << matrix_blotto->PlayerUtility(0, 0, 13) << ","
-            << matrix_blotto->PlayerUtility(1, 0, 13) << std::endl;
+            << " -> utils: " << matrix_blotto->PlayerUtility(Player{0}, 0, 13) << ","
+            << matrix_blotto->PlayerUtility(Player{1}, 0, 13) << std::endl;
 }
 
 void ExtensiveToMatrixGameTest() {

--- a/open_spiel/algorithms/mcts.cc
+++ b/open_spiel/algorithms/mcts.cc
@@ -81,7 +81,7 @@ std::unique_ptr<State> ApplyTreePolicy(SearchNode* root,
         current_node->children.emplace_back();
       }
       current_node->player_sign =
-          (working_state->CurrentPlayer() == 0) ? 1 : -1;
+          (working_state->CurrentPlayer() == Player{0}) ? 1 : -1;
       return working_state;
     }
 
@@ -135,7 +135,7 @@ double RandomRolloutEvaluator::evaluate(const State& state) const {
         working_state->ApplyAction(actions[index]);
       }
     }
-    result += working_state->PlayerReturn(0);
+    result += working_state->PlayerReturn(Player{0});
   }
   return result / n_rollouts_;
 }
@@ -155,7 +155,7 @@ Action MCTSearch(const State& state, double uct_c, int max_search_nodes,
     // Now evaluate this node
     double node_value;
     if (working_state->IsTerminal())
-      node_value = working_state->PlayerReturn(0);
+      node_value = working_state->PlayerReturn(Player{0});
     else
       node_value = evaluator.evaluate(*working_state);
 

--- a/open_spiel/algorithms/mcts.h
+++ b/open_spiel/algorithms/mcts.h
@@ -71,7 +71,7 @@ Action MCTSearch(const State& state, double uct_c, int max_search_nodes,
 // A SpielBot that uses the MCTS algorithm as its policy.
 class MCTSBot : public Bot {
  public:
-  MCTSBot(const Game& game, int player, double uct_c, int max_search_nodes,
+  MCTSBot(const Game& game, Player player, double uct_c, int max_search_nodes,
           const Evaluator& evaluator)
       : Bot{game, player},
         uct_c_{uct_c},

--- a/open_spiel/algorithms/mcts_test.cc
+++ b/open_spiel/algorithms/mcts_test.cc
@@ -32,9 +32,9 @@ void BotTest_RandomVsRandom() {
   for (int iteration = 0; iteration < num_iters; ++iteration) {
     auto this_results = EvaluateBots(game->NewInitialState().get(), bot_ptrs,
                                      /*seed=*/iteration);
-    for (int i = 0; i < num_players; ++i) average_results[i] += this_results[i];
+    for (auto i = Player{0}; i < num_players; ++i) average_results[i] += this_results[i];
   }
-  for (int i = 0; i < num_players; ++i) average_results[i] /= num_iters;
+  for (auto i = Player{0}; i < num_players; ++i) average_results[i] /= num_iters;
 
   SPIEL_CHECK_FLOAT_NEAR(average_results[0], 0.125, 0.01);
   SPIEL_CHECK_FLOAT_NEAR(average_results[1], -0.125, 0.01);

--- a/open_spiel/algorithms/minimax.cc
+++ b/open_spiel/algorithms/minimax.cc
@@ -47,9 +47,9 @@ namespace {
 //   The optimal value of the sub-game starting in state (given alpha/beta).
 double _alpha_beta(State* state, int depth, double alpha, double beta,
                    std::function<double(const State&)> value_function,
-                   int maximizing_player_id, Action* best_action) {
+                   Player maximizing_player, Action* best_action) {
   if (state->IsTerminal()) {
-    return state->PlayerReturn(maximizing_player_id);
+    return state->PlayerReturn(maximizing_player);
   }
 
   if (depth == 0 && !value_function) {
@@ -62,15 +62,15 @@ double _alpha_beta(State* state, int depth, double alpha, double beta,
     return value_function(*state);
   }
 
-  int player = state->CurrentPlayer();
-  if (player == maximizing_player_id) {
+  Player player = state->CurrentPlayer();
+  if (player == maximizing_player) {
     double value = -std::numeric_limits<double>::infinity();
 
     for (auto action : state->LegalActions()) {
       state->ApplyAction(action);
       double child_value =
           _alpha_beta(state, /*depth=*/depth - 1, /*alpha=*/alpha,
-                      /*beta=*/beta, value_function, maximizing_player_id,
+                      /*beta=*/beta, value_function, maximizing_player,
                       /*best_action=*/nullptr);
       state->UndoAction(player, action);
 
@@ -95,7 +95,7 @@ double _alpha_beta(State* state, int depth, double alpha, double beta,
       state->ApplyAction(action);
       double child_value =
           _alpha_beta(state, /*depth=*/depth - 1, /*alpha=*/alpha,
-                      /*beta=*/beta, value_function, maximizing_player_id,
+                      /*beta=*/beta, value_function, maximizing_player,
                       /*best_action=*/nullptr);
       state->UndoAction(player, action);
 
@@ -120,7 +120,7 @@ double _alpha_beta(State* state, int depth, double alpha, double beta,
 std::pair<double, Action> AlphaBetaSearch(
     const Game& game, const State* state,
     std::function<double(const State&)> value_function, int depth_limit,
-    int maximizing_player_id) {
+    Player maximizing_player) {
   if (game.NumPlayers() != 2) {
     SpielFatalError("Game must be a 2-player game");
   }
@@ -150,15 +150,15 @@ std::pair<double, Action> AlphaBetaSearch(
     search_root = state->Clone();
   }
 
-  if (maximizing_player_id == kInvalidPlayer) {
-    maximizing_player_id = search_root->CurrentPlayer();
+  if (maximizing_player == kInvalidPlayer) {
+    maximizing_player = search_root->CurrentPlayer();
   }
 
   double infinity = std::numeric_limits<double>::infinity();
   Action best_action = kInvalidAction;
   double value = _alpha_beta(
       search_root.get(), /*depth=*/depth_limit, /*alpha=*/-infinity,
-      /*beta=*/infinity, value_function, maximizing_player_id, &best_action);
+      /*beta=*/infinity, value_function, maximizing_player, &best_action);
 
   return std::pair<double, Action>(value, best_action);
 }

--- a/open_spiel/algorithms/minimax.h
+++ b/open_spiel/algorithms/minimax.h
@@ -47,7 +47,7 @@ namespace algorithms {
 std::pair<double, Action> AlphaBetaSearch(
     const Game& game, const State* state,
     std::function<double(const State&)> value_function, int depth_limit,
-    int maximizing_player_id);
+    Player maximizing_player);
 
 }  // namespace algorithms
 }  // namespace open_spiel

--- a/open_spiel/algorithms/tabular_exploitability.cc
+++ b/open_spiel/algorithms/tabular_exploitability.cc
@@ -27,14 +27,14 @@ namespace open_spiel {
 namespace algorithms {
 
 TabularBestResponse::TabularBestResponse(const Game& game,
-                                         int best_responder_id,
+                                         Player best_responder,
                                          const Policy* policy)
-    : best_responder_id_(best_responder_id),
+    : best_responder_(best_responder),
       tabular_policy_container_(),
       policy_(policy),
-      tree_(HistoryTree(game.NewInitialState(), best_responder_id_)),
+      tree_(HistoryTree(game.NewInitialState(), best_responder_)),
       num_players_(game.NumPlayers()),
-      infosets_(GetAllInfoSets(game.NewInitialState(), best_responder_id,
+      infosets_(GetAllInfoSets(game.NewInitialState(), best_responder,
                                policy, &tree_)),
       root_(game.NewInitialState()) {
   if (game.GetType().dynamics != GameType::Dynamics::kSequential) {
@@ -43,14 +43,14 @@ TabularBestResponse::TabularBestResponse(const Game& game,
 }
 
 TabularBestResponse::TabularBestResponse(
-    const Game& game, int best_responder_id,
+    const Game& game, Player best_responder,
     const std::unordered_map<std::string, ActionsAndProbs>& policy_table)
-    : best_responder_id_(best_responder_id),
+    : best_responder_(best_responder),
       tabular_policy_container_(policy_table),
       policy_(&tabular_policy_container_),
-      tree_(HistoryTree(game.NewInitialState(), best_responder_id_)),
+      tree_(HistoryTree(game.NewInitialState(), best_responder_)),
       num_players_(game.NumPlayers()),
-      infosets_(GetAllInfoSets(game.NewInitialState(), best_responder_id,
+      infosets_(GetAllInfoSets(game.NewInitialState(), best_responder,
                                policy_, &tree_)),
       root_(game.NewInitialState()) {
   if (game.GetType().dynamics != GameType::Dynamics::kSequential) {
@@ -64,7 +64,7 @@ double TabularBestResponse::HandleTerminalCase(const HistoryNode& node) const {
 
 double TabularBestResponse::HandleDecisionCase(HistoryNode* node) {
   if (node == nullptr) SpielFatalError("HandleDecisionCase: node is null.");
-  if (node->GetState()->CurrentPlayer() == best_responder_id_) {
+  if (node->GetState()->CurrentPlayer() == best_responder_) {
     // If we're playing as the best responder, we look at every child node,
     // and pick the one with the highest expected utility to play.
     Action action = BestResponseAction(node->GetInfoState());
@@ -207,7 +207,7 @@ double Exploitability(const Game& game, const Policy& policy) {
 
   std::unique_ptr<State> root = game.NewInitialState();
   double nash_conv = 0;
-  for (int i = 0; i < game.NumPlayers(); ++i) {
+  for (auto i = Player{0}; i < game.NumPlayers(); ++i) {
     TabularBestResponse best_response(game, i, &policy);
     nash_conv += best_response.Value(root->ToString());
   }
@@ -229,15 +229,15 @@ double NashConv(const Game& game, const Policy& policy) {
 
   std::unique_ptr<State> root = game.NewInitialState();
   std::vector<double> best_response_values(game.NumPlayers());
-  for (int i = 0; i < game.NumPlayers(); ++i) {
-    TabularBestResponse best_response(game, i, &policy);
-    best_response_values[i] = best_response.Value(root->ToString());
+  for (auto p = Player{0}; p < game.NumPlayers(); ++p) {
+    TabularBestResponse best_response(game, p, &policy);
+    best_response_values[p] = best_response.Value(root->ToString());
   }
   std::vector<double> on_policy_values = ExpectedReturns(*root, policy, -1);
   SPIEL_CHECK_EQ(best_response_values.size(), on_policy_values.size());
   double nash_conv = 0;
-  for (int i = 0; i < game.NumPlayers(); ++i) {
-    nash_conv += best_response_values[i] - on_policy_values[i];
+  for (auto p = Player{0}; p < game.NumPlayers(); ++p) {
+    nash_conv += best_response_values[p] - on_policy_values[p];
   }
   return nash_conv;
 }

--- a/open_spiel/algorithms/tabular_exploitability.h
+++ b/open_spiel/algorithms/tabular_exploitability.h
@@ -58,10 +58,10 @@ double NashConv(const Game& game,
 // raises a SpielFatalError if an incompatible game is passed to it.
 class TabularBestResponse {
  public:
-  TabularBestResponse(const Game& game, int best_responder_id,
+  TabularBestResponse(const Game& game, Player best_responder,
                       const Policy* policy);
   TabularBestResponse(
-      const Game& game, int best_responder_id,
+      const Game& game, Player best_responder,
       const std::unordered_map<std::string, ActionsAndProbs>& policy_table);
 
   TabularBestResponse(TabularBestResponse&&) = default;
@@ -70,7 +70,7 @@ class TabularBestResponse {
 
   // Returns the action that maximizes utility for the agent at the given
   // infostate. The infostate must correspond to a decision node for
-  // best_responder_id.
+  // best_responder.
   Action BestResponseAction(const std::string& infostate);
 
   // Returns a map of infostates to best responses, for all information states
@@ -85,7 +85,7 @@ class TabularBestResponse {
     return best_response_actions_;
   }
 
-  // Returns the expected utility for best_responder_id when playing the game
+  // Returns the expected utility for best_responder when playing the game
   // beginning at history.
   double Value(const std::string& history);
 
@@ -99,7 +99,7 @@ class TabularBestResponse {
     // TODO(author1): Replace this with something that traverses the tree
     // and rebuilds the probabilities.
     infosets_ =
-        GetAllInfoSets(root_->Clone(), best_responder_id_, policy_, &tree_);
+        GetAllInfoSets(root_->Clone(), best_responder_, policy_, &tree_);
   }
 
   // Set the policy given a policy table. This stores the table internally.
@@ -125,7 +125,7 @@ class TabularBestResponse {
   // have nothing to do.
   double HandleTerminalCase(const HistoryNode& node) const;
 
-  int best_responder_id_;
+  Player best_responder_;
 
   // Used to store a specific policy if not passed in from the caller.
   TabularPolicy tabular_policy_container_;
@@ -141,9 +141,9 @@ class TabularBestResponse {
   // the same information state, along with the counter-factual probability of
   // doing so. If the information state is a chance node, the probability comes
   // from the State::ChanceOutcomes method. If the information state is a
-  // decision node for best_responder_id, the probability is one, following the
+  // decision node for best_responder, the probability is one, following the
   // definition of counter-factual probability. Finally, if the information
-  // state is a decision node for a player other than best_responder_id, the
+  // state is a decision node for a player other than best_responder, the
   // probabilities come from their policy (i.e. policy_).
   std::unordered_map<std::string, std::vector<std::pair<HistoryNode*, double>>>
       infosets_;

--- a/open_spiel/algorithms/tabular_exploitability_test.cc
+++ b/open_spiel/algorithms/tabular_exploitability_test.cc
@@ -293,9 +293,9 @@ void CheckBestResponsesAgaintGoldenResponses(
 }
 
 void CheckBestResponseAgainstGoldenPolicy(
-    const Game& game, int best_responder_id, const TabularPolicy& policy,
+    const Game& game, Player best_responder, const TabularPolicy& policy,
     const InfostatesAndActions& golden_actions) {
-  TabularBestResponse best_response(game, best_responder_id, &policy);
+  TabularBestResponse best_response(game, best_responder, &policy);
   best_response.Value(game.NewInitialState()->ToString());
   std::unordered_map<std::string, Action> best_responses =
       best_response.GetBestResponseActions();
@@ -317,7 +317,7 @@ InfostatesAndActions GetKuhnUniformBestResponsePid1() {
 void KuhnPokerUniformBestResponsePid0() {
   std::unique_ptr<Game> game = LoadGame("kuhn_poker");
   TabularPolicy policy = GetUniformPolicy(*game);
-  CheckBestResponseAgainstGoldenPolicy(*game, /*best_responder_id=*/0, policy,
+  CheckBestResponseAgainstGoldenPolicy(*game, /*best_responder=*/Player{0}, policy,
                                        GetKuhnUniformBestResponsePid0());
 }
 
@@ -326,7 +326,7 @@ void KuhnPokerUniformBestResponsePid0() {
 void KuhnPokerUniformBestResponsePid1() {
   std::unique_ptr<Game> game = LoadGame("kuhn_poker");
   TabularPolicy policy = GetUniformPolicy(*game);
-  CheckBestResponseAgainstGoldenPolicy(*game, /*best_responder_id=*/1, policy,
+  CheckBestResponseAgainstGoldenPolicy(*game, /*best_responder=*/Player{1}, policy,
                                        GetKuhnUniformBestResponsePid1());
 }
 
@@ -339,7 +339,7 @@ InfostatesAndActions GetExploitabilityDescentBestResponses() {
 
 void KuhnPokerExploitabilityDescentIteration4BestResponsePid0() {
   std::unique_ptr<Game> game = LoadGame("kuhn_poker");
-  CheckBestResponseAgainstGoldenPolicy(*game, /*best_responder_id=*/1,
+  CheckBestResponseAgainstGoldenPolicy(*game, /*best_responder=*/Player{1},
                                        GetKuhnEdIter4Policy(),
                                        GetExploitabilityDescentBestResponses());
 }
@@ -347,7 +347,7 @@ void KuhnPokerExploitabilityDescentIteration4BestResponsePid0() {
 void KuhnPokerUniformBestResponseAfterSwitchingPolicies() {
   std::unique_ptr<Game> game = LoadGame("kuhn_poker");
   TabularPolicy policy = GetKuhnEdIter4Policy();
-  TabularBestResponse response(*game, 1, &policy);
+  TabularBestResponse response(*game, Player{1}, &policy);
 
   // Check that it's good
   InfostatesAndActions ed_golden_actions =
@@ -374,7 +374,7 @@ void KuhnPokerOptimalBestResponsePid0() {
   TabularPolicy policy = GetOptimalKuhnPolicy(/*alpha=*/0.2);
   InfostatesAndActions actual_best_responses = {
       {"0", 0}, {"0pb", 0}, {"1", 0}, {"1pb", 0}, {"2", 0}, {"2pb", 1}};
-  CheckBestResponseAgainstGoldenPolicy(*game, /*best_responder_id=*/0, policy,
+  CheckBestResponseAgainstGoldenPolicy(*game, /*best_responder=*/Player{0}, policy,
                                        actual_best_responses);
 }
 
@@ -385,17 +385,17 @@ void KuhnPokerOptimalBestResponsePid1() {
   TabularPolicy policy = GetOptimalKuhnPolicy(/*alpha=*/0.2);
   InfostatesAndActions actual_best_responses = {
       {"0b", 0}, {"0p", 0}, {"1p", 0}, {"1b", 0}, {"2p", 1}, {"2b", 1}};
-  CheckBestResponseAgainstGoldenPolicy(*game, /*best_responder_id=*/1, policy,
+  CheckBestResponseAgainstGoldenPolicy(*game, /*best_responder=*/Player{1}, policy,
                                        actual_best_responses);
 }
 
 void KuhnPokerExploitabilityDescentMinimalSimulationPid0() {
   std::unique_ptr<Game> game = LoadGame("kuhn_poker");
-  int best_responder_id = 1;
+  auto best_responder = Player{1};
 
   // We create a best responder with one policy...
   TabularPolicy kuhn_ed_iter1_policy = GetKuhnEdIter1Policy();
-  TabularBestResponse best_response(*game, best_responder_id,
+  TabularBestResponse best_response(*game, best_responder,
                                     &kuhn_ed_iter1_policy);
 
   // Calculate all the best responses...
@@ -427,9 +427,9 @@ void KuhnPokerExploitabilityDescentMinimalSimulationPid0() {
 }
 
 void CheckBestResponseValuesAgainstGoldenValues(
-    const Game& game, int best_responder_id, const TabularPolicy& policy,
+    const Game& game, Player best_responder, const TabularPolicy& policy,
     const std::vector<std::pair<std::string, double>>& golden_values) {
-  TabularBestResponse best_response(game, best_responder_id, &policy);
+  TabularBestResponse best_response(game, best_responder, &policy);
   for (const auto& history_and_value : golden_values) {
     const std::string& history = history_and_value.first;
     if (!Near(best_response.Value(history), history_and_value.second)) {
@@ -446,7 +446,7 @@ void KuhnPokerUniformValueTestPid0() {
   TabularPolicy policy = GetUniformPolicy(*game);
   std::vector<std::pair<std::string, double>> histories_and_values =
       GetKuhnUniformBestResponseValuesPid0();
-  CheckBestResponseValuesAgainstGoldenValues(*game, /*best_responder_id=*/0,
+  CheckBestResponseValuesAgainstGoldenValues(*game, /*best_responder=*/Player{0},
                                              policy, histories_and_values);
 }
 
@@ -455,7 +455,7 @@ void KuhnPokerUniformValueTestPid1() {
   TabularPolicy policy = GetUniformPolicy(*game);
   std::vector<std::pair<std::string, double>> histories_and_values =
       GetKuhnUniformBestResponseValuesPid1();
-  CheckBestResponseValuesAgainstGoldenValues(*game, /*best_responder_id=*/1,
+  CheckBestResponseValuesAgainstGoldenValues(*game, /*best_responder=*/Player{1},
                                              policy, histories_and_values);
 }
 
@@ -464,7 +464,7 @@ void KuhnPokerOptimalValueTestPid0() {
   TabularPolicy policy = GetOptimalKuhnPolicy(/*alpha=*/0.2);
   std::vector<std::pair<std::string, double>> histories_and_values =
       GetKuhnOptimalBestResponseValuesPid0();
-  CheckBestResponseValuesAgainstGoldenValues(*game, /*best_responder_id=*/0,
+  CheckBestResponseValuesAgainstGoldenValues(*game, /*best_responder=*/Player{0},
                                              policy, histories_and_values);
 }
 
@@ -473,7 +473,7 @@ void KuhnPokerOptimalValueTestPid1() {
   TabularPolicy policy = GetOptimalKuhnPolicy(/*alpha=*/0.2);
   std::vector<std::pair<std::string, double>> histories_and_values =
       GetKuhnOptimalBestResponseValuesPid1();
-  CheckBestResponseValuesAgainstGoldenValues(*game, /*best_responder_id=*/1,
+  CheckBestResponseValuesAgainstGoldenValues(*game, /*best_responder=*/Player{1},
                                              policy, histories_and_values);
 }
 

--- a/open_spiel/algorithms/trajectories.cc
+++ b/open_spiel/algorithms/trajectories.cc
@@ -28,7 +28,7 @@ namespace open_spiel {
 namespace algorithms {
 namespace {
 std::string StateKey(const Game& game, const State& state,
-                     int player = kInvalidPlayer) {
+                     Player player = kInvalidPlayer) {
   if (game.GetType().provides_information_state) {
     if (player == kInvalidPlayer) return state.InformationState();
     return state.InformationState(player);

--- a/open_spiel/algorithms/value_iteration.cc
+++ b/open_spiel/algorithms/value_iteration.cc
@@ -60,7 +60,7 @@ void InitializeMaps(const map<std::string, state_pointer>& states,
     if (kv.second->IsTerminal()) {
       // For both 1-player and 2-player zero sum games, suffices to look at
       // player 0's utility
-      (*values)[key] = kv.second->PlayerReturn(0);
+      (*values)[key] = kv.second->PlayerReturn(Player{0});
     } else {
       (*values)[key] = 0;
       AddTransition(transitions, key, kv.second);
@@ -103,7 +103,7 @@ std::map<std::string, double> ValueIteration(const Game& game, int depth_limit,
       // is the maximizing player (i.e. player 0), and to maximum utility
       // if current player is the minimizing player (i.e. player 1).
       double value = min_utility;
-      if (player == 1) value = -value;
+      if (player == Player{1}) value = -value;
       for (auto action : kv.second->LegalActions()) {
         auto possibilities = transitions[std::make_pair(key, action)];
         double q_value = 0;
@@ -112,7 +112,7 @@ std::map<std::string, double> ValueIteration(const Game& game, int depth_limit,
         }
         // Player 0 is maximizing the value (which is w.r.t. player 0)
         // Player 1 is minimizing the value
-        if (player == 0)
+        if (player == Player{0})
           value = std::max(value, q_value);
         else
           value = std::min(value, q_value);

--- a/open_spiel/examples/example.cc
+++ b/open_spiel/examples/example.cc
@@ -24,7 +24,7 @@ const char* kUsageStr =
     "example --game=<shortname> [--players=<num>] "
     "[--show_infostate] [--seed=<num>] [--show_legals=<true/false>]";
 
-void PrintLegalActions(const open_spiel::State& state, int player,
+void PrintLegalActions(const open_spiel::State& state, open_spiel::Player player,
                        const std::vector<open_spiel::Action>& movelist) {
   std::cerr << "Legal moves for player " << player << ":" << std::endl;
   for (open_spiel::Action action : movelist) {
@@ -35,8 +35,8 @@ void PrintLegalActions(const open_spiel::State& state, int player,
 int main(int argc, char** argv) {
   std::string game_name =
       open_spiel::ParseCmdLineArgDefault(argc, argv, "game", "");
-  int players =
-      std::stoi(open_spiel::ParseCmdLineArgDefault(argc, argv, "players", "0"));
+  auto players =
+      open_spiel::Player{std::stoi(open_spiel::ParseCmdLineArgDefault(argc, argv, "players", "0"))};
   bool show_infostate = open_spiel::ParseCmdLineArgDefault(
                             argc, argv, "show_infostate", "false") == "true";
   std::pair<bool, std::string> seed =
@@ -95,12 +95,12 @@ int main(int argc, char** argv) {
                 << std::endl;
       state->ApplyAction(action);
     } else if (state->IsSimultaneousNode()) {
-      // Players choose simultaneously?
+      // open_spiel::Players choose simultaneously?
       std::vector<open_spiel::Action> joint_action;
       std::vector<double> infostate;
 
       // Sample a action for each player
-      for (int player = 0; player < game->NumPlayers(); ++player) {
+      for (auto player = open_spiel::Player{0}; player < game->NumPlayers(); ++player) {
         if (show_infostate) {
           if (game->GetType().provides_information_state_as_normalized_vector) {
             state->InformationStateAsNormalizedVector(player, &infostate);
@@ -128,7 +128,7 @@ int main(int argc, char** argv) {
       state->ApplyActions(joint_action);
     } else {
       // Decision node, sample one uniformly.
-      int player = state->CurrentPlayer();
+      auto player = state->CurrentPlayer();
       if (show_infostate) {
         if (game->GetType().provides_information_state_as_normalized_vector) {
           std::vector<double> infostate;
@@ -158,7 +158,7 @@ int main(int argc, char** argv) {
   }
 
   auto returns = state->Returns();
-  for (int p = 0; p < game->NumPlayers(); p++) {
+  for (auto p = open_spiel::Player{0}; p < game->NumPlayers(); p++) {
     std::cerr << "Final return to player " << p << " is " << returns[p]
               << std::endl;
   }

--- a/open_spiel/examples/mcts_example.cc
+++ b/open_spiel/examples/mcts_example.cc
@@ -24,8 +24,8 @@
 int main(int argc, char** argv) {
   std::string game_name =
       open_spiel::ParseCmdLineArgDefault(argc, argv, "game", "tic_tac_toe");
-  int mcts_player = std::stoi(
-      open_spiel::ParseCmdLineArgDefault(argc, argv, "mcts_player", "0"));
+  auto mcts_player = open_spiel::Player{std::stoi(
+      open_spiel::ParseCmdLineArgDefault(argc, argv, "mcts_player", "0"))};
   int rollout_count = std::stoi(
       open_spiel::ParseCmdLineArgDefault(argc, argv, "rollout_count", "100"));
   int max_search_nodes = std::stoi(open_spiel::ParseCmdLineArgDefault(
@@ -56,10 +56,10 @@ int main(int argc, char** argv) {
 
   // Create Random Bot
   std::shared_ptr<open_spiel::Bot> random_bot =
-      open_spiel::MakeUniformRandomBot(*game, 1 - mcts_player, /*seed=*/1234);
+      open_spiel::MakeUniformRandomBot(*game, open_spiel::Player{1 - mcts_player}, /*seed=*/1234);
 
   open_spiel::Bot* bots[2];
-  if (mcts_player == 0) {
+  if (mcts_player == open_spiel::Player{0}) {
     bots[0] = &mcts_bot;
     bots[1] = random_bot.get();
   } else {
@@ -88,7 +88,7 @@ int main(int argc, char** argv) {
           "MCTS not supported for games with simultaneous actions.");
     } else {
       // Decision node, ask the right bot to make its action
-      int player = state->CurrentPlayer();
+      open_spiel::Player player = state->CurrentPlayer();
       if (game->GetType().provides_information_state_as_normalized_vector) {
         std::vector<double> infostate;
         state->InformationStateAsNormalizedVector(player, &infostate);

--- a/open_spiel/game_transforms/game_wrapper.h
+++ b/open_spiel/game_transforms/game_wrapper.h
@@ -30,9 +30,9 @@ class WrappedState : public State {
   WrappedState(const WrappedState& other)
       : State(other), state_(other.state_->Clone()) {}
 
-  int CurrentPlayer() const override { return state_->CurrentPlayer(); }
+  Player CurrentPlayer() const override { return state_->CurrentPlayer(); }
 
-  virtual std::vector<Action> LegalActions(int player) const {
+  virtual std::vector<Action> LegalActions(Player player) const {
     return state_->LegalActions(player);
   }
 
@@ -40,7 +40,7 @@ class WrappedState : public State {
     return state_->LegalActions();
   }
 
-  std::string ActionToString(int player, Action action_id) const override {
+  std::string ActionToString(Player player, Action action_id) const override {
     return state_->ActionToString(player, action_id);
   }
 
@@ -52,27 +52,27 @@ class WrappedState : public State {
 
   std::vector<double> Returns() const override { return state_->Returns(); }
 
-  std::string InformationState(int player) const override {
+  std::string InformationState(Player player) const override {
     return state_->InformationState(player);
   }
 
   void InformationStateAsNormalizedVector(
-      int player, std::vector<double>* values) const override {
+      Player player, std::vector<double>* values) const override {
     state_->InformationStateAsNormalizedVector(player, values);
   }
 
-  virtual std::string Observation(int player) const {
+  virtual std::string Observation(Player player) const {
     return state_->Observation(player);
   }
 
   virtual void ObservationAsNormalizedVector(
-      int player, std::vector<double>* values) const {
+      Player player, std::vector<double>* values) const {
     state_->ObservationAsNormalizedVector(player, values);
   }
 
   virtual std::unique_ptr<State> Clone() const = 0;
 
-  virtual void UndoAction(int player, Action action) {
+  virtual void UndoAction(Player player, Action action) {
     state_->UndoAction(player, action);
     history_.pop_back();
   }

--- a/open_spiel/game_transforms/turn_based_simultaneous_game.cc
+++ b/open_spiel/game_transforms/turn_based_simultaneous_game.cc
@@ -61,7 +61,7 @@ TurnBasedSimultaneousState::TurnBasedSimultaneousState(
   action_vector_.resize(num_players);
 }
 
-int TurnBasedSimultaneousState::CurrentPlayer() const {
+Player TurnBasedSimultaneousState::CurrentPlayer() const {
   return current_player_;
 }
 
@@ -69,7 +69,7 @@ void TurnBasedSimultaneousState::DetermineWhoseTurn() {
   if (state_->CurrentPlayer() == kSimultaneousPlayerId) {
     // When the underlying game's node is at a simultaneous move node, they get
     // rolled out as turn-based, starting with player 0.
-    current_player_ = 0;
+    current_player_ = Player{0};
     rollout_mode_ = true;
   } else {
     // Otherwise, just execute it normally.
@@ -123,7 +123,7 @@ std::vector<Action> TurnBasedSimultaneousState::LegalActions() const {
   return state_->LegalActions(CurrentPlayer());
 }
 
-std::string TurnBasedSimultaneousState::ActionToString(int player,
+std::string TurnBasedSimultaneousState::ActionToString(Player player,
                                                        Action action_id) const {
   return state_->ActionToString(player, action_id);
 }
@@ -132,7 +132,7 @@ std::string TurnBasedSimultaneousState::ToString() const {
   std::string partial_action = "";
   if (rollout_mode_) {
     partial_action = "Partial joint action: ";
-    for (int p = 0; p < current_player_; ++p) {
+    for (auto p = Player{0}; p < current_player_; ++p) {
       absl::StrAppend(&partial_action, action_vector_[p]);
       partial_action.push_back(' ');
     }
@@ -149,7 +149,7 @@ std::vector<double> TurnBasedSimultaneousState::Returns() const {
   return state_->Returns();
 }
 
-std::string TurnBasedSimultaneousState::InformationState(int player) const {
+std::string TurnBasedSimultaneousState::InformationState(Player player) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
 
@@ -169,7 +169,7 @@ std::string TurnBasedSimultaneousState::InformationState(int player) const {
 }
 
 void TurnBasedSimultaneousState::InformationStateAsNormalizedVector(
-    int player, std::vector<double>* values) const {
+    Player player, std::vector<double>* values) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
 
@@ -177,10 +177,10 @@ void TurnBasedSimultaneousState::InformationStateAsNormalizedVector(
 
   // First, get the 2 * num_players bits to encode whose turn it is and who
   // the observer is.
-  for (int p = 0; p < num_players_; ++p) {
+  for (auto p = Player{0}; p < num_players_; ++p) {
     values->push_back(p == current_player_ ? 1 : 0);
   }
-  for (int p = 0; p < num_players_; ++p) {
+  for (auto p = Player{0}; p < num_players_; ++p) {
     values->push_back(p == player ? 1 : 0);
   }
 

--- a/open_spiel/game_transforms/turn_based_simultaneous_game.h
+++ b/open_spiel/game_transforms/turn_based_simultaneous_game.h
@@ -34,14 +34,14 @@ class TurnBasedSimultaneousState : public State {
                              std::unique_ptr<State> state);
   TurnBasedSimultaneousState(const TurnBasedSimultaneousState& other);
 
-  int CurrentPlayer() const override;
-  std::string ActionToString(int player, Action action_id) const override;
+  Player CurrentPlayer() const override;
+  std::string ActionToString(Player player, Action action_id) const override;
   std::string ToString() const override;
   bool IsTerminal() const override;
   std::vector<double> Returns() const override;
-  std::string InformationState(int player) const override;
+  std::string InformationState(Player player) const override;
   void InformationStateAsNormalizedVector(
-      int player, std::vector<double>* values) const override;
+      Player player, std::vector<double>* values) const override;
   std::unique_ptr<State> Clone() const override;
   std::vector<std::pair<Action, double>> ChanceOutcomes() const override;
 
@@ -64,7 +64,7 @@ class TurnBasedSimultaneousState : public State {
   std::vector<Action> action_vector_;
 
   // The current player (which will never be kSimultaneousPlayerId).
-  int current_player_;
+  Player current_player_;
 
   // Are we currently rolling out a simultaneous move node?
   bool rollout_mode_;

--- a/open_spiel/game_transforms/turn_based_simultaneous_game_test.cc
+++ b/open_spiel/game_transforms/turn_based_simultaneous_game_test.cc
@@ -54,7 +54,7 @@ void SimulateGames(std::mt19937* rng, const Game& game, State* sim_state,
       std::vector<Action> joint_action;
 
       // Sample a action for each player
-      for (int p = 0; p < game.NumPlayers(); p++) {
+      for (auto p = Player{0}; p < game.NumPlayers(); p++) {
         // Check the information states to each player are consistent.
         SPIEL_CHECK_EQ(sim_state->InformationState(p),
                        wrapped_sim_state->InformationState(p));
@@ -84,7 +84,7 @@ void SimulateGames(std::mt19937* rng, const Game& game, State* sim_state,
   auto sim_returns = sim_state->Returns();
   auto turn_returns = turn_based_state->Returns();
 
-  for (int player = 0; player < game.NumPlayers(); player++) {
+  for (auto player = Player{0}; player < game.NumPlayers(); player++) {
     double utility = sim_returns[player];
     SPIEL_CHECK_GE(utility, game.MinUtility());
     SPIEL_CHECK_LE(utility, game.MaxUtility());

--- a/open_spiel/games/backgammon.cc
+++ b/open_spiel/games/backgammon.cc
@@ -106,7 +106,7 @@ std::string PositionToString(int pos) {
   }
 }
 
-std::string BackgammonState::ActionToString(int player, Action move_id) const {
+std::string BackgammonState::ActionToString(Player player, Action move_id) const {
   if (player == kChancePlayerId) {
     return absl::StrCat("chance outcome ", move_id,
                         " (roll: ", kChanceOutcomeValues[move_id][0],
@@ -120,12 +120,12 @@ std::string BackgammonState::ActionToString(int player, Action move_id) const {
   }
 }
 
-std::string BackgammonState::InformationState(int player) const {
+std::string BackgammonState::InformationState(Player player) const {
   return ToString();
 }
 
 void BackgammonState::InformationStateAsNormalizedVector(
-    int player, std::vector<double>* values) const {
+    Player player, std::vector<double>* values) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LE(player, 1);
   int opponent = Opponent(player);
@@ -194,8 +194,8 @@ int BackgammonState::board(int player, int pos) const {
   }
 }
 
-int BackgammonState::CurrentPlayer() const {
-  return IsTerminal() ? kTerminalPlayerId : cur_player_;
+Player BackgammonState::CurrentPlayer() const {
+  return IsTerminal() ? kTerminalPlayerId : Player{cur_player_};
 }
 
 int BackgammonState::Opponent(int player) const { return 1 - player; }

--- a/open_spiel/games/backgammon.h
+++ b/open_spiel/games/backgammon.h
@@ -110,17 +110,17 @@ class BackgammonState : public State {
   BackgammonState(int num_distinct_actions, int num_players,
                   ScoringType scoring_type);
 
-  int CurrentPlayer() const override;
-  void UndoAction(int player, Action action) override;
+  Player CurrentPlayer() const override;
+  void UndoAction(Player player, Action action) override;
   std::vector<Action> LegalActions() const override;
-  std::string ActionToString(int player, Action move_id) const override;
+  std::string ActionToString(Player player, Action move_id) const override;
   std::vector<std::pair<Action, double>> ChanceOutcomes() const override;
   std::string ToString() const override;
   bool IsTerminal() const override;
   std::vector<double> Returns() const override;
-  std::string InformationState(int player) const override;
+  std::string InformationState(Player player) const override;
   void InformationStateAsNormalizedVector(
-      int player, std::vector<double>* values) const override;
+      Player player, std::vector<double>* values) const override;
   std::unique_ptr<State> Clone() const override;
 
   // Setter function used for debugging and tests. Note: this does not set the
@@ -213,8 +213,8 @@ class BackgammonState : public State {
 
   ScoringType scoring_type_;  // Which rules apply when scoring the game.
 
-  int cur_player_;
-  int prev_player_;
+  Player cur_player_;
+  Player prev_player_;
   int turns_;
   int x_turns_;
   int o_turns_;

--- a/open_spiel/games/blotto.cc
+++ b/open_spiel/games/blotto.cc
@@ -77,7 +77,7 @@ void BlottoState::DoApplyActions(const std::vector<Action>& actions) {
     int winner = 0;
     int max_value = -1;
 
-    for (int p = 0; p < num_players_; ++p) {
+    for (auto p = Player{0}; p < num_players_; ++p) {
       // Get the expanded action if necessary.
       if (p >= player_actions.size()) {
         player_actions.push_back(action_map_->at(joint_action_[p]));
@@ -101,7 +101,7 @@ void BlottoState::DoApplyActions(const std::vector<Action>& actions) {
   // Find the global winner(s).
   std::set<int> winners;
   int max_points = 0;
-  for (int p = 0; p < num_players_; ++p) {
+  for (auto p = Player{0}; p < num_players_; ++p) {
     if (scores[p] > max_points) {
       max_points = scores[p];
       winners = {p};
@@ -112,7 +112,7 @@ void BlottoState::DoApplyActions(const std::vector<Action>& actions) {
 
   // Finally, assign returns. Each winner gets 1/num_winners, each loser gets
   // -1 / num_losers.
-  for (int p = 0; p < num_players_; ++p) {
+  for (auto p = Player{0}; p < num_players_; ++p) {
     if (winners.size() == num_players_) {
       // All players won same number of fields. Draw.
       returns_[p] = 0;
@@ -126,11 +126,11 @@ void BlottoState::DoApplyActions(const std::vector<Action>& actions) {
   }
 }
 
-std::vector<Action> BlottoState::LegalActions(int player) const {
+std::vector<Action> BlottoState::LegalActions(Player player) const {
   return (*legal_actions_);
 }
 
-std::string BlottoState::ActionToString(int player, Action move_id) const {
+std::string BlottoState::ActionToString(Player player, Action move_id) const {
   return "[" + absl::StrJoin(action_map_->at(move_id), ",") + "]";
 }
 

--- a/open_spiel/games/blotto.h
+++ b/open_spiel/games/blotto.h
@@ -48,8 +48,8 @@ class BlottoState : public NFGState {
               const ActionMap* action_map,
               const std::vector<Action>* legal_actions_);
 
-  std::vector<Action> LegalActions(int player) const override;
-  std::string ActionToString(int player, Action move_id) const override;
+  std::vector<Action> LegalActions(Player player) const override;
+  std::string ActionToString(Player player, Action move_id) const override;
   std::string ToString() const override;
   bool IsTerminal() const override;
   std::vector<double> Returns() const override;

--- a/open_spiel/games/blotto_test.cc
+++ b/open_spiel/games/blotto_test.cc
@@ -25,7 +25,7 @@ void BasicBlottoTests() {
   testing::LoadGameTest("blotto");
   testing::NoChanceOutcomesTest(*LoadGame("blotto"));
   testing::RandomSimTest(*LoadGame("blotto"), 100);
-  for (int players = 3; players <= 5; players++) {
+  for (Player players = 3; players <= 5; players++) {
     testing::RandomSimTest(
         *LoadGame("blotto", {{"players", GameParameter(players)}}), 100);
   }

--- a/open_spiel/games/breakthrough.cc
+++ b/open_spiel/games/breakthrough.cc
@@ -72,7 +72,7 @@ int StateToPlayer(CellState state) {
   }
 }
 
-CellState PlayerToState(int player) {
+CellState PlayerToState(Player player) {
   switch (player) {
     case 0:
       return CellState::kBlack;
@@ -189,7 +189,7 @@ void BreakthroughState::DoApplyAction(Action action) {
   total_moves_++;
 }
 
-std::string BreakthroughState::ActionToString(int player, Action action) const {
+std::string BreakthroughState::ActionToString(Player player, Action action) const {
   std::vector<int> values(4, -1);
   UnrankActionMixedBase(action, {rows_, cols_, kNumDirections, 2}, &values);
   int r1 = values[0];
@@ -213,7 +213,7 @@ std::string BreakthroughState::ActionToString(int player, Action action) const {
 
 std::vector<Action> BreakthroughState::LegalActions() const {
   std::vector<Action> movelist;
-  const int player = CurrentPlayer();
+  const Player player = CurrentPlayer();
   CellState mystate = PlayerToState(player);
   std::vector<int> action_bases = {rows_, cols_, kNumDirections, 2};
   std::vector<int> action_values = {0, 0, 0, 0};
@@ -313,14 +313,14 @@ std::vector<double> BreakthroughState::Returns() const {
   }
 }
 
-std::string BreakthroughState::InformationState(int player) const {
+std::string BreakthroughState::InformationState(Player player) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
   return ToString();
 }
 
 void BreakthroughState::InformationStateAsNormalizedVector(
-    int player, std::vector<double>* values) const {
+    Player player, std::vector<double>* values) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
 
@@ -337,7 +337,7 @@ void BreakthroughState::InformationStateAsNormalizedVector(
   }
 }
 
-void BreakthroughState::UndoAction(int player, Action action) {
+void BreakthroughState::UndoAction(Player player, Action action) {
   std::vector<int> values(4, -1);
   UnrankActionMixedBase(action, {rows_, cols_, kNumDirections, 2}, &values);
   int r1 = values[0];

--- a/open_spiel/games/breakthrough.h
+++ b/open_spiel/games/breakthrough.h
@@ -50,16 +50,16 @@ enum class CellState {
 class BreakthroughState : public State {
  public:
   explicit BreakthroughState(int num_distinct_actions, int rows, int cols);
-  int CurrentPlayer() const override;
-  std::string ActionToString(int player, Action action) const override;
+  Player CurrentPlayer() const override;
+  std::string ActionToString(Player player, Action action) const override;
   std::string ToString() const override;
   bool IsTerminal() const override;
   std::vector<double> Returns() const override;
-  std::string InformationState(int player) const override;
+  std::string InformationState(Player player) const override;
   void InformationStateAsNormalizedVector(
-      int player, std::vector<double>* values) const override;
+      Player player, std::vector<double>* values) const override;
   std::unique_ptr<State> Clone() const override;
-  void UndoAction(int player, Action action) override;
+  void UndoAction(Player player, Action action) override;
 
   bool InBounds(int r, int c) const;
   void SetBoard(int r, int c, CellState cs) { board_[r * cols_ + c] = cs; }
@@ -77,7 +77,7 @@ class BreakthroughState : public State {
   int observation_plane(int r, int c) const;
 
   // Fields sets to bad/invalid values. Use Game::NewInitialState().
-  int cur_player_ = kInvalidPlayer;
+  Player cur_player_ = kInvalidPlayer;
   int winner_ = kInvalidPlayer;
   int total_moves_ = -1;
   std::array<int, 2> pieces_;

--- a/open_spiel/games/bridge_uncontested_bidding.cc
+++ b/open_spiel/games/bridge_uncontested_bidding.cc
@@ -93,7 +93,7 @@ constexpr int Level(Action bid) { return 1 + (bid - 1) / kNumDenominations; }
 constexpr char kRankChar[] = "23456789TJQKA";
 constexpr char kSuitChar[] = "CDHSN";
 
-std::string UncontestedBiddingState::ActionToString(int player,
+std::string UncontestedBiddingState::ActionToString(Player player,
                                                     Action action_id) const {
   if (player == kChancePlayerId) return "Deal";
   if (action_id == kPass) return "Pass";
@@ -169,14 +169,14 @@ std::string UncontestedBiddingState::AuctionString() const {
   return actions;
 }
 
-std::string UncontestedBiddingState::InformationState(int player) const {
+std::string UncontestedBiddingState::InformationState(Player player) const {
   if (!dealt_) return "";
   return absl::StrCat(deal_.HandString(player * 13, (player + 1) * 13), " ",
                       AuctionString());
 }
 
 void UncontestedBiddingState::InformationStateAsNormalizedVector(
-    int player, std::vector<double>* values) const {
+    Player player, std::vector<double>* values) const {
   values->resize(kStateSize);
   std::fill(values->begin(), values->end(), 0.);
   auto ptr = values->begin();
@@ -234,7 +234,7 @@ void UncontestedBiddingState::ScoreDeal() {
 
   // Populate East-West cards
   ddTableDeal dd_table_deal{};
-  for (int player = 0; player < kNumPlayers; ++player) {
+  for (Player player = 0; player < kNumPlayers; ++player) {
     for (int i = kNumCardsPerHand * player; i < kNumCardsPerHand * (1 + player);
          ++i) {
       dd_table_deal.cards[player * 2][deal_.Suit(i)] += 1
@@ -380,7 +380,7 @@ std::unique_ptr<State> UncontestedBiddingGame::DeserializeState(
                  kNumPlayers * (kNumCardsPerHand + kNumSuits) - 1);
   std::array<int, kNumCards> cards{};
   std::array<int, kNumCards> cards_dealt{};
-  for (int player = 0; player < kNumPlayers; ++player) {
+  for (Player player = 0; player < kNumPlayers; ++player) {
     int suit = 0;
     int start = player * (kNumCardsPerHand + kNumSuits);
     for (int i = 0; i < kNumCardsPerHand; ++i) {

--- a/open_spiel/games/bridge_uncontested_bidding.h
+++ b/open_spiel/games/bridge_uncontested_bidding.h
@@ -158,15 +158,15 @@ class UncontestedBiddingState : public State {
   }
   UncontestedBiddingState(const UncontestedBiddingState&) = default;
 
-  int CurrentPlayer() const override;
-  std::string ActionToString(int player, Action action_id) const override;
+  Player CurrentPlayer() const override;
+  std::string ActionToString(Player player, Action action_id) const override;
   std::string AuctionString() const;
   std::string ToString() const override;
   bool IsTerminal() const override;
   std::vector<double> Returns() const override;
-  std::string InformationState(int player) const override;
+  std::string InformationState(Player player) const override;
   void InformationStateAsNormalizedVector(
-      int player, std::vector<double>* values) const override;
+      Player player, std::vector<double>* values) const override;
   std::unique_ptr<State> Clone() const override;
   std::vector<Action> LegalActions() const override;
   std::vector<std::pair<Action, double>> ChanceOutcomes() const override;

--- a/open_spiel/games/catch.cc
+++ b/open_spiel/games/catch.cc
@@ -104,7 +104,7 @@ CellState CatchState::BoardAt(int row, int column) const {
   return CellState::kEmpty;
 }
 
-std::string CatchState::ActionToString(int player, Action action_id) const {
+std::string CatchState::ActionToString(Player player, Action action_id) const {
   if (player == kChancePlayerId)
     return absl::StrCat("Initialized ball to ", action_id);
   SPIEL_CHECK_EQ(player, 0);
@@ -145,18 +145,18 @@ std::vector<double> CatchState::Returns() const {
   }
 }
 
-std::string CatchState::InformationState(int player) const {
+std::string CatchState::InformationState(Player player) const {
   SPIEL_CHECK_EQ(player, 0);
   return HistoryString();
 }
 
-std::string CatchState::Observation(int player) const {
+std::string CatchState::Observation(Player player) const {
   SPIEL_CHECK_EQ(player, 0);
   return ToString();
 }
 
 void CatchState::ObservationAsNormalizedVector(
-    int player, std::vector<double>* values) const {
+    Player player, std::vector<double>* values) const {
   SPIEL_CHECK_EQ(player, 0);
 
   values->resize(game_.NumRows() * game_.NumColumns());
@@ -168,7 +168,7 @@ void CatchState::ObservationAsNormalizedVector(
 }
 
 void CatchState::InformationStateAsNormalizedVector(
-    int player, std::vector<double>* values) const {
+    Player player, std::vector<double>* values) const {
   SPIEL_CHECK_EQ(player, 0);
 
   values->resize(game_.NumColumns() + kNumActions * game_.NumRows());
@@ -183,7 +183,7 @@ void CatchState::InformationStateAsNormalizedVector(
   }
 }
 
-void CatchState::UndoAction(int player, Action move) {
+void CatchState::UndoAction(Player player, Action move) {
   if (player == kChancePlayerId) {
     initialized_ = false;
     return;

--- a/open_spiel/games/catch.h
+++ b/open_spiel/games/catch.h
@@ -64,19 +64,19 @@ class CatchState : public State {
   CatchState(const CatchGame& parent_game);
   CatchState(const CatchState&) = default;
 
-  int CurrentPlayer() const override;
-  std::string ActionToString(int player, Action action_id) const override;
+  Player CurrentPlayer() const override;
+  std::string ActionToString(Player player, Action action_id) const override;
   std::string ToString() const override;
   bool IsTerminal() const override;
   std::vector<double> Returns() const override;
-  std::string InformationState(int player) const override;
-  std::string Observation(int player) const override;
+  std::string InformationState(Player player) const override;
+  std::string Observation(Player player) const override;
   void ObservationAsNormalizedVector(
-      int player, std::vector<double>* values) const override;
+      Player player, std::vector<double>* values) const override;
   void InformationStateAsNormalizedVector(
-      int player, std::vector<double>* values) const override;
+      Player player, std::vector<double>* values) const override;
   std::unique_ptr<State> Clone() const override;
-  void UndoAction(int player, Action move) override;
+  void UndoAction(Player player, Action move) override;
   std::vector<Action> LegalActions() const override;
   ActionsAndProbs ChanceOutcomes() const override;
   CellState BoardAt(int row, int column) const;

--- a/open_spiel/games/chess.cc
+++ b/open_spiel/games/chess.cc
@@ -109,7 +109,7 @@ std::vector<Action> ChessState::LegalActions() const {
   return actions;
 }
 
-std::string ChessState::ActionToString(int player, Action action) const {
+std::string ChessState::ActionToString(Player player, Action action) const {
   Move move = ActionToMove(action);
   return move.ToSAN(Board());
 }
@@ -125,12 +125,12 @@ std::vector<double> ChessState::Returns() const {
   }
 }
 
-std::string ChessState::InformationState(int player) const {
+std::string ChessState::InformationState(Player player) const {
   return ToString();
 }
 
 void ChessState::InformationStateAsNormalizedVector(
-    int player, std::vector<double>* values) const {
+    Player player, std::vector<double>* values) const {
   SPIEL_CHECK_NE(player, kChancePlayerId);
 
   std::size_t vector_size = 1;
@@ -180,7 +180,7 @@ std::unique_ptr<State> ChessState::Clone() const {
   return std::unique_ptr<State>(new ChessState(*this));
 }
 
-void ChessState::UndoAction(int player, Action action) {
+void ChessState::UndoAction(Player player, Action action) {
   // TODO: Make this fast by storing undo info in another stack.
   SPIEL_CHECK_GE(moves_history_.size(), 1);
   --repetitions_[current_board_.HashValue()];

--- a/open_spiel/games/chess.h
+++ b/open_spiel/games/chess.h
@@ -68,7 +68,7 @@ inline int ColorToPlayer(Color c) {
   }
 }
 
-inline int OtherPlayer(int player) { return player == 0 ? 1 : 0; }
+inline int OtherPlayer(Player player) { return player == Player{0} ? 1 : 0; }
 
 // Action encoding (must be changed to support larger boards):
 // bits 0-5: from square (0-64)
@@ -178,11 +178,11 @@ class ChessState : public State {
 
   ChessState& operator=(const ChessState&) = default;
 
-  int CurrentPlayer() const override {
+  Player CurrentPlayer() const override {
     return IsTerminal() ? kTerminalPlayerId : ColorToPlayer(Board().ToPlay());
   }
   std::vector<Action> LegalActions() const override;
-  std::string ActionToString(int player, Action action) const override;
+  std::string ActionToString(Player player, Action action) const override;
   std::string ToString() const override;
 
   bool IsTerminal() const override {
@@ -191,11 +191,11 @@ class ChessState : public State {
 
   std::vector<double> Returns() const override;
 
-  std::string InformationState(int player) const override;
+  std::string InformationState(Player player) const override;
   void InformationStateAsNormalizedVector(
-      int player, std::vector<double>* values) const override;
+      Player player, std::vector<double>* values) const override;
   std::unique_ptr<State> Clone() const override;
-  void UndoAction(int player, Action action) override;
+  void UndoAction(Player player, Action action) override;
 
   // Current board.
   StandardChessBoard& Board() { return current_board_; }

--- a/open_spiel/games/coin_game.cc
+++ b/open_spiel/games/coin_game.cc
@@ -97,7 +97,7 @@ SymbolType GetSymbolType(char symbol) {
   SpielFatalError(absl::StrCat("Unexpected symbol: ", std::string(1, symbol)));
 }
 
-inline char PlayerSymbol(int player) { return '0' + static_cast<char>(player); }
+inline char PlayerSymbol(Player player) { return '0' + static_cast<char>(player); }
 inline char CoinSymbol(int coin) { return 'a' + static_cast<char>(coin); }
 int CoinId(char symbol) { return symbol - 'a'; }
 
@@ -209,7 +209,7 @@ ActionsAndProbs CoinState::ChanceOutcomes() const {
   }
 }
 
-std::string CoinState::Observation(int player) const {
+std::string CoinState::Observation(Player player) const {
   std::ostringstream out;
   // A player only learns its own preference.
   SpielStrOut(out, player_preferences_[player], "\n");
@@ -309,15 +309,15 @@ void CoinState::DoApplyAction(Action action) {
   }
 }
 
-void CoinState::IncPlayerCoinCount(int player, int coin_color) {
+void CoinState::IncPlayerCoinCount(Player player, int coin_color) {
   player_coins_[player * game_.NumCoinColors() + coin_color]++;
 }
 
-int CoinState::GetPlayerCoinCount(int player, int coin_color) const {
+int CoinState::GetPlayerCoinCount(Player player, int coin_color) const {
   return player_coins_[player * game_.NumCoinColors() + coin_color];
 }
 
-std::string CoinState::ActionToString(int player, Action action_id) const {
+std::string CoinState::ActionToString(Player player, Action action_id) const {
   if (player == kChancePlayerId) {
     return absl::StrCat(action_id);
   } else {
@@ -345,7 +345,7 @@ void CoinState::PrintCoinsCollected(std::ostream& out) const {
     SpielStrOut(out, CoinSymbol(coint_color), " ");
   }
   SpielStrOut(out, "\n");
-  for (int player = 0; player < num_players_; player++) {
+  for (auto player = Player{0}; player < num_players_; player++) {
     SpielStrOut(out, "player", player, " ");
     for (int coint_color = 0; coint_color < game_.NumCoinColors();
          coint_color++) {
@@ -357,7 +357,7 @@ void CoinState::PrintCoinsCollected(std::ostream& out) const {
 
 void CoinState::PrintPreferences(std::ostream& out) const {
   SpielStrOut(out, "preferences=");
-  for (int player = 0; player < setup_.num_players_assigned_preference;
+  for (Player player = 0; player < setup_.num_players_assigned_preference;
        player++) {
     SpielStrOut(out, player, ":", CoinSymbol(player_preferences_[player]), " ");
   }
@@ -406,8 +406,8 @@ std::vector<double> CoinState::Returns() const {
   int collected_coins = 0;
   std::vector<int> coin_count(game_.NumCoinColors());
   for (int coin_color = 0; coin_color < game_.NumCoinColors(); coin_color++) {
-    for (int player = 0; player < num_players_; player++) {
-      int player_coins = GetPlayerCoinCount(player, coin_color);
+    for (auto player = Player{0}; player < num_players_; player++) {
+      Player player_coins = GetPlayerCoinCount(player, coin_color);
       coin_count[coin_color] += player_coins;
       collected_coins += player_coins;
     }
@@ -418,7 +418,7 @@ std::vector<double> CoinState::Returns() const {
   }
   const int bad_coins = collected_coins - good_coins;
   std::vector<double> rewards(num_players_);
-  for (int player = 0; player < num_players_; player++) {
+  for (auto player = Player{0}; player < num_players_; player++) {
     int self_coins = coin_count[player_preferences_[player]];
     int other_coins = good_coins - self_coins;
     rewards[player] = (std::pow(self_coins, 2) + std::pow(other_coins, 2) -

--- a/open_spiel/games/coin_game.h
+++ b/open_spiel/games/coin_game.h
@@ -70,16 +70,16 @@ class CoinState : public State {
   explicit CoinState(const CoinGame& parent_game);
   CoinState(const CoinState&) = default;
 
-  int CurrentPlayer() const override;
+  Player CurrentPlayer() const override;
   std::vector<Action> LegalActions() const override;
-  std::string ActionToString(int player, Action action_id) const override;
+  std::string ActionToString(Player player, Action action_id) const override;
   std::string ToString() const override;
   bool IsTerminal() const override;
   std::vector<double> Returns() const override;
   std::unique_ptr<State> Clone() const override;
 
   ActionsAndProbs ChanceOutcomes() const override;
-  std::string Observation(int player) const override;
+  std::string Observation(Player player) const override;
 
  protected:
   void DoApplyAction(Action action) override;
@@ -90,8 +90,8 @@ class CoinState : public State {
   char GetField(Location loc) const;
   void SetField(Location loc, char symbol);
   bool InBounds(Location loc) const;
-  int GetPlayerCoinCount(int player, int coin_color) const;
-  void IncPlayerCoinCount(int player, int coin_color);
+  int GetPlayerCoinCount(Player player, int coin_color) const;
+  void IncPlayerCoinCount(Player player, int coin_color);
 
   void PrintCoinsCollected(std::ostream& out) const;
   void PrintPreferences(std::ostream& out) const;
@@ -105,7 +105,7 @@ class CoinState : public State {
 
   const CoinGame& game_;
   Setup setup_;
-  int cur_player_ = kChancePlayerId;  // Chance player for setting up the game.
+  Player cur_player_ = kChancePlayerId;  // Chance player for setting up the game.
   int total_moves_ = 0;
   std::vector<int> player_preferences_;
   std::vector<Location> player_location_;

--- a/open_spiel/games/connect_four.cc
+++ b/open_spiel/games/connect_four.cc
@@ -46,7 +46,7 @@ std::unique_ptr<Game> Factory(const GameParameters& params) {
 
 REGISTER_SPIEL_GAME(kGameType, Factory);
 
-CellState PlayerToState(int player) {
+CellState PlayerToState(Player player) {
   switch (player) {
     case 0:
       return CellState::kCross;
@@ -105,19 +105,19 @@ std::vector<Action> ConnectFourState::LegalActions() const {
   return moves;
 }
 
-std::string ConnectFourState::ActionToString(int player,
+std::string ConnectFourState::ActionToString(Player player,
                                              Action action_id) const {
   return absl::StrCat(StateToString(PlayerToState(player)), action_id);
 }
 
-bool ConnectFourState::HasLineFrom(int player, int row, int col) const {
+bool ConnectFourState::HasLineFrom(Player player, int row, int col) const {
   return HasLineFromInDirection(player, row, col, 0, 1) ||
          HasLineFromInDirection(player, row, col, -1, -1) ||
          HasLineFromInDirection(player, row, col, -1, 0) ||
          HasLineFromInDirection(player, row, col, -1, 1);
 }
 
-bool ConnectFourState::HasLineFromInDirection(int player, int row, int col,
+bool ConnectFourState::HasLineFromInDirection(Player player, int row, int col,
                                               int drow, int dcol) const {
   if (row + 3 * drow >= kRows || col + 3 * dcol >= kCols ||
       row + 3 * drow < 0 || col + 3 * dcol < 0)
@@ -131,7 +131,7 @@ bool ConnectFourState::HasLineFromInDirection(int player, int row, int col,
   return true;
 }
 
-bool ConnectFourState::HasLine(int player) const {
+bool ConnectFourState::HasLine(Player player) const {
   CellState c = PlayerToState(player);
   for (int col = 0; col < kCols; ++col) {
     for (int row = 0; row < kRows; ++row) {
@@ -173,14 +173,14 @@ std::vector<double> ConnectFourState::Returns() const {
   return {0.0, 0.0};
 }
 
-std::string ConnectFourState::InformationState(int player) const {
+std::string ConnectFourState::InformationState(Player player) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
   return ToString();
 }
 
 void ConnectFourState::InformationStateAsNormalizedVector(
-    int player, std::vector<double>* values) const {
+    Player player, std::vector<double>* values) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
 
@@ -191,7 +191,7 @@ void ConnectFourState::InformationStateAsNormalizedVector(
   }
 }
 
-void ConnectFourState::UndoAction(int player, Action move) {
+void ConnectFourState::UndoAction(Player player, Action move) {
   board_[move] = CellState::kEmpty;
   current_player_ = player;
   history_.pop_back();

--- a/open_spiel/games/connect_four.h
+++ b/open_spiel/games/connect_four.h
@@ -57,17 +57,17 @@ class ConnectFourState : public State {
   ConnectFourState(const ConnectFourState& other) = default;
   explicit ConnectFourState(int num_distinct_actions, const std::string& str);
 
-  int CurrentPlayer() const override;
+  Player CurrentPlayer() const override;
   std::vector<Action> LegalActions() const override;
-  std::string ActionToString(int player, Action action_id) const override;
+  std::string ActionToString(Player player, Action action_id) const override;
   std::string ToString() const override;
   bool IsTerminal() const override;
   std::vector<double> Returns() const override;
-  std::string InformationState(int player) const override;
+  std::string InformationState(Player player) const override;
   void InformationStateAsNormalizedVector(
-      int player, std::vector<double>* values) const override;
+      Player player, std::vector<double>* values) const override;
   std::unique_ptr<State> Clone() const override;
-  void UndoAction(int player, Action move) override;
+  void UndoAction(Player player, Action move) override;
 
  protected:
   void DoApplyAction(Action move) override;
@@ -75,12 +75,12 @@ class ConnectFourState : public State {
  private:
   CellState& CellAt(int row, int col);
   CellState CellAt(int row, int col) const;
-  bool HasLine(int player) const;  // Does this player have a line?
-  bool HasLineFrom(int player, int row, int col) const;
-  bool HasLineFromInDirection(int player, int row, int col, int drow,
+  bool HasLine(Player player) const;  // Does this player have a line?
+  bool HasLineFrom(Player player, int row, int col) const;
+  bool HasLineFromInDirection(Player player, int row, int col, int drow,
                               int dcol) const;
   bool IsFull() const;      // Is the board full?
-  int current_player_ = 0;  // Player zero goes first
+  Player current_player_ = 0;  // Player zero goes first
   std::array<CellState, kNumCells> board_;
 };
 

--- a/open_spiel/games/coop_box_pushing.cc
+++ b/open_spiel/games/coop_box_pushing.cc
@@ -171,7 +171,7 @@ CoopBoxPushingState::CoopBoxPushingState(int horizon)
   SetPlayer({6, 6}, 1, OrientationType::kWest);
 }
 
-std::string CoopBoxPushingState::ActionToString(int player,
+std::string CoopBoxPushingState::ActionToString(Player player,
                                                 Action action) const {
   return ::open_spiel::coop_box_pushing::ActionToString(action);
 }
@@ -180,14 +180,14 @@ void CoopBoxPushingState::SetField(std::pair<int, int> coord, char v) {
   field_[coord.first * kCols + coord.second] = v;
 }
 
-void CoopBoxPushingState::SetPlayer(std::pair<int, int> coord, int player,
+void CoopBoxPushingState::SetPlayer(std::pair<int, int> coord, Player player,
                                     OrientationType orientation) {
   SetField(coord, ToCharacter(orientation));
   player_coords_[player] = coord;
   player_orient_[player] = orientation;
 }
 
-void CoopBoxPushingState::SetPlayer(std::pair<int, int> coord, int player) {
+void CoopBoxPushingState::SetPlayer(std::pair<int, int> coord, Player player) {
   SetPlayer(coord, player, player_orient_[player]);
 }
 
@@ -208,7 +208,7 @@ bool CoopBoxPushingState::InBounds(std::pair<int, int> coord) const {
           coord.second < kCols);
 }
 
-void CoopBoxPushingState::MoveForward(int player) {
+void CoopBoxPushingState::MoveForward(Player player) {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LE(player, 1);
 
@@ -354,7 +354,7 @@ void CoopBoxPushingState::DoApplyAction(Action action) {
   }
 }
 
-std::vector<Action> CoopBoxPushingState::LegalActions(int player) const {
+std::vector<Action> CoopBoxPushingState::LegalActions(Player player) const {
   if (player == kSimultaneousPlayerId) {
     return LegalFlatJointActions();
   }
@@ -409,12 +409,12 @@ std::vector<double> CoopBoxPushingState::Rewards() const {
 }
 
 bool CoopBoxPushingState::SameAsPlayer(std::pair<int, int> coord,
-                                       int player) const {
+                                       Player player) const {
   return coord == player_coords_[player];
 }
 
 int CoopBoxPushingState::ObservationPlane(std::pair<int, int> coord,
-                                          int player) const {
+                                          Player player) const {
   int plane = 0;
   switch (field(coord)) {
     case kField:
@@ -449,7 +449,7 @@ int CoopBoxPushingState::ObservationPlane(std::pair<int, int> coord,
 }
 
 void CoopBoxPushingState::InformationStateAsNormalizedVector(
-    int player, std::vector<double>* values) const {
+    Player player, std::vector<double>* values) const {
   values->resize(kCellStates * kRows * kCols);
   int plane_size = kRows * kCols;
 

--- a/open_spiel/games/coop_box_pushing.h
+++ b/open_spiel/games/coop_box_pushing.h
@@ -55,19 +55,19 @@ class CoopBoxPushingState : public SimMoveState {
  public:
   CoopBoxPushingState(int horizon);
 
-  std::string ActionToString(int player, Action action) const override;
+  std::string ActionToString(Player player, Action action) const override;
   std::string ToString() const override;
   bool IsTerminal() const override;
   std::vector<double> Returns() const override;
   std::vector<double> Rewards() const override;
-  std::string InformationState(int player) const {
+  std::string InformationState(Player player) const {
     SPIEL_CHECK_GE(player, 0);
     SPIEL_CHECK_LT(player, num_players_);
     return absl::StrCat("Observing player: ", player, "\n", ToString());
   }
-  void InformationStateAsNormalizedVector(int player,
+  void InformationStateAsNormalizedVector(Player player,
                                           std::vector<double>* values) const;
-  int CurrentPlayer() const override {
+  Player CurrentPlayer() const override {
     return IsTerminal() ? kTerminalPlayerId : cur_player_;
   }
   std::unique_ptr<State> Clone() const override;
@@ -75,7 +75,7 @@ class CoopBoxPushingState : public SimMoveState {
   ActionsAndProbs ChanceOutcomes() const;
 
   void Reset(const GameParameters& params);
-  std::vector<Action> LegalActions(int player) const override;
+  std::vector<Action> LegalActions(Player player) const override;
 
  protected:
   void DoApplyAction(Action action) override;
@@ -83,21 +83,21 @@ class CoopBoxPushingState : public SimMoveState {
 
  private:
   void SetField(std::pair<int, int> coord, char v);
-  void SetPlayer(std::pair<int, int> coord, int player,
+  void SetPlayer(std::pair<int, int> coord, Player player,
                  OrientationType orientation);
-  void SetPlayer(std::pair<int, int> coord, int player);
+  void SetPlayer(std::pair<int, int> coord, Player player);
   void AddReward(double reward);
   char field(std::pair<int, int> coord) const;
   void ResolveMoves();
-  void MoveForward(int player);
+  void MoveForward(Player player);
   bool InBounds(std::pair<int, int> coord) const;
-  bool SameAsPlayer(std::pair<int, int> coord, int player) const;
-  int ObservationPlane(std::pair<int, int> coord, int player) const;
+  bool SameAsPlayer(std::pair<int, int> coord, Player player) const;
+  int ObservationPlane(std::pair<int, int> coord, Player player) const;
 
   // Fields sets to bad/invalid values. Use Game::NewInitialState().
   double total_rewards_ = -1;
   int horizon_ = -1;     // Limit on the total number of moves.
-  int cur_player_ = -1;  // Could be chance's turn.
+  Player cur_player_ = -1;  // Could be chance's turn.
   int total_moves_ = 0;
   int initiative_;  // 0 = player initiative+1 goes first.
   bool win_;        // True if agents push the big box to the goal.

--- a/open_spiel/games/first_sealed_auction.cc
+++ b/open_spiel/games/first_sealed_auction.cc
@@ -69,7 +69,7 @@ int FPSBAState::CurrentPlayer() const {
 std::vector<Action> FPSBAState::EligibleWinners() const {
   int max_bid = *std::max_element(bids_.begin(), bids_.end());
   std::vector<Action> eligibles;
-  for (int player = 0; player < num_players_; player++) {
+  for (auto player = Player{0}; player < num_players_; player++) {
     if (bids_[player] == max_bid) {
       eligibles.push_back(player);
     }
@@ -94,7 +94,7 @@ std::vector<Action> FPSBAState::LegalActions() const {
   return {};
 }
 
-std::string FPSBAState::ActionToString(int player, Action action_id) const {
+std::string FPSBAState::ActionToString(Player player, Action action_id) const {
   if (player != kChancePlayerId) {
     return absl::StrCat("Player ", player, " bid: ", action_id);
   } else if (valuations_.size() < num_players_) {
@@ -137,7 +137,7 @@ void FPSBAState::DoApplyAction(Action action_id) {
   }
 }
 
-std::string FPSBAState::InformationState(int player) const {
+std::string FPSBAState::InformationState(Player player) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
   if (valuations_.size() <= player) return absl::StrCat("p", player);
@@ -148,7 +148,7 @@ std::string FPSBAState::InformationState(int player) const {
 }
 
 void FPSBAState::InformationStateAsNormalizedVector(
-    int player, std::vector<double>* values) const {
+    Player player, std::vector<double>* values) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
   values->resize(2 * max_value_ + num_players_);
@@ -167,7 +167,7 @@ void FPSBAState::InformationStateAsNormalizedVector(
   SPIEL_CHECK_EQ(cursor - values->begin(), values->size());
 }
 
-std::string FPSBAState::Observation(int player) const {
+std::string FPSBAState::Observation(Player player) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
   if (valuations_.size() <= player) return "";
@@ -175,7 +175,7 @@ std::string FPSBAState::Observation(int player) const {
 }
 
 void FPSBAState::ObservationAsNormalizedVector(
-    int player, std::vector<double>* values) const {
+    Player player, std::vector<double>* values) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
   values->resize(max_value_);
@@ -194,7 +194,7 @@ ActionsAndProbs FPSBAState::ChanceOutcomes() const {
   } else if (bids_.size() == num_players_ && winner_ == kInvalidPlayer) {
     int max_bid = *std::max_element(bids_.begin(), bids_.end());
     int num_tie = std::count(bids_.begin(), bids_.end(), max_bid);
-    for (int player = 0; player < num_players_; player++) {
+    for (auto player = Player{0}; player < num_players_; player++) {
       if (bids_[player] == max_bid) {
         valuesAndProbs.push_back(std::make_pair(player, 1. / num_tie));
       }

--- a/open_spiel/games/first_sealed_auction.h
+++ b/open_spiel/games/first_sealed_auction.h
@@ -47,19 +47,19 @@ class FPSBAState : public State {
   FPSBAState(int num_distinct_actions, int num_players);
   FPSBAState(const FPSBAState& other) = default;
 
-  int CurrentPlayer() const override;
+  Player CurrentPlayer() const override;
   std::vector<Action> LegalActions() const override;
-  std::string ActionToString(int player, Action action_id) const override;
+  std::string ActionToString(Player player, Action action_id) const override;
   std::string ToString() const override;
   bool IsTerminal() const override;
   std::vector<double> Returns() const override;
   std::unique_ptr<State> Clone() const override;
-  std::string InformationState(int player) const override;
+  std::string InformationState(Player player) const override;
   void InformationStateAsNormalizedVector(
-      int player, std::vector<double>* values) const override;
-  std::string Observation(int player) const override;
+      Player player, std::vector<double>* values) const override;
+  std::string Observation(Player player) const override;
   void ObservationAsNormalizedVector(
-      int player, std::vector<double>* values) const override;
+      Player player, std::vector<double>* values) const override;
   ActionsAndProbs ChanceOutcomes() const override;
 
  protected:

--- a/open_spiel/games/go.cc
+++ b/open_spiel/games/go.cc
@@ -98,7 +98,7 @@ std::vector<Action> GoState::LegalActions() const {
   return actions;
 }
 
-std::string GoState::ActionToString(int player, Action action) const {
+std::string GoState::ActionToString(Player player, Action action) const {
   return absl::StrCat(GoColorToString(static_cast<GoColor>(player)), " ",
                       GoPointToString(action));
 }
@@ -150,7 +150,7 @@ std::unique_ptr<State> GoState::Clone() const {
   return std::unique_ptr<State>(new GoState(*this));
 }
 
-void GoState::UndoAction(int player, Action action) {
+void GoState::UndoAction(Player player, Action action) {
   // We don't have direct undo functionality, but copying the board and
   // replaying all actions is still pretty fast (> 1 million undos/second).
   history_.pop_back();

--- a/open_spiel/games/go.h
+++ b/open_spiel/games/go.h
@@ -63,11 +63,11 @@ class GoState : public State {
   // Constructs a Go state for the empty board.
   GoState(int board_size, float komi, int handicap);
 
-  int CurrentPlayer() const override {
+  Player CurrentPlayer() const override {
     return IsTerminal() ? kTerminalPlayerId : ColorToPlayer(to_play_);
   }
   std::vector<Action> LegalActions() const override;
-  std::string ActionToString(int player, Action action) const override;
+  std::string ActionToString(Player player, Action action) const override;
   std::string ToString() const override;
 
   bool IsTerminal() const override;
@@ -75,7 +75,7 @@ class GoState : public State {
   std::vector<double> Returns() const override;
 
   std::unique_ptr<State> Clone() const override;
-  void UndoAction(int player, Action action) override;
+  void UndoAction(Player player, Action action) override;
 
   const GoBoard& board() const { return board_; }
 

--- a/open_spiel/games/goofspiel.cc
+++ b/open_spiel/games/goofspiel.cc
@@ -85,7 +85,7 @@ GoofspielState::GoofspielState(int num_distinct_actions, int num_players,
 
   // Player hands.
   player_hands_.clear();
-  for (int p = 0; p < num_players_; ++p) {
+  for (auto p = Player{0}; p < num_players_; ++p) {
     std::vector<bool> hand(num_cards_, true);
     player_hands_.push_back(hand);
   }
@@ -127,7 +127,7 @@ void GoofspielState::DoApplyAction(Action action_id) {
 void GoofspielState::DoApplyActions(const std::vector<Action>& actions) {
   // Check the actions are valid.
   SPIEL_CHECK_EQ(actions.size(), num_players_);
-  for (int p = 0; p < num_players_; ++p) {
+  for (auto p = Player{0}; p < num_players_; ++p) {
     const int action = actions[p];
     SPIEL_CHECK_GE(action, 0);
     SPIEL_CHECK_LT(action, num_cards_);
@@ -162,7 +162,7 @@ void GoofspielState::DoApplyActions(const std::vector<Action>& actions) {
   actions_history_.push_back(actions);
 
   // Remove the cards from the player's hands.
-  for (int p = 0; p < num_players_; ++p) {
+  for (auto p = Player{0}; p < num_players_; ++p) {
     player_hands_[p][actions[p]] = false;
   }
 
@@ -192,7 +192,7 @@ void GoofspielState::DoApplyActions(const std::vector<Action>& actions) {
 
     // Each player plays their last card
     std::vector<Action> actions(num_players_);
-    for (int p = 0; p < num_players_; ++p) {
+    for (auto p = Player{0}; p < num_players_; ++p) {
       auto legal_actions = LegalActions(p);
       SPIEL_CHECK_EQ(legal_actions.size(), 1);
       actions[p] = legal_actions[0];
@@ -201,7 +201,7 @@ void GoofspielState::DoApplyActions(const std::vector<Action>& actions) {
   } else if (turns_ == num_cards_) {
     // Game over - determine winner.
     int max_points = -1;
-    for (int p = 0; p < num_players_; ++p) {
+    for (auto p = Player{0}; p < num_players_; ++p) {
       if (points_[p] > max_points) {
         winners_.clear();
         max_points = points_[p];
@@ -222,7 +222,7 @@ std::vector<std::pair<Action, double>> GoofspielState::ChanceOutcomes() const {
   return outcomes;
 }
 
-std::vector<Action> GoofspielState::LegalActions(int player) const {
+std::vector<Action> GoofspielState::LegalActions(Player player) const {
   if (player == kSimultaneousPlayerId) return LegalFlatJointActions();
   if (player == kChancePlayerId) return LegalChanceOutcomes();
   if (player == kTerminalPlayerId) return std::vector<Action>();
@@ -238,7 +238,7 @@ std::vector<Action> GoofspielState::LegalActions(int player) const {
   return movelist;
 }
 
-std::string GoofspielState::ActionToString(int player, Action action_id) const {
+std::string GoofspielState::ActionToString(Player player, Action action_id) const {
   if (player == kSimultaneousPlayerId)
     return FlatJointActionToString(action_id);
   SPIEL_CHECK_GE(action_id, 0);
@@ -252,7 +252,7 @@ std::string GoofspielState::ToString() const {
   std::string points_line = "Points: ";
   std::string result = "";
 
-  for (int p = 0; p < num_players_; ++p) {
+  for (auto p = Player{0}; p < num_players_; ++p) {
     absl::StrAppend(&points_line, points_[p]);
     absl::StrAppend(&points_line, " ");
     absl::StrAppend(&result, "P");
@@ -269,7 +269,7 @@ std::string GoofspielState::ToString() const {
 
   // In imperfect information, the full state depends on both betting sequences
   if (impinfo_) {
-    for (int p = 0; p < num_players_; ++p) {
+    for (auto p = Player{0}; p < num_players_; ++p) {
       absl::StrAppend(&result, "P", p, " actions: ");
       for (int i = 0; i < actions_history_.size(); ++i) {
         absl::StrAppend(&result, actions_history_[i][p]);
@@ -308,7 +308,7 @@ std::vector<double> GoofspielState::Returns() const {
   }
 }
 
-std::string GoofspielState::InformationState(int player) const {
+std::string GoofspielState::InformationState(Player player) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
 
@@ -322,7 +322,7 @@ std::string GoofspielState::InformationState(int player) const {
     // Only know the observing player's action sequence.
     // Know the win-loss outcome of each step.
 
-    for (int p = 0; p < num_players_; ++p) {
+    for (auto p = Player{0}; p < num_players_; ++p) {
       absl::StrAppend(&points_line, points_[p]);
       absl::StrAppend(&points_line, " ");
 
@@ -371,19 +371,19 @@ std::string GoofspielState::InformationState(int player) const {
 }
 
 void GoofspielState::InformationStateAsNormalizedVector(
-    int player, std::vector<double>* values) const {
+    Player player, std::vector<double>* values) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
 
   values->clear();
 
   // 1-hot vector for the observing player.
-  for (int p = 0; p < num_players_; ++p) {
+  for (auto p = Player{0}; p < num_players_; ++p) {
     values->push_back(p == player ? 1 : 0);
   }
 
   // Point totals: one-hot vector encoding points, per player.
-  for (int p = 0; p < num_players_; ++p) {
+  for (auto p = Player{0}; p < num_players_; ++p) {
     // Cards numbered 1 .. K
     int max_points_slots = (num_cards_ * (num_cards_ + 1)) / 2 + 1;
     for (int i = 0; i < max_points_slots; ++i) {
@@ -399,7 +399,7 @@ void GoofspielState::InformationStateAsNormalizedVector(
 
     // Sequence of who won each trick.
     for (int i = 0; i < win_sequence_.size(); ++i) {
-      for (int p = 0; p < num_players_; ++p) {
+      for (auto p = Player{0}; p < num_players_; ++p) {
         values->push_back(win_sequence_[i] == p ? 1 : 0);
       }
     }
@@ -420,7 +420,7 @@ void GoofspielState::InformationStateAsNormalizedVector(
 
   } else {
     // Bit vectors encoding all players' hands.
-    for (int p = 0; p < num_players_; ++p) {
+    for (auto p = Player{0}; p < num_players_; ++p) {
       for (int c = 0; c < num_cards_; ++c) {
         values->push_back(player_hands_[p][c] ? 1 : 0);
       }

--- a/open_spiel/games/goofspiel.h
+++ b/open_spiel/games/goofspiel.h
@@ -65,19 +65,19 @@ class GoofspielState : public SimMoveState {
                           int num_cards, PointsOrder points_order,
                           bool impinfo);
 
-  int CurrentPlayer() const override;
-  std::string ActionToString(int player, Action action_id) const override;
+  Player CurrentPlayer() const override;
+  std::string ActionToString(Player player, Action action_id) const override;
   std::string ToString() const override;
   bool IsTerminal() const override;
   std::vector<double> Returns() const override;
-  std::string InformationState(int player) const override;
+  std::string InformationState(Player player) const override;
 
   void InformationStateAsNormalizedVector(
-      int player, std::vector<double>* values) const override;
+      Player player, std::vector<double>* values) const override;
   std::unique_ptr<State> Clone() const override;
   std::vector<std::pair<Action, double>> ChanceOutcomes() const override;
 
-  std::vector<Action> LegalActions(int player) const override;
+  std::vector<Action> LegalActions(Player player) const override;
 
  protected:
   void DoApplyAction(Action action_id) override;
@@ -88,7 +88,7 @@ class GoofspielState : public SimMoveState {
   PointsOrder points_order_;
   bool impinfo_;
 
-  int current_player_;
+  Player current_player_;
   std::set<int> winners_;
   int turns_;
   int point_card_index_;

--- a/open_spiel/games/goofspiel_test.cc
+++ b/open_spiel/games/goofspiel_test.cc
@@ -29,7 +29,7 @@ void BasicGoofspielTests() {
   testing::LoadGameTest("goofspiel");
   testing::ChanceOutcomesTest(*LoadGame("goofspiel"));
   testing::RandomSimTest(*LoadGame("goofspiel"), 100);
-  for (int players = 3; players <= 5; players++) {
+  for (Player players = 3; players <= 5; players++) {
     testing::RandomSimTest(
         *LoadGame("goofspiel", {{"players", GameParameter(players)}}), 100);
   }

--- a/open_spiel/games/havannah.cc
+++ b/open_spiel/games/havannah.cc
@@ -184,7 +184,7 @@ std::vector<Action> HavannahState::LegalActions() const {
   return moves;
 }
 
-std::string HavannahState::ActionToString(int player, Action action_id) const {
+std::string HavannahState::ActionToString(Player player, Action action_id) const {
   return ActionToMove(action_id).ToString();
 }
 
@@ -270,18 +270,18 @@ std::vector<double> HavannahState::Returns() const {
   return {0, 0};  // Unfinished
 }
 
-std::string HavannahState::InformationState(int player) const {
+std::string HavannahState::InformationState(Player player) const {
   return HistoryString();
 }
 
-std::string HavannahState::Observation(int player) const {
+std::string HavannahState::Observation(Player player) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
   return ToString();
 }
 
 void HavannahState::ObservationAsNormalizedVector(
-    int player, std::vector<double>* values) const {
+    Player player, std::vector<double>* values) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
 

--- a/open_spiel/games/havannah.h
+++ b/open_spiel/games/havannah.h
@@ -38,7 +38,7 @@ constexpr int kDefaultBoardSize = 8;
 constexpr int kMaxNeighbors = 6;  // Maximum number of neighbors for a cell
 constexpr int kCellStates = 1 + kNumPlayers;
 
-enum Player : uint8_t {
+enum HavannahPlayer : uint8_t {
   kPlayer1,
   kPlayer2,
   kPlayerNone,
@@ -100,7 +100,7 @@ class HavannahState : public State {
   // cell that is not a group leader.
   struct Cell {
     // Who controls this cell.
-    Player player;
+    HavannahPlayer player;
 
     // Whether this cell is marked/visited in a ring search. Should always be
     // false except while running CheckRingDFS.
@@ -117,7 +117,7 @@ class HavannahState : public State {
     uint8_t edge;    // A bitset of which edges this group is connected to.
 
     Cell() {}
-    Cell(Player player_, int parent_, int corner_, int edge_)
+    Cell(HavannahPlayer player_, int parent_, int corner_, int edge_)
         : player(player_),
           mark(false),
           parent(parent_),
@@ -136,17 +136,17 @@ class HavannahState : public State {
 
   HavannahState(const HavannahState&) = default;
 
-  int CurrentPlayer() const override {
+  Player CurrentPlayer() const override {
     return IsTerminal() ? kTerminalPlayerId : static_cast<int>(current_player_);
   }
-  std::string ActionToString(int player, Action action_id) const override;
+  std::string ActionToString(Player player, Action action_id) const override;
   std::string ToString() const override;
   bool IsTerminal() const override { return outcome_ != kPlayerNone; }
   std::vector<double> Returns() const override;
-  std::string InformationState(int player) const override;
-  std::string Observation(int player) const override;
+  std::string InformationState(Player player) const override;
+  std::string Observation(Player player) const override;
   void ObservationAsNormalizedVector(
-      int player, std::vector<double>* values) const override;
+      Player player, std::vector<double>* values) const override;
   std::unique_ptr<State> Clone() const override;
   std::vector<Action> LegalActions() const override;
 
@@ -174,8 +174,8 @@ class HavannahState : public State {
 
  private:
   std::vector<Cell> board_;
-  Player current_player_ = kPlayer1;
-  Player outcome_ = kPlayerNone;
+  HavannahPlayer current_player_ = kPlayer1;
+  HavannahPlayer outcome_ = kPlayerNone;
   const int board_size_;
   const int board_diameter_;
   const int valid_cells_;

--- a/open_spiel/games/hex.cc
+++ b/open_spiel/games/hex.cc
@@ -52,7 +52,7 @@ REGISTER_SPIEL_GAME(kGameType, Factory);
 
 }  // namespace
 
-CellState HexState::PlayerAndActionToState(int player, Action move) const {
+CellState HexState::PlayerAndActionToState(Player player, Action move) const {
   // This function returns the CellState resulting from the given move.
   // The cell state tells us:
   // - The colour of the stone.
@@ -194,7 +194,7 @@ std::vector<Action> HexState::LegalActions() const {
   return moves;
 }
 
-std::string HexState::ActionToString(int player, Action action_id) const {
+std::string HexState::ActionToString(Player player, Action action_id) const {
   // This does not comply with the Hex Text Protocol
   // TODO(author8): Make compliant with HTP
   return absl::StrCat(StateToString(PlayerAndActionToState(player, action_id)),
@@ -250,18 +250,18 @@ std::vector<double> HexState::Returns() const {
   return {result_black_perspective_, -result_black_perspective_};
 }
 
-std::string HexState::InformationState(int player) const {
+std::string HexState::InformationState(Player player) const {
   return HistoryString();
 }
 
-std::string HexState::Observation(int player) const {
+std::string HexState::Observation(Player player) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
   return ToString();
 }
 
 void HexState::ObservationAsNormalizedVector(
-    int player, std::vector<double>* values) const {
+    Player player, std::vector<double>* values) const {
   // TODO(author8): Make an option to not expose connection info
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);

--- a/open_spiel/games/hex.h
+++ b/open_spiel/games/hex.h
@@ -65,17 +65,17 @@ class HexState : public State {
 
   HexState(const HexState&) = default;
 
-  int CurrentPlayer() const override {
+  Player CurrentPlayer() const override {
     return IsTerminal() ? kTerminalPlayerId : current_player_;
   }
-  std::string ActionToString(int player, Action action_id) const override;
+  std::string ActionToString(Player player, Action action_id) const override;
   std::string ToString() const override;
   bool IsTerminal() const override;
   std::vector<double> Returns() const override;
-  std::string InformationState(int player) const override;
-  std::string Observation(int player) const override;
+  std::string InformationState(Player player) const override;
+  std::string Observation(Player player) const override;
   void ObservationAsNormalizedVector(
-      int player, std::vector<double>* values) const override;
+      Player player, std::vector<double>* values) const override;
   std::unique_ptr<State> Clone() const override;
   std::vector<Action> LegalActions() const override;
   CellState BoardAt(int cell) const { return board_[cell]; }
@@ -85,8 +85,8 @@ class HexState : public State {
   void DoApplyAction(Action move) override;
 
  private:
-  CellState PlayerAndActionToState(int player, Action move) const;
-  int current_player_ = 0;                         // Player zero goes first
+  CellState PlayerAndActionToState(Player player, Action move) const;
+  Player current_player_ = 0;                         // Player zero goes first
   double result_black_perspective_ = 0;            // 1 if Black (player 0) wins
   std::vector<int> AdjacentCells(int cell) const;  // Cells adjacent to cell
   const int board_size_;

--- a/open_spiel/games/kuhn_poker.cc
+++ b/open_spiel/games/kuhn_poker.cc
@@ -102,7 +102,7 @@ void KuhnState::DoApplyAction(Action move) {
     // who stayed in the hand.
     // Check players in turn starting with the highest card.
     for (int card = num_players_; card >= 0; --card) {
-      const int player = card_dealt_[card];
+      const Player player = card_dealt_[card];
       if (player != kInvalidPlayer && DidBet(player)) {
         winner_ = player;
         break;
@@ -126,7 +126,7 @@ std::vector<Action> KuhnState::LegalActions() const {
   }
 }
 
-std::string KuhnState::ActionToString(int player, Action move) const {
+std::string KuhnState::ActionToString(Player player, Action move) const {
   if (player == kChancePlayerId)
     return absl::StrCat("Deal:", move);
   else if (move == ActionType::kPass)
@@ -160,7 +160,7 @@ std::vector<double> KuhnState::Returns() const {
   }
 
   std::vector<double> returns(num_players_);
-  for (int player = 0; player < num_players_; ++player) {
+  for (auto player = Player{0}; player < num_players_; ++player) {
     const int bet = DidBet(player) ? 2 : 1;
     returns[player] = (player == winner_) ? (pot_ - bet) : -bet;
   }
@@ -168,7 +168,7 @@ std::vector<double> KuhnState::Returns() const {
 }
 
 // Information state is card then bets, e.g. 1pb
-std::string KuhnState::InformationState(int player) const {
+std::string KuhnState::InformationState(Player player) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
 
@@ -180,7 +180,7 @@ std::string KuhnState::InformationState(int player) const {
 }
 
 // Observation is card then contributions to the pot, e.g. 111
-std::string KuhnState::Observation(int player) const {
+std::string KuhnState::Observation(Player player) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
 
@@ -189,14 +189,14 @@ std::string KuhnState::Observation(int player) const {
 
   // Adding the contribution of each players to the pot. These values are not
   // between 0 and 1.
-  for (int p = 0; p < num_players_; p++) {
+  for (auto p = Player{0}; p < num_players_; p++) {
     str += std::to_string(ante_[p]);
   }
   return str;
 }
 
 void KuhnState::InformationStateAsNormalizedVector(
-    int player, std::vector<double>* values) const {
+    Player player, std::vector<double>* values) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
 
@@ -217,7 +217,7 @@ void KuhnState::InformationStateAsNormalizedVector(
 }
 
 void KuhnState::ObservationAsNormalizedVector(
-    int player, std::vector<double>* values) const {
+    Player player, std::vector<double>* values) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
   // The format is described in ObservationNormalizedVectorShape
@@ -237,7 +237,7 @@ void KuhnState::ObservationAsNormalizedVector(
   int offset = 2 * num_players_ + 1;
   // Adding the contribution of each players to the pot. These values are not
   // between 0 and 1.
-  for (int p = 0; p < num_players_; p++) {
+  for (auto p = Player{0}; p < num_players_; p++) {
     (*values)[offset + p] = ante_[p];
   }
 }
@@ -246,7 +246,7 @@ std::unique_ptr<State> KuhnState::Clone() const {
   return std::unique_ptr<State>(new KuhnState(*this));
 }
 
-void KuhnState::UndoAction(int player, Action move) {
+void KuhnState::UndoAction(Player player, Action move) {
   if (history_.size() <= num_players_) {
     // Undoing a deal move.
     card_dealt_[move] = kInvalidPlayer;
@@ -271,7 +271,7 @@ std::vector<std::pair<Action, double>> KuhnState::ChanceOutcomes() const {
   return outcomes;
 }
 
-bool KuhnState::DidBet(int player) const {
+bool KuhnState::DidBet(Player player) const {
   if (first_bettor_ == kInvalidPlayer) {
     return false;
   } else if (player == first_bettor_) {

--- a/open_spiel/games/kuhn_poker.h
+++ b/open_spiel/games/kuhn_poker.h
@@ -49,20 +49,20 @@ class KuhnState : public State {
   explicit KuhnState(int num_distinct_actions, int num_players);
   KuhnState(const KuhnState&) = default;
 
-  int CurrentPlayer() const override;
+  Player CurrentPlayer() const override;
 
-  std::string ActionToString(int player, Action move) const override;
+  std::string ActionToString(Player player, Action move) const override;
   std::string ToString() const override;
   bool IsTerminal() const override;
   std::vector<double> Returns() const override;
-  std::string InformationState(int player) const override;
-  std::string Observation(int player) const override;
+  std::string InformationState(Player player) const override;
+  std::string Observation(Player player) const override;
   void InformationStateAsNormalizedVector(
-      int player, std::vector<double>* values) const override;
+      Player player, std::vector<double>* values) const override;
   void ObservationAsNormalizedVector(
-      int player, std::vector<double>* values) const override;
+      Player player, std::vector<double>* values) const override;
   std::unique_ptr<State> Clone() const override;
-  void UndoAction(int player, Action move) override;
+  void UndoAction(Player player, Action move) override;
   std::vector<std::pair<Action, double>> ChanceOutcomes() const override;
   std::vector<Action> LegalActions() const override;
   std::vector<int> hand() const { return {card_dealt_[CurrentPlayer()]}; }
@@ -72,7 +72,7 @@ class KuhnState : public State {
 
  private:
   // Whether the specified player made a bet
-  bool DidBet(int player) const;
+  bool DidBet(Player player) const;
 
   // The move history and number of players are sufficient information to
   // specify the state of the game. We keep track of more information to make

--- a/open_spiel/games/kuhn_poker_test.cc
+++ b/open_spiel/games/kuhn_poker_test.cc
@@ -28,7 +28,7 @@ void BasicKuhnTests() {
   testing::LoadGameTest("kuhn_poker");
   testing::ChanceOutcomesTest(*LoadGame("kuhn_poker"));
   testing::RandomSimTest(*LoadGame("kuhn_poker"), 100);
-  for (int players = 3; players <= 5; players++) {
+  for (Player players = 3; players <= 5; players++) {
     testing::RandomSimTest(
         *LoadGame("kuhn_poker", {{"players", GameParameter(players)}}), 100);
   }

--- a/open_spiel/games/leduc_poker.h
+++ b/open_spiel/games/leduc_poker.h
@@ -62,17 +62,17 @@ class LeducState : public State {
  public:
   explicit LeducState(int num_players, const LeducGame& parent);
 
-  int CurrentPlayer() const override;
-  std::string ActionToString(int player, Action move) const override;
+  Player CurrentPlayer() const override;
+  std::string ActionToString(Player player, Action move) const override;
   std::string ToString() const override;
   bool IsTerminal() const override;
   std::vector<double> Returns() const override;
-  std::string InformationState(int player) const override;
-  std::string Observation(int player) const override;
+  std::string InformationState(Player player) const override;
+  std::string Observation(Player player) const override;
   void InformationStateAsNormalizedVector(
-      int player, std::vector<double>* values) const override;
+      Player player, std::vector<double>* values) const override;
   void ObservationAsNormalizedVector(
-      int player, std::vector<double>* values) const override;
+      Player player, std::vector<double>* values) const override;
   std::unique_ptr<State> Clone() const override;
   // The probability of taking each possible action in a particular info state.
   std::vector<std::pair<Action, double>> ChanceOutcomes() const override;
@@ -82,7 +82,7 @@ class LeducState : public State {
   int deck_size() const { return deck_size_; }
   int public_card() const { return public_card_; }
   int raises() const { return num_raises_; }
-  int private_card(int player) const { return private_cards_[player]; }
+  int private_card(Player player) const { return private_cards_[player]; }
   std::vector<Action> LegalActions() const override;
 
   // Returns a vector of MaxGameLength containing all of the betting actions
@@ -113,14 +113,14 @@ class LeducState : public State {
   void ResolveWinner();
   bool ReadyForNextRound() const;
   void NewRound();
-  int RankHand(int player) const;
+  int RankHand(Player player) const;
   void SequenceAppendMove(int move);
-  void Ante(int player, int amount);
+  void Ante(Player player, int amount);
 
   const LeducGame& parent_game_;
 
   // Fields sets to bad/invalid values. Use Game::NewInitialState().
-  int cur_player_;
+  Player cur_player_;
 
   int num_calls_;    // Number of calls this round (total, not per player).
   int num_raises_;   // Number of raises made in the round (not per player).

--- a/open_spiel/games/leduc_poker_test.cc
+++ b/open_spiel/games/leduc_poker_test.cc
@@ -25,7 +25,7 @@ void BasicLeducTests() {
   testing::LoadGameTest("leduc_poker");
   testing::ChanceOutcomesTest(*LoadGame("leduc_poker"));
   testing::RandomSimTest(*LoadGame("leduc_poker"), 100);
-  for (int players = 3; players <= 5; players++) {
+  for (Player players = 3; players <= 5; players++) {
     testing::RandomSimTest(
         *LoadGame("leduc_poker", {{"players", GameParameter(players)}}), 100);
   }

--- a/open_spiel/games/liars_dice.cc
+++ b/open_spiel/games/liars_dice.cc
@@ -81,7 +81,7 @@ LiarsDiceState::LiarsDiceState(int num_distinct_actions, int num_players,
   }
 }
 
-std::string LiarsDiceState::ActionToString(int player, Action action_id) const {
+std::string LiarsDiceState::ActionToString(Player player, Action action_id) const {
   if (player != kChancePlayerId) {
     if (action_id == total_num_dice_ * kDiceSides) {
       return "Liar";
@@ -109,7 +109,7 @@ void LiarsDiceState::ResolveWinner() {
 
   // Count all the matches among all dice from all the players
   // kDiceSides (e.g. 6) is wild, so it always matches.
-  for (int p = 0; p < num_players_; p++) {
+  for (auto p = Player{0}; p < num_players_; p++) {
     for (int d = 0; d < num_dice_[p]; d++) {
       if (dice_outcomes_[p][d] == face || dice_outcomes_[p][d] == kDiceSides) {
         matches++;
@@ -148,7 +148,7 @@ void LiarsDiceState::DoApplyAction(Action action) {
         // Time to start playing!
         cur_player_ = 0;
         // Sort all players' rolls
-        for (int p = 0; p < num_players_; p++) {
+        for (auto p = Player{0}; p < num_players_; p++) {
           std::sort(dice_outcomes_[p].begin(), dice_outcomes_[p].end());
         }
       }
@@ -211,7 +211,7 @@ std::vector<std::pair<Action, double>> LiarsDiceState::ChanceOutcomes() const {
   return outcomes;
 }
 
-std::string LiarsDiceState::InformationState(int player) const {
+std::string LiarsDiceState::InformationState(Player player) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
 
@@ -230,7 +230,7 @@ std::string LiarsDiceState::InformationState(int player) const {
 std::string LiarsDiceState::ToString() const {
   std::string result = "";
 
-  for (int p = 0; p < num_players_; p++) {
+  for (auto p = Player{0}; p < num_players_; p++) {
     if (p != 0) absl::StrAppend(&result, " ");
     for (int d = 0; d < num_dice_[p]; d++) {
       absl::StrAppend(&result, dice_outcomes_[p][d]);
@@ -270,7 +270,7 @@ std::vector<double> LiarsDiceState::Returns() const {
 }
 
 void LiarsDiceState::InformationStateAsNormalizedVector(
-    int player, std::vector<double>* values) const {
+    Player player, std::vector<double>* values) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
 
@@ -324,7 +324,7 @@ LiarsDiceGame::LiarsDiceGame(const GameParameters& params)
   total_num_dice_ = 0;
   num_dice_.resize(num_players_, 0);
 
-  for (int p = 0; p < num_players_; p++) {
+  for (auto p = Player{0}; p < num_players_; p++) {
     std::string key = absl::StrCat("numdice", p);
 
     int my_num_dice = def_num_dice;

--- a/open_spiel/games/liars_dice.h
+++ b/open_spiel/games/liars_dice.h
@@ -45,14 +45,14 @@ class LiarsDiceState : public State {
   LiarsDiceState(const LiarsDiceState&) = default;
 
   void Reset(const GameParameters& params);
-  int CurrentPlayer() const override;
-  std::string ActionToString(int player, Action action_id) const override;
+  Player CurrentPlayer() const override;
+  std::string ActionToString(Player player, Action action_id) const override;
   std::string ToString() const override;
   bool IsTerminal() const override;
   std::vector<double> Returns() const override;
-  std::string InformationState(int player) const override;
+  std::string InformationState(Player player) const override;
   void InformationStateAsNormalizedVector(
-      int player, std::vector<double>* values) const override;
+      Player player, std::vector<double>* values) const override;
   std::unique_ptr<State> Clone() const override;
   std::vector<std::pair<Action, double>> ChanceOutcomes() const override;
   std::vector<Action> LegalActions() const override;
@@ -64,7 +64,7 @@ class LiarsDiceState : public State {
   void ResolveWinner();
 
   // Initialized to invalid values. Use Game::NewInitialState().
-  int cur_player_;  // Player whose turn it is.
+  Player cur_player_;  // Player whose turn it is.
   int cur_roller_;  // Player currently rolling dice.
   int winner_;
   int loser_;

--- a/open_spiel/games/markov_soccer.cc
+++ b/open_spiel/games/markov_soccer.cc
@@ -76,7 +76,7 @@ MarkovSoccerState::MarkovSoccerState(const MarkovSoccerGame& parent_game)
     : SimMoveState(parent_game.NumDistinctActions(), parent_game.NumPlayers()),
       parent_game_(parent_game) {}
 
-std::string MarkovSoccerState::ActionToString(int player,
+std::string MarkovSoccerState::ActionToString(Player player,
                                               Action action_id) const {
   if (player == kSimultaneousPlayerId)
     return FlatJointActionToString(action_id);
@@ -158,7 +158,7 @@ bool MarkovSoccerState::InBounds(int r, int c) const {
   return (r >= 0 && c >= 0 && r < kRows && c < kCols);
 }
 
-void MarkovSoccerState::ResolveMove(int player, int move) {
+void MarkovSoccerState::ResolveMove(Player player, int move) {
   int old_row = player_row_[player - 1];
   int old_col = player_col_[player - 1];
   int new_row = old_row + row_offsets[move];
@@ -242,7 +242,7 @@ void MarkovSoccerState::DoApplyAction(Action action_id) {
   total_moves_++;
 }
 
-std::vector<Action> MarkovSoccerState::LegalActions(int player) const {
+std::vector<Action> MarkovSoccerState::LegalActions(Player player) const {
   if (IsChanceNode()) {
     if (total_moves_ == 0) {
       return {kChanceLoc1, kChanceLoc2};
@@ -328,7 +328,7 @@ int MarkovSoccerState::observation_plane(int r, int c) const {
 }
 
 void MarkovSoccerState::InformationStateAsNormalizedVector(
-    int player, std::vector<double>* values) const {
+    Player player, std::vector<double>* values) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
 

--- a/open_spiel/games/markov_soccer.h
+++ b/open_spiel/games/markov_soccer.h
@@ -39,18 +39,18 @@ class MarkovSoccerState : public SimMoveState {
   explicit MarkovSoccerState(const MarkovSoccerGame& parent_game);
   MarkovSoccerState(const MarkovSoccerState&) = default;
 
-  std::string ActionToString(int player, Action action_id) const override;
+  std::string ActionToString(Player player, Action action_id) const override;
   std::string ToString() const override;
   bool IsTerminal() const override;
   std::vector<double> Returns() const override;
-  std::string InformationState(int player) const {
+  std::string InformationState(Player player) const {
     SPIEL_CHECK_GE(player, 0);
     SPIEL_CHECK_LT(player, num_players_);
     return ToString();
   }
-  void InformationStateAsNormalizedVector(int player,
+  void InformationStateAsNormalizedVector(Player player,
                                           std::vector<double>* values) const;
-  int CurrentPlayer() const override {
+  Player CurrentPlayer() const override {
     return IsTerminal() ? kTerminalPlayerId : cur_player_;
   }
   std::unique_ptr<State> Clone() const override;
@@ -58,7 +58,7 @@ class MarkovSoccerState : public SimMoveState {
   ActionsAndProbs ChanceOutcomes() const;
 
   void Reset(int horizon);
-  std::vector<Action> LegalActions(int player) const override;
+  std::vector<Action> LegalActions(Player player) const override;
 
  protected:
   void DoApplyAction(Action action_id) override;
@@ -67,7 +67,7 @@ class MarkovSoccerState : public SimMoveState {
  private:
   void SetField(int r, int c, char v);
   char field(int r, int c) const;
-  void ResolveMove(int player, int move);
+  void ResolveMove(Player player, int move);
   bool InBounds(int r, int c) const;
   int observation_plane(int r, int c) const;
 
@@ -75,7 +75,7 @@ class MarkovSoccerState : public SimMoveState {
 
   // Fields set to bad values. Use Game::NewInitialState().
   int winner_ = -1;
-  int cur_player_ = -1;  // Could be chance's turn.
+  Player cur_player_ = -1;  // Could be chance's turn.
   int total_moves_ = -1;
   int horizon_ = -1;
   std::array<int, 2> player_row_ = {{-1, -1}};  // Players' rows.

--- a/open_spiel/games/matching_pennies_3p.cc
+++ b/open_spiel/games/matching_pennies_3p.cc
@@ -54,11 +54,11 @@ MatchingPennies3pState::MatchingPennies3pState(int num_distinct_actions,
       terminal_(false),
       returns_({0, 0, 0}) {}
 
-std::vector<Action> MatchingPennies3pState::LegalActions(int player) const {
+std::vector<Action> MatchingPennies3pState::LegalActions(Player player) const {
   return {kHeadsActionId, kTailsActionId};  // Heads and Tails.
 }
 
-std::string MatchingPennies3pState::ActionToString(int player,
+std::string MatchingPennies3pState::ActionToString(Player player,
                                                    Action move_id) const {
   switch (move_id) {
     case kHeadsActionId:

--- a/open_spiel/games/matching_pennies_3p.h
+++ b/open_spiel/games/matching_pennies_3p.h
@@ -46,8 +46,8 @@ class MatchingPennies3pState : public NFGState {
  public:
   MatchingPennies3pState(int num_distinct_actions, int num_players);
 
-  std::vector<Action> LegalActions(int player) const override;
-  std::string ActionToString(int player, Action move_id) const override;
+  std::vector<Action> LegalActions(Player player) const override;
+  std::string ActionToString(Player player, Action move_id) const override;
   bool IsTerminal() const override;
   std::vector<double> Returns() const override;
   std::unique_ptr<State> Clone() const override;

--- a/open_spiel/games/oshi_zumo.cc
+++ b/open_spiel/games/oshi_zumo.cc
@@ -111,10 +111,10 @@ void OshiZumoState::DoApplyActions(const std::vector<Action>& actions) {
   total_moves_++;
 }
 
-std::vector<Action> OshiZumoState::LegalActions(int player) const {
+std::vector<Action> OshiZumoState::LegalActions(Player player) const {
   if (player == kSimultaneousPlayerId) return LegalFlatJointActions();
   SPIEL_CHECK_FALSE(IsChanceNode());
-  SPIEL_CHECK_TRUE(player == 0 || player == 1);
+  SPIEL_CHECK_TRUE(player == Player{0} || player == Player{1});
 
   std::vector<Action> movelist;
   for (int bet = 0; bet <= coins_[player]; bet++) {
@@ -123,7 +123,7 @@ std::vector<Action> OshiZumoState::LegalActions(int player) const {
   return movelist;
 }
 
-std::string OshiZumoState::ActionToString(int player, Action action_id) const {
+std::string OshiZumoState::ActionToString(Player player, Action action_id) const {
   if (player == kSimultaneousPlayerId)
     return FlatJointActionToString(action_id);
   SPIEL_CHECK_GE(action_id, 0);
@@ -182,14 +182,14 @@ std::vector<double> OshiZumoState::Returns() const {
   }
 }
 
-std::string OshiZumoState::InformationState(int player) const {
+std::string OshiZumoState::InformationState(Player player) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
   return ToString();  // All the information is public.
 }
 
 void OshiZumoState::InformationStateAsNormalizedVector(
-    int player, std::vector<double>* values) const {
+    Player player, std::vector<double>* values) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
 

--- a/open_spiel/games/oshi_zumo.h
+++ b/open_spiel/games/oshi_zumo.h
@@ -52,16 +52,16 @@ class OshiZumoState : public SimMoveState {
  public:
   explicit OshiZumoState(const OshiZumoGame& parent_game);
 
-  int CurrentPlayer() const override;
-  std::string ActionToString(int player, Action action_id) const override;
+  Player CurrentPlayer() const override;
+  std::string ActionToString(Player player, Action action_id) const override;
   std::string ToString() const override;
   bool IsTerminal() const override;
   std::vector<double> Returns() const override;
-  std::string InformationState(int player) const override;
+  std::string InformationState(Player player) const override;
   void InformationStateAsNormalizedVector(
-      int player, std::vector<double>* values) const override;
+      Player player, std::vector<double>* values) const override;
   std::unique_ptr<State> Clone() const override;
-  std::vector<Action> LegalActions(int player) const override;
+  std::vector<Action> LegalActions(Player player) const override;
 
  protected:
   void DoApplyActions(const std::vector<Action>& actions) override;

--- a/open_spiel/games/oware.cc
+++ b/open_spiel/games/oware.cc
@@ -71,8 +71,8 @@ OwareState::OwareState(const OwareBoard& board)
 
 std::vector<Action> OwareState::LegalActions() const {
   std::vector<Action> actions;
-  const int lower = PlayerLowerHouse(board_.current_player);
-  const int upper = PlayerUpperHouse(board_.current_player);
+  const Player lower = PlayerLowerHouse(board_.current_player);
+  const Player upper = PlayerUpperHouse(board_.current_player);
   if (OpponentSeeds() == 0) {
     // In case the opponent does not have any seeds, a player must make
     // a move which gives the opponent seeds.
@@ -92,11 +92,11 @@ std::vector<Action> OwareState::LegalActions() const {
   return actions;
 }
 
-std::string OwareState::ActionToString(int player, Action action) const {
-  return std::string(1, (player == 0 ? 'A' : 'a') + action);
+std::string OwareState::ActionToString(Player player, Action action) const {
+  return std::string(1, (player == Player{0} ? 'A' : 'a') + action);
 }
 
-void OwareState::WritePlayerScore(std::ostringstream& out, int player) const {
+void OwareState::WritePlayerScore(std::ostringstream& out, Player player) const {
   out << "Player " << player << " score = " << board_.score[player];
   if (CurrentPlayer() == player) {
     out << " [PLAYING]" << std::endl;
@@ -212,7 +212,7 @@ bool OwareState::IsGrandSlam(int house) const {
 
 int OwareState::OpponentSeeds() const {
   int count = 0;
-  const int opponent = 1 - board_.current_player;
+  const Player opponent = 1 - board_.current_player;
   const int lower = PlayerLowerHouse(opponent);
   const int upper = PlayerUpperHouse(opponent);
   for (int house = lower; house <= upper; house++) {
@@ -263,23 +263,23 @@ void OwareState::DoApplyAction(Action action) {
 
 void OwareState::CollectAndTerminate() {
   for (int house = 0; house < NumHouses(); house++) {
-    const int player = house / num_houses_per_player_;
+    const Player player = house / num_houses_per_player_;
     board_.score[player] += board_.seeds[house];
     board_.seeds[house] = 0;
   }
 }
 
-std::string OwareState::Observation(int player) const {
+std::string OwareState::Observation(Player player) const {
   return board_.ToString();
 }
 
 void OwareState::ObservationAsNormalizedVector(
-    int player, std::vector<double>* values) const {
+    Player player, std::vector<double>* values) const {
   values->resize(/*seeds*/ NumHouses() + /*scores*/ kNumPlayers);
   for (int house = 0; house < NumHouses(); ++house) {
     (*values)[house] = ((double)board_.seeds[house]) / total_seeds_;
   }
-  for (int player = 0; player < kNumPlayers; ++player) {
+  for (Player player = 0; player < kNumPlayers; ++player) {
     (*values)[NumHouses() + player] =
         ((double)board_.score[player]) / total_seeds_;
   }

--- a/open_spiel/games/oware.h
+++ b/open_spiel/games/oware.h
@@ -57,18 +57,18 @@ class OwareState : public State {
   // Custom board setup to support testing.
   explicit OwareState(const OwareBoard& board);
 
-  int CurrentPlayer() const override {
+  Player CurrentPlayer() const override {
     return IsTerminal() ? kTerminalPlayerId : board_.current_player;
   }
 
   std::vector<Action> LegalActions() const override;
-  std::string ActionToString(int player, Action action_id) const override;
+  std::string ActionToString(Player player, Action action_id) const override;
   std::string ToString() const override;
   bool IsTerminal() const override;
   std::vector<double> Returns() const override;
   std::unique_ptr<State> Clone() const override;
   const OwareBoard& Board() const { return board_; }
-  std::string Observation(int player) const override;
+  std::string Observation(Player player) const override;
 
   // The game board is provided as a vector, encoding the players' seeds
   // and their score, as a fraction of the number of total number of seeds in
@@ -76,13 +76,13 @@ class OwareState : public State {
   // training, although the given representation is not necessary the best
   // for that purpose.
   void ObservationAsNormalizedVector(
-      int player, std::vector<double>* values) const override;
+      Player player, std::vector<double>* values) const override;
 
  protected:
   void DoApplyAction(Action action) override;
 
  private:
-  void WritePlayerScore(std::ostringstream& out, int player) const;
+  void WritePlayerScore(std::ostringstream& out, Player player) const;
 
   // Collects the seeds from the given house and distributes them
   // counterclockwise, skipping the starting position in all cases.
@@ -114,11 +114,11 @@ class OwareState : public State {
     return LowerHouse(house) + num_houses_per_player_ - 1;
   }
 
-  int PlayerLowerHouse(int player) const {
+  int PlayerLowerHouse(Player player) const {
     return player * num_houses_per_player_;
   }
 
-  int PlayerUpperHouse(int player) const {
+  int PlayerUpperHouse(Player player) const {
     return player * num_houses_per_player_ + num_houses_per_player_ - 1;
   }
 
@@ -130,7 +130,7 @@ class OwareState : public State {
     return house % num_houses_per_player_;
   }
 
-  int ActionToHouse(int player, Action action) const {
+  int ActionToHouse(Player player, Action action) const {
     return player * num_houses_per_player_ + action;
   }
 

--- a/open_spiel/games/oware/oware_board.cc
+++ b/open_spiel/games/oware/oware_board.cc
@@ -18,11 +18,11 @@ namespace open_spiel {
 namespace oware {
 
 OwareBoard::OwareBoard(int num_houses_per_player, int num_seeds_per_house)
-    : current_player(0),
+    : current_player(Player{0}),
       score(kNumPlayers, 0),
       seeds(kNumPlayers * num_houses_per_player, num_seeds_per_house) {}
 
-OwareBoard::OwareBoard(int current_player, const std::vector<int>& score,
+OwareBoard::OwareBoard(Player current_player, const std::vector<int>& score,
                        const std::vector<int>& seeds)
     : current_player(current_player), score(score), seeds(seeds) {
   SPIEL_CHECK_EQ(score.size(), kNumPlayers);

--- a/open_spiel/games/oware/oware_board.h
+++ b/open_spiel/games/oware/oware_board.h
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "open_spiel/spiel_utils.h"
+#include "open_spiel/spiel.h"
 namespace open_spiel {
 namespace oware {
 
@@ -29,7 +30,7 @@ struct OwareBoard {
  public:
   OwareBoard(int num_houses_per_player, int num_seeds_per_house);
   // Custom board setup to support testing.
-  OwareBoard(int current_player, const std::vector<int>& score,
+  OwareBoard(Player current_player, const std::vector<int>& score,
              const std::vector<int>& seeds);
   OwareBoard(const OwareBoard&) = default;
   OwareBoard& operator=(const OwareBoard&) = default;
@@ -42,7 +43,7 @@ struct OwareBoard {
   // captured and the ones still in play.
   int TotalSeeds() const;
 
-  int current_player;
+  Player current_player;
   // The number of seeds each player has in their score house, one entry
   // for each player.
   std::vector<int> score;

--- a/open_spiel/games/pentago.cc
+++ b/open_spiel/games/pentago.cc
@@ -152,7 +152,7 @@ std::vector<Action> PentagoState::LegalActions() const {
   return moves;
 }
 
-std::string PentagoState::ActionToString(int player, Action action_id) const {
+std::string PentagoState::ActionToString(Player player, Action action_id) const {
   Move m(action_id);
   return absl::StrCat(std::string(1, static_cast<char>('a' + m.x)),
                       std::string(1, static_cast<char>('1' + m.y)),
@@ -210,7 +210,7 @@ std::string PentagoState::ToString() const {
   return out.str();
 }
 
-Player PentagoState::get(int i) const {
+PentagoPlayer PentagoState::get(int i) const {
   return (board_[0] & xy_bit_mask[i]
               ? kPlayer1
               : board_[1] & xy_bit_mask[i] ? kPlayer2 : kPlayerNone);
@@ -223,18 +223,18 @@ std::vector<double> PentagoState::Returns() const {
   return {0, 0};  // Unfinished
 }
 
-std::string PentagoState::InformationState(int player) const {
+std::string PentagoState::InformationState(Player player) const {
   return HistoryString();
 }
 
-std::string PentagoState::Observation(int player) const {
+std::string PentagoState::Observation(Player player) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
   return ToString();
 }
 
 void PentagoState::ObservationAsNormalizedVector(
-    int player, std::vector<double>* values) const {
+    Player player, std::vector<double>* values) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
 

--- a/open_spiel/games/pentago.h
+++ b/open_spiel/games/pentago.h
@@ -40,7 +40,7 @@ constexpr int kPossibleActions = kBoardPositions * kPossibleRotations;
 constexpr int kPossibleWinConditions = 32;
 constexpr int kCellStates = 1 + kNumPlayers;
 
-enum Player {
+enum PentagoPlayer {
   kPlayer1,
   kPlayer2,
   kPlayerNone,
@@ -54,30 +54,30 @@ class PentagoState : public State {
 
   PentagoState(const PentagoState&) = default;
 
-  int CurrentPlayer() const override {
+  Player CurrentPlayer() const override {
     return IsTerminal() ? kTerminalPlayerId : static_cast<int>(current_player_);
   }
-  std::string ActionToString(int player, Action action_id) const override;
+  std::string ActionToString(Player player, Action action_id) const override;
   std::string ToString() const override;
   bool IsTerminal() const override { return outcome_ != kPlayerNone; }
   std::vector<double> Returns() const override;
-  std::string InformationState(int player) const override;
-  std::string Observation(int player) const override;
+  std::string InformationState(Player player) const override;
+  std::string Observation(Player player) const override;
   void ObservationAsNormalizedVector(
-      int player, std::vector<double>* values) const override;
+      Player player, std::vector<double>* values) const override;
   std::unique_ptr<State> Clone() const override;
   std::vector<Action> LegalActions() const override;
 
  protected:
   void DoApplyAction(Action action) override;
 
-  Player get(int x, int y) const { return get(x + y * kBoardSize); }
-  Player get(int i) const;
+  PentagoPlayer get(int x, int y) const { return get(x + y * kBoardSize); }
+  PentagoPlayer get(int i) const;
 
  private:
   std::array<uint64_t, kNumPlayers> board_;
-  Player current_player_ = kPlayer1;
-  Player outcome_ = kPlayerNone;
+  PentagoPlayer current_player_ = kPlayer1;
+  PentagoPlayer outcome_ = kPlayerNone;
   int moves_made_ = 0;
   const bool ansi_color_output_;
 };

--- a/open_spiel/games/phantom_ttt.cc
+++ b/open_spiel/games/phantom_ttt.cc
@@ -72,8 +72,8 @@ PhantomTTTState::PhantomTTTState(int num_distinct_actions,
 
 void PhantomTTTState::DoApplyAction(Action move) {
   // Current player's view.
-  int cur_player = CurrentPlayer();
-  auto& cur_view = cur_player == 0 ? x_view_ : o_view_;
+  Player cur_player = CurrentPlayer();
+  auto& cur_view = cur_player == Player{0} ? x_view_ : o_view_;
 
   // Two cases: either there is a mark already there, or not.
   if (state_.BoardAt(move) == CellState::kEmpty) {
@@ -93,8 +93,8 @@ void PhantomTTTState::DoApplyAction(Action move) {
 
 std::vector<Action> PhantomTTTState::LegalActions() const {
   std::vector<Action> moves;
-  const int player = CurrentPlayer();
-  const auto& cur_view = player == 0 ? x_view_ : o_view_;
+  const Player player = CurrentPlayer();
+  const auto& cur_view = player == Player{0} ? x_view_ : o_view_;
 
   for (Action move = 0; move < kNumCells; ++move) {
     if (cur_view[move] == CellState::kEmpty) {
@@ -105,8 +105,8 @@ std::vector<Action> PhantomTTTState::LegalActions() const {
   return moves;
 }
 
-std::string PhantomTTTState::ViewToString(int player) const {
-  const auto& cur_view = player == 0 ? x_view_ : o_view_;
+std::string PhantomTTTState::ViewToString(Player player) const {
+  const auto& cur_view = player == Player{0} ? x_view_ : o_view_;
   std::string str;
   for (int r = 0; r < kNumRows; ++r) {
     for (int c = 0; c < kNumCols; ++c) {
@@ -119,7 +119,7 @@ std::string PhantomTTTState::ViewToString(int player) const {
   return str;
 }
 
-std::string PhantomTTTState::ActionSequenceToString(int player) const {
+std::string PhantomTTTState::ActionSequenceToString(Player player) const {
   std::string str;
   for (const auto& player_with_action : action_sequence_) {
     if (player_with_action.first == player) {
@@ -141,14 +141,14 @@ std::string PhantomTTTState::ActionSequenceToString(int player) const {
   return str;
 }
 
-std::string PhantomTTTState::InformationState(int player) const {
+std::string PhantomTTTState::InformationState(Player player) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
   return ViewToString(player) + "\n" + ActionSequenceToString(player);
 }
 
 void PhantomTTTState::InformationStateAsNormalizedVector(
-    int player, std::vector<double>* values) const {
+    Player player, std::vector<double>* values) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
 
@@ -156,7 +156,7 @@ void PhantomTTTState::InformationStateAsNormalizedVector(
   // Then the action sequence follows (one-hot encoded, per action).
   // Encoded in the same way as InformationStateAsString, so full sequences
   // which may contain action value 10 to represent "I don't know."
-  const auto& player_view = player == 0 ? x_view_ : o_view_;
+  const auto& player_view = player == Player{0} ? x_view_ : o_view_;
   values->resize(kNumCells * kCellStates +
                  kLongestSequence * (1 + kBitsPerAction));
   std::fill(values->begin(), values->end(), 0.);
@@ -191,7 +191,7 @@ std::unique_ptr<State> PhantomTTTState::Clone() const {
   return std::unique_ptr<State>(new PhantomTTTState(*this));
 }
 
-void PhantomTTTState::UndoAction(int player, Action move) {
+void PhantomTTTState::UndoAction(Player player, Action move) {
   Action last_move = action_sequence_.back().second;
   SPIEL_CHECK_EQ(last_move, move);
 
@@ -204,7 +204,7 @@ void PhantomTTTState::UndoAction(int player, Action move) {
   }
 
   // Undo the action from that player's view, and pop from the action seq
-  auto& player_view = player == 0 ? x_view_ : o_view_;
+  auto& player_view = player == Player{0} ? x_view_ : o_view_;
   player_view[move] = CellState::kEmpty;
   action_sequence_.pop_back();
 

--- a/open_spiel/games/phantom_ttt.h
+++ b/open_spiel/games/phantom_ttt.h
@@ -58,35 +58,35 @@ class PhantomTTTState : public State {
   PhantomTTTState(int num_distinct_actions, ObservationType obs_type);
 
   // Forward to underlying game state
-  int CurrentPlayer() const override { return state_.CurrentPlayer(); }
-  std::string ActionToString(int player, Action action_id) const {
+  Player CurrentPlayer() const override { return state_.CurrentPlayer(); }
+  std::string ActionToString(Player player, Action action_id) const {
     return state_.ActionToString(player, action_id);
   }
   std::string ToString() const override { return state_.ToString(); }
   bool IsTerminal() const override { return state_.IsTerminal(); }
   std::vector<double> Returns() const override { return state_.Returns(); }
-  std::string Observation(int player) const override {
+  std::string Observation(Player player) const override {
     return state_.Observation(player);
   }
   void ObservationAsNormalizedVector(
-      int player, std::vector<double>* values) const override {
+      Player player, std::vector<double>* values) const override {
     state_.ObservationAsNormalizedVector(player, values);
   }
 
   // These are implemented for phantom games
-  std::string InformationState(int player) const override;
+  std::string InformationState(Player player) const override;
   void InformationStateAsNormalizedVector(
-      int player, std::vector<double>* values) const override;
+      Player player, std::vector<double>* values) const override;
   std::unique_ptr<State> Clone() const override;
-  void UndoAction(int player, Action move) override;
+  void UndoAction(Player player, Action move) override;
   std::vector<Action> LegalActions() const override;
 
  protected:
   void DoApplyAction(Action move) override;
 
  private:
-  std::string ViewToString(int player) const;
-  std::string ActionSequenceToString(int player) const;
+  std::string ViewToString(Player player) const;
+  std::string ActionSequenceToString(Player player) const;
 
   tic_tac_toe::TicTacToeState state_;
   ObservationType obs_type_;

--- a/open_spiel/games/pig.cc
+++ b/open_spiel/games/pig.cc
@@ -65,7 +65,7 @@ static std::unique_ptr<Game> Factory(const GameParameters& params) {
 REGISTER_SPIEL_GAME(kGameType, Factory);
 }  // namespace
 
-std::string PigState::ActionToString(int player, Action move_id) const {
+std::string PigState::ActionToString(Player player, Action move_id) const {
   if (player == kChancePlayerId) {
     return absl::StrCat("chance outcome ", move_id);
   } else if (move_id == kRoll) {
@@ -80,7 +80,7 @@ bool PigState::IsTerminal() const {
     return true;
   }
 
-  for (int p = 0; p < num_players_; p++) {
+  for (auto p = Player{0}; p < num_players_; p++) {
     if (scores_[p] >= win_score_) {
       return true;
     }
@@ -96,7 +96,7 @@ std::vector<double> PigState::Returns() const {
   // For (n>2)-player games, must keep it zero-sum.
   std::vector<double> returns(num_players_, -1.0 / (num_players_ - 1));
 
-  for (int player = 0; player < num_players_; ++player) {
+  for (auto player = Player{0}; player < num_players_; ++player) {
     if (scores_[player] >= win_score_) {
       returns[player] = 1.0;
       return returns;
@@ -107,7 +107,7 @@ std::vector<double> PigState::Returns() const {
   return std::vector<double>(0.0, num_players_);
 }
 
-std::string PigState::InformationState(int player) const {
+std::string PigState::InformationState(Player player) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
   return ToString();
@@ -119,7 +119,7 @@ std::vector<int> PigGame::InformationStateNormalizedVectorShape() const {
 }
 
 void PigState::InformationStateAsNormalizedVector(
-    int player, std::vector<double>* values) const {
+    Player player, std::vector<double>* values) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
 
@@ -151,7 +151,7 @@ void PigState::InformationStateAsNormalizedVector(
   pos += num_bins;
 
   // Find the right bin for each player.
-  for (int p = 0; p < num_players_; p++) {
+  for (auto p = Player{0}; p < num_players_; p++) {
     bin = scores_[p] / kBinSize;
     if (bin >= num_bins) {
       // When the value is too large, use last bin.

--- a/open_spiel/games/pig.h
+++ b/open_spiel/games/pig.h
@@ -41,15 +41,15 @@ class PigState : public State {
   PigState(int num_distinct_actions, int num_players, int dice_outcomes,
            int horizon, int win_score);
 
-  int CurrentPlayer() const override;
-  std::string ActionToString(int player, Action move_id) const override;
+  Player CurrentPlayer() const override;
+  std::string ActionToString(Player player, Action move_id) const override;
   std::vector<std::pair<Action, double>> ChanceOutcomes() const override;
   std::string ToString() const override;
   bool IsTerminal() const override;
   std::vector<double> Returns() const override;
-  std::string InformationState(int player) const override;
+  std::string InformationState(Player player) const override;
   void InformationStateAsNormalizedVector(
-      int player, std::vector<double>* values) const override;
+      Player player, std::vector<double>* values) const override;
 
   std::unique_ptr<State> Clone() const override;
 
@@ -67,7 +67,7 @@ class PigState : public State {
   int win_score_ = 0;
 
   int total_moves_ = -1;  // Total num moves taken during the game.
-  int cur_player_ = -1;   // Player to play.
+  Player cur_player_ = -1;   // Player to play.
   int turn_player_ = -1;  // Whose actual turn is it. At chance nodes, we need
                           // to remember whose is playing for next turns (while
                           // cur_player will be the chance player's id.)

--- a/open_spiel/games/pig_test.cc
+++ b/open_spiel/games/pig_test.cc
@@ -25,7 +25,7 @@ void BasicPigTests() {
   testing::LoadGameTest("pig");
   testing::ChanceOutcomesTest(*LoadGame("pig"));
   testing::RandomSimTest(*LoadGame("pig"), 100);
-  for (int players = 3; players <= 5; players++) {
+  for (Player players = 3; players <= 5; players++) {
     testing::RandomSimTest(
         *LoadGame("pig", {{"players", GameParameter(players)}}), 100);
   }

--- a/open_spiel/games/quoridor.cc
+++ b/open_spiel/games/quoridor.cc
@@ -225,7 +225,7 @@ bool QuoridorState::SearchEndZone(Player p, Move wall1, Move wall2) const {
   return false;
 }
 
-std::string QuoridorState::ActionToString(int player, Action action_id) const {
+std::string QuoridorState::ActionToString(Player player, Action action_id) const {
   return ActionToMove(action_id).ToString();
 }
 
@@ -297,18 +297,18 @@ std::vector<double> QuoridorState::Returns() const {
   return {0, 0};  // Unfinished
 }
 
-std::string QuoridorState::InformationState(int player) const {
+std::string QuoridorState::InformationState(Player player) const {
   return HistoryString();
 }
 
-std::string QuoridorState::Observation(int player) const {
+std::string QuoridorState::Observation(Player player) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
   return ToString();
 }
 
 void QuoridorState::ObservationAsNormalizedVector(
-    int player, std::vector<double>* values) const {
+    Player player, std::vector<double>* values) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
 

--- a/open_spiel/games/quoridor.h
+++ b/open_spiel/games/quoridor.h
@@ -38,7 +38,7 @@ constexpr int kMaxBoardSize = 25;
 constexpr int kMaxGameLengthFactor = 4;
 constexpr int kCellStates = 1 + kNumPlayers;
 
-enum Player : uint8_t {
+enum QuoridorPlayer : uint8_t {
   kPlayer1,
   kPlayer2,
   kPlayerWall,
@@ -91,17 +91,17 @@ class QuoridorState : public State {
 
   QuoridorState(const QuoridorState&) = default;
 
-  int CurrentPlayer() const override {
+  Player CurrentPlayer() const override {
     return IsTerminal() ? kTerminalPlayerId : static_cast<int>(current_player_);
   }
-  std::string ActionToString(int player, Action action_id) const override;
+  std::string ActionToString(Player player, Action action_id) const override;
   std::string ToString() const override;
   bool IsTerminal() const override { return outcome_ != kPlayerNone; }
   std::vector<double> Returns() const override;
-  std::string InformationState(int player) const override;
-  std::string Observation(int player) const override;
+  std::string InformationState(Player player) const override;
+  std::string Observation(Player player) const override;
   void ObservationAsNormalizedVector(
-      int player, std::vector<double>* values) const override;
+      Player player, std::vector<double>* values) const override;
   std::unique_ptr<State> Clone() const override;
   std::vector<Action> LegalActions() const override;
 
@@ -119,22 +119,22 @@ class QuoridorState : public State {
   bool IsWall(Move m) const {
     return m.IsValid() ? board_[m.xy] == kPlayerWall : true;
   }
-  Player GetPlayer(Move m) const {
+  QuoridorPlayer GetPlayer(Move m) const {
     return m.IsValid() ? board_[m.xy] : kPlayerWall;
   }
-  void SetPlayer(Move m, Player p, Player old) {
+  void SetPlayer(Move m, QuoridorPlayer p, Player old) {
     SPIEL_CHECK_TRUE(m.IsValid());
     SPIEL_CHECK_EQ(board_[m.xy], old);
     board_[m.xy] = p;
   }
 
  private:
-  std::vector<Player> board_;
+  std::vector<QuoridorPlayer> board_;
   int wall_count_[kNumPlayers];
   int end_zone_[kNumPlayers];
   Move player_loc_[kNumPlayers];
-  Player current_player_ = kPlayer1;
-  Player outcome_ = kPlayerNone;
+  QuoridorPlayer current_player_ = kPlayer1;
+  QuoridorPlayer outcome_ = kPlayerNone;
   int moves_made_ = 0;
   const int board_size_;
   const int board_diameter_;

--- a/open_spiel/games/tic_tac_toe.cc
+++ b/open_spiel/games/tic_tac_toe.cc
@@ -51,7 +51,7 @@ REGISTER_SPIEL_GAME(kGameType, Factory);
 
 }  // namespace
 
-CellState PlayerToState(int player) {
+CellState PlayerToState(Player player) {
   switch (player) {
     case 0:
       return CellState::kCross;
@@ -94,12 +94,12 @@ std::vector<Action> TicTacToeState::LegalActions() const {
   return moves;
 }
 
-std::string TicTacToeState::ActionToString(int player, Action action_id) const {
+std::string TicTacToeState::ActionToString(Player player, Action action_id) const {
   return absl::StrCat(StateToString(PlayerToState(player)), "(",
                       action_id % kNumCols, ",", action_id / kNumCols, ")");
 }
 
-bool TicTacToeState::HasLine(int player) const {
+bool TicTacToeState::HasLine(Player player) const {
   CellState c = PlayerToState(player);
   return (board_[0] == c && board_[1] == c && board_[2] == c) ||
          (board_[3] == c && board_[4] == c && board_[5] == c) ||
@@ -150,18 +150,18 @@ std::vector<double> TicTacToeState::Returns() const {
   }
 }
 
-std::string TicTacToeState::InformationState(int player) const {
+std::string TicTacToeState::InformationState(Player player) const {
   return HistoryString();
 }
 
-std::string TicTacToeState::Observation(int player) const {
+std::string TicTacToeState::Observation(Player player) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
   return ToString();
 }
 
 void TicTacToeState::ObservationAsNormalizedVector(
-    int player, std::vector<double>* values) const {
+    Player player, std::vector<double>* values) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
 
@@ -172,7 +172,7 @@ void TicTacToeState::ObservationAsNormalizedVector(
   }
 }
 
-void TicTacToeState::UndoAction(int player, Action move) {
+void TicTacToeState::UndoAction(Player player, Action move) {
   board_[move] = CellState::kEmpty;
   current_player_ = player;
   history_.pop_back();

--- a/open_spiel/games/tic_tac_toe.h
+++ b/open_spiel/games/tic_tac_toe.h
@@ -55,19 +55,19 @@ class TicTacToeState : public State {
   TicTacToeState(const TicTacToeState&) = default;
   TicTacToeState& operator=(const TicTacToeState&) = default;
 
-  int CurrentPlayer() const override {
+  Player CurrentPlayer() const override {
     return IsTerminal() ? kTerminalPlayerId : current_player_;
   }
-  std::string ActionToString(int player, Action action_id) const override;
+  std::string ActionToString(Player player, Action action_id) const override;
   std::string ToString() const override;
   bool IsTerminal() const override;
   std::vector<double> Returns() const override;
-  std::string InformationState(int player) const override;
-  std::string Observation(int player) const override;
+  std::string InformationState(Player player) const override;
+  std::string Observation(Player player) const override;
   void ObservationAsNormalizedVector(
-      int player, std::vector<double>* values) const override;
+      Player player, std::vector<double>* values) const override;
   std::unique_ptr<State> Clone() const override;
-  void UndoAction(int player, Action move) override;
+  void UndoAction(Player player, Action move) override;
   std::vector<Action> LegalActions() const override;
   CellState BoardAt(int cell) const { return board_[cell]; }
   CellState BoardAt(int row, int column) const {
@@ -79,9 +79,9 @@ class TicTacToeState : public State {
   void DoApplyAction(Action move) override;
 
  private:
-  bool HasLine(int player) const;  // Does this player have a line?
+  bool HasLine(Player player) const;  // Does this player have a line?
   bool IsFull() const;             // Is the board full?
-  int current_player_ = 0;         // Player zero goes first
+  Player current_player_ = 0;         // Player zero goes first
 };
 
 // Game object.
@@ -105,7 +105,7 @@ class TicTacToeGame : public Game {
   int MaxGameLength() const { return kNumCells; }
 };
 
-CellState PlayerToState(int player);
+CellState PlayerToState(Player player);
 std::string StateToString(CellState state);
 
 inline std::ostream& operator<<(std::ostream& stream, const CellState& state) {

--- a/open_spiel/games/tiny_bridge.cc
+++ b/open_spiel/games/tiny_bridge.cc
@@ -201,14 +201,14 @@ std::unique_ptr<State> TinyBridgePlayGame::NewInitialState() const {
       NumDistinctActions(), NumPlayers(), trumps, leader, holder));
 }
 
-std::string TinyBridgeAuctionState::HandString(int player) const {
+std::string TinyBridgeAuctionState::HandString(Player player) const {
   if (player >= actions_.size()) return "??";
   return ActionToString(kChancePlayerId, actions_[player]);
 }
 
 std::string TinyBridgeAuctionState::DealString() const {
   std::string deal;
-  for (int player = 0; player < num_players_; ++player) {
+  for (auto player = Player{0}; player < num_players_; ++player) {
     int hand = (num_players_ == 2) ? (2 * player) : player;
     if (player != 0) deal.push_back(' ');
     deal.append(
@@ -359,7 +359,7 @@ std::vector<std::pair<Action, double>> TinyBridgeAuctionState::ChanceOutcomes()
   return outcomes;
 }
 
-std::string TinyBridgeAuctionState::ActionToString(int player,
+std::string TinyBridgeAuctionState::ActionToString(Player player,
                                                    Action action_id) const {
   if (player == kChancePlayerId) {
     const int card1 = action_id % kNumCards;
@@ -409,7 +409,7 @@ std::vector<double> TinyBridgeAuctionState::Returns() const {
   }
 }
 
-std::string TinyBridgeAuctionState::InformationState(int player) const {
+std::string TinyBridgeAuctionState::InformationState(Player player) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
 
@@ -425,7 +425,7 @@ std::unique_ptr<State> TinyBridgeAuctionState::Clone() const {
   return std::unique_ptr<State>{new TinyBridgeAuctionState(*this)};
 }
 
-void TinyBridgeAuctionState::UndoAction(int player, Action action) {
+void TinyBridgeAuctionState::UndoAction(Player player, Action action) {
   actions_.pop_back();
   is_terminal_ = false;
 }
@@ -476,7 +476,7 @@ int TinyBridgePlayState::CurrentHand() const {
   return ((actions_.size() < 4 ? leader_ : winner_[0]) + actions_.size()) % 4;
 }
 
-std::string TinyBridgePlayState::ActionToString(int player,
+std::string TinyBridgePlayState::ActionToString(Player player,
                                                 Action action_id) const {
   return CardString(action_id);
 }
@@ -501,7 +501,7 @@ std::unique_ptr<State> TinyBridgePlayState::Clone() const {
   return std::unique_ptr<State>{new TinyBridgePlayState(*this)};
 }
 
-void TinyBridgePlayState::UndoAction(int player, Action action) {
+void TinyBridgePlayState::UndoAction(Player player, Action action) {
   actions_.pop_back();
   history_.pop_back();
 }

--- a/open_spiel/games/tiny_bridge.h
+++ b/open_spiel/games/tiny_bridge.h
@@ -128,18 +128,18 @@ class TinyBridgeAuctionState : public State {
       : State(num_distinct_actions, num_players) {}
   TinyBridgeAuctionState(const TinyBridgeAuctionState&) = default;
 
-  int CurrentPlayer() const override;
+  Player CurrentPlayer() const override;
   std::vector<Action> LegalActions() const override;
-  std::string ActionToString(int player, Action action_id) const override;
+  std::string ActionToString(Player player, Action action_id) const override;
   std::string ToString() const override;
   bool IsTerminal() const override;
   std::vector<double> Returns() const override;
-  std::string InformationState(int player) const override;
+  std::string InformationState(Player player) const override;
   std::unique_ptr<State> Clone() const override;
-  void UndoAction(int player, Action action) override;
+  void UndoAction(Player player, Action action) override;
   std::vector<std::pair<Action, double>> ChanceOutcomes() const override;
   std::string AuctionString() const;
-  std::string HandString(int player) const;
+  std::string HandString(Player player) const;
   std::string DealString() const;
 
  protected:
@@ -173,14 +173,14 @@ class TinyBridgePlayState : public State {
         holder_(holder) {}
   TinyBridgePlayState(const TinyBridgePlayState&) = default;
 
-  int CurrentPlayer() const { return CurrentHand() % 2; }
+  Player CurrentPlayer() const { return CurrentHand() % 2; }
   int CurrentHand() const;
 
-  std::string ActionToString(int player, Action action_id) const override;
+  std::string ActionToString(Player player, Action action_id) const override;
   bool IsTerminal() const override;
   std::vector<double> Returns() const override;
   std::unique_ptr<State> Clone() const override;
-  void UndoAction(int player, Action action) override;
+  void UndoAction(Player player, Action action) override;
   std::string ToString() const override;
   std::vector<Action> LegalActions() const override;
 

--- a/open_spiel/games/y.cc
+++ b/open_spiel/games/y.cc
@@ -142,7 +142,7 @@ std::vector<Action> YState::LegalActions() const {
   return moves;
 }
 
-std::string YState::ActionToString(int player, Action action_id) const {
+std::string YState::ActionToString(Player player, Action action_id) const {
   return ActionToMove(action_id).ToString();
 }
 
@@ -224,17 +224,17 @@ std::vector<double> YState::Returns() const {
   return {0, 0};  // Unfinished
 }
 
-std::string YState::InformationState(int player) const {
+std::string YState::InformationState(Player player) const {
   return HistoryString();
 }
 
-std::string YState::Observation(int player) const {
+std::string YState::Observation(Player player) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
   return ToString();
 }
 
-void YState::ObservationAsNormalizedVector(int player,
+void YState::ObservationAsNormalizedVector(Player player,
                                            std::vector<double>* values) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);

--- a/open_spiel/games/y.h
+++ b/open_spiel/games/y.h
@@ -38,7 +38,7 @@ constexpr int kDefaultBoardSize = 19;
 constexpr int kMaxNeighbors = 6;  // Maximum number of neighbors for a cell
 constexpr int kCellStates = 1 + kNumPlayers;
 
-enum Player : uint8_t {
+enum YPlayer : uint8_t {
   kPlayer1,
   kPlayer2,
   kPlayerNone,
@@ -97,7 +97,7 @@ class YState : public State {
   // cell that is not a group leader.
   struct Cell {
     // Who controls this cell.
-    Player player;
+    YPlayer player;
 
     // A parent index to allow finding the group leader. It is the leader of the
     // group if it points to itself. Allows path compression to shorten the path
@@ -109,7 +109,7 @@ class YState : public State {
     uint8_t edge;   // A bitset of which edges this group is connected to.
 
     Cell() {}
-    Cell(Player player_, int parent_, int edge_)
+    Cell(YPlayer player_, int parent_, int edge_)
         : player(player_), parent(parent_), size(1), edge(edge_) {}
   };
 
@@ -118,17 +118,17 @@ class YState : public State {
 
   YState(const YState&) = default;
 
-  int CurrentPlayer() const override {
+  Player CurrentPlayer() const override {
     return IsTerminal() ? kTerminalPlayerId : static_cast<int>(current_player_);
   }
-  std::string ActionToString(int player, Action action_id) const override;
+  std::string ActionToString(Player player, Action action_id) const override;
   std::string ToString() const override;
   bool IsTerminal() const override { return outcome_ != kPlayerNone; }
   std::vector<double> Returns() const override;
-  std::string InformationState(int player) const override;
-  std::string Observation(int player) const override;
+  std::string InformationState(Player player) const override;
+  std::string Observation(Player player) const override;
   void ObservationAsNormalizedVector(
-      int player, std::vector<double>* values) const override;
+      Player player, std::vector<double>* values) const override;
   std::unique_ptr<State> Clone() const override;
   std::vector<Action> LegalActions() const override;
 
@@ -147,8 +147,8 @@ class YState : public State {
 
  private:
   std::vector<Cell> board_;
-  Player current_player_ = kPlayer1;
-  Player outcome_ = kPlayerNone;
+  YPlayer current_player_ = kPlayer1;
+  YPlayer outcome_ = kPlayerNone;
   const int board_size_;
   int moves_made_ = 0;
   Move last_move_ = kMoveNone;

--- a/open_spiel/matrix_game.h
+++ b/open_spiel/matrix_game.h
@@ -93,9 +93,9 @@ class MatrixGame : public NormalFormGame {
   double ColUtility(int row, int col) const {
     return col_utilities_[Index(row, col)];
   }
-  double PlayerUtility(int player, int row, int col) {
-    SPIEL_CHECK_TRUE(player == 0 || player == 1);
-    return (player == 0 ? row_utilities_[Index(row, col)]
+  double PlayerUtility(Player player, int row, int col) {
+    SPIEL_CHECK_TRUE(player == Player{0} || player == Player{1});
+    return (player == Player{0} ? row_utilities_[Index(row, col)]
                         : col_utilities_[Index(row, col)]);
   }
   const std::string& RowActionName(int row) const {
@@ -118,7 +118,7 @@ class MatrixState : public NFGState {
   explicit MatrixState(const MatrixGame& game);
   MatrixState(const MatrixState&) = default;
 
-  virtual std::vector<Action> LegalActions(int player) const {
+  virtual std::vector<Action> LegalActions(Player player) const {
     if (player == kSimultaneousPlayerId) {
       return LegalFlatJointActions();
     } else {
@@ -131,7 +131,7 @@ class MatrixState : public NFGState {
 
   std::string ToString() const override;
 
-  virtual std::string ActionToString(int player, Action action_id) const {
+  virtual std::string ActionToString(Player player, Action action_id) const {
     if (player == kSimultaneousPlayerId)
       return FlatJointActionToString(action_id);
     else if (player == kRowPlayer)

--- a/open_spiel/normal_form_game.h
+++ b/open_spiel/normal_form_game.h
@@ -33,12 +33,12 @@ class NFGState : public SimMoveState {
       : SimMoveState(num_distinct_actions, num_players) {}
 
   // There are no chance nodes in a normal-form game (there is only one state),
-  int CurrentPlayer() const final {
+  Player CurrentPlayer() const final {
     return IsTerminal() ? kTerminalPlayerId : kSimultaneousPlayerId;
   }
 
   // Since there's only one state, we can implement the representations here.
-  std::string InformationState(int player) const override {
+  std::string InformationState(Player player) const override {
     std::string info_state = absl::StrCat("Observing player: ", player, ". ");
     if (!IsTerminal()) {
       absl::StrAppend(&info_state, "Non-terminal");
@@ -60,7 +60,7 @@ class NFGState : public SimMoveState {
     return result;
   }
 
-  void InformationStateAsNormalizedVector(int player,
+  void InformationStateAsNormalizedVector(Player player,
                                           std::vector<double>* values) const {
     values->resize(1);
     if (IsTerminal()) {

--- a/open_spiel/simultaneous_move_game.cc
+++ b/open_spiel/simultaneous_move_game.cc
@@ -19,7 +19,7 @@ namespace open_spiel {
 std::vector<Action> SimMoveState::FlatJointActionToActions(
     Action flat_action) const {
   std::vector<Action> actions(num_players_, kInvalidAction);
-  for (int player = 0; player < num_players_; ++player) {
+  for (auto player = Player{0}; player < num_players_; ++player) {
     // For each player with legal actions available:
     const auto legal_actions = LegalActions(player);
     int num_actions = legal_actions.size();
@@ -43,7 +43,7 @@ std::vector<Action> SimMoveState::LegalFlatJointActions() const {
   // Compute the number of possible joint actions = \prod #actions(i)
   // over all players with any legal actions available.
   int number_joint_actions = 1;
-  for (int player = 0; player < num_players_; ++player) {
+  for (auto player = Player{0}; player < num_players_; ++player) {
     int num_actions = LegalActions(player).size();
     if (num_actions > 1) number_joint_actions *= num_actions;
   }
@@ -59,7 +59,7 @@ std::string SimMoveState::FlatJointActionToString(Action flat_action) const {
   // string. For example, [Heads, Tails] would mean than player 0 chooses Heads,
   // and player 1 chooses Tails.
   std::string str;
-  for (int player = 0; player < num_players_; ++player) {
+  for (auto player = Player{0}; player < num_players_; ++player) {
     if (!str.empty()) str.append(", ");
     const auto legal_actions = LegalActions(player);
     int num_actions = legal_actions.size();

--- a/open_spiel/simultaneous_move_game.h
+++ b/open_spiel/simultaneous_move_game.h
@@ -34,7 +34,7 @@ class SimMoveState : public State {
   SimMoveState(const SimMoveState&) = default;
 
   // Subclasses must implement a per-player LegalActions function.
-  virtual std::vector<Action> LegalActions(int player) const = 0;
+  virtual std::vector<Action> LegalActions(Player player) const = 0;
 
   // LegalActions() returns either the chance outcomes (at a chance node),
   // or a flattened form of the joint legal actions (at simultaneous move

--- a/open_spiel/spiel.h
+++ b/open_spiel/spiel.h
@@ -164,7 +164,7 @@ class State {
   // Returns current player. Player numbers start from 0.
   // Negative numbers are for chance (-1) or simultaneous (-2).
   // kTerminalState should be returned on a TerminalNode().
-  virtual int CurrentPlayer() const = 0;
+  virtual Player CurrentPlayer() const = 0;
 
   // Change the state of the game by applying the specified action in turn-based
   // games. This function encodes the logic of the game rules. Returns true
@@ -184,7 +184,7 @@ class State {
     history_.push_back(action_id);
   }
 
-  // `LegalActions(int player)` is valid for all nodes in all games, returning
+  // `LegalActions(Player player)` is valid for all nodes in all games, returning
   // an empty list for players who don't act at this state.
   //
   // This default implementation is fine for turn-based games, but should
@@ -192,7 +192,7 @@ class State {
   //
   // Since games mostly override LegalActions(), this method will not be visible
   // in derived classes unless a using directive is added.
-  virtual std::vector<Action> LegalActions(int player) const {
+  virtual std::vector<Action> LegalActions(Player player) const {
     if (!IsTerminal() && player == CurrentPlayer()) {
       return IsChanceNode() ? LegalChanceOutcomes() : LegalActions();
     } else {
@@ -207,14 +207,14 @@ class State {
   //
   // In simultaneous-move games, the abstract base class implements it in
   // terms of LegalActions(player) and LegalChanceOutcomes(), and so derived
-  // classes only need to implement `LegalActions(int player)`.
+  // classes only need to implement `LegalActions(Player player)`.
   // This will result in LegalActions() being hidden unless a using directive
   // is added.
   virtual std::vector<Action> LegalActions() const = 0;
 
   // Returns a vector of length `game.NumDistinctActions()` containing 1 for
   // legal actions and 0 for illegal actions.
-  std::vector<int> LegalActionsMask(int player) const {
+  std::vector<int> LegalActionsMask(Player player) const {
     std::vector<int> mask(num_distinct_actions_, 0);
     std::vector<Action> legal_actions = LegalActions(player);
 
@@ -234,7 +234,7 @@ class State {
   // for chess the string "Nf3" would correspond to different starting squares
   // in different states (and hence probably different action ids).
   // This method will format chance outcomes if player == kChancePlayer
-  virtual std::string ActionToString(int player, Action action_id) const = 0;
+  virtual std::string ActionToString(Player player, Action action_id) const = 0;
 
   // Returns a string representation of the state. This has no particular
   // semantics and is targeting debugging code.
@@ -271,7 +271,7 @@ class State {
 
   // Returns Reward for one player (see above for definition). If Rewards for
   // multiple players are required it is more efficient to use Rewards() above.
-  virtual double PlayerReward(int player) const {
+  virtual double PlayerReward(Player player) const {
     auto rewards = Rewards();
     SPIEL_CHECK_LT(player, rewards.size());
     return rewards[player];
@@ -279,7 +279,7 @@ class State {
 
   // Returns Return for one player (see above for definition). If Returns for
   // multiple players are required it is more efficient to use Returns() above.
-  virtual double PlayerReturn(int player) const {
+  virtual double PlayerReturn(Player player) const {
     auto returns = Returns();
     SPIEL_CHECK_LT(player, returns.size());
     return returns[player];
@@ -331,7 +331,7 @@ class State {
 
   // There are currently no use-case for calling this function with
   // 'kChancePlayerId'. Thus, games are expected to raise an error in that case.
-  virtual std::string InformationState(int player) const {
+  virtual std::string InformationState(Player player) const {
     SpielFatalError("InformationState is not implemented.");
   }
 
@@ -350,12 +350,12 @@ class State {
   // There are currently no use-case for calling this function with
   // 'kChancePlayerId'. Thus, games are expected to raise an error in that case.
   virtual void InformationStateAsNormalizedVector(
-      int player, std::vector<double>* values) const {
+      Player player, std::vector<double>* values) const {
     SpielFatalError("InformationStateAsNormalizedVector unimplemented!");
   }
 
   virtual std::vector<double> InformationStateAsNormalizedVector(
-      int player) const {
+      Player player) const {
     std::vector<double> normalized_info_state;
     InformationStateAsNormalizedVector(player, &normalized_info_state);
     return normalized_info_state;
@@ -379,7 +379,7 @@ class State {
   // Note that neither of these are valid information states, since the same
   // observation may arise from two different observation histories (i.e. they
   // are not perfect recall).
-  virtual std::string Observation(int player) const {
+  virtual std::string Observation(Player player) const {
     SpielFatalError("Observation is not implemented.");
   }
 
@@ -388,11 +388,11 @@ class State {
   }
 
   virtual void ObservationAsNormalizedVector(
-      int player, std::vector<double>* values) const {
+      Player player, std::vector<double>* values) const {
     SpielFatalError("ObservationAsNormalizedVector unimplemented!");
   }
 
-  virtual std::vector<double> ObservationAsNormalizedVector(int player) const {
+  virtual std::vector<double> ObservationAsNormalizedVector(Player player) const {
     std::vector<double> normalized_observation;
     ObservationAsNormalizedVector(player, &normalized_observation);
     return normalized_observation;
@@ -418,7 +418,7 @@ class State {
   // undo an action. It is only necessary for algorithms that need a fast undo
   // (e.g. minimax search).
   // One must call history_.pop_back() in the implementations.
-  virtual void UndoAction(int player, Action action) {
+  virtual void UndoAction(Player player, Action action) {
     SpielFatalError("UndoAction function is not overridden; not undoing.");
   }
 
@@ -527,7 +527,7 @@ class Game {
   virtual int NumPlayers() const = 0;
 
   // Utility range. These functions define the lower and upper bounds on the
-  // values returned by State::PlayerReturn(int player) over all valid player
+  // values returned by State::PlayerReturn(Player player) over all valid player
   // numbers. This range should be as tight as possible; the intention is to
   // give some information to algorithms that require it, and so their
   // performance may suffer if the range is not tight. Loss/win/draw outcomes

--- a/open_spiel/spiel_bots.cc
+++ b/open_spiel/spiel_bots.cc
@@ -23,7 +23,7 @@ namespace {
 
 class UniformRandomBot : public Bot {
  public:
-  UniformRandomBot(const Game& game, int player_id, int seed)
+  UniformRandomBot(const Game& game, Player player_id, int seed)
       : Bot(game, player_id), rng_(seed) {}
 
   std::pair<ActionsAndProbs, Action> Step(const State& state) override {
@@ -44,7 +44,7 @@ class UniformRandomBot : public Bot {
 }  // namespace
 
 // A uniform random bot, for test purposes.
-std::unique_ptr<Bot> MakeUniformRandomBot(const Game& game, int player_id,
+std::unique_ptr<Bot> MakeUniformRandomBot(const Game& game, Player player_id,
                                           int seed) {
   return std::unique_ptr<Bot>(new UniformRandomBot(game, player_id, seed));
 }
@@ -53,7 +53,7 @@ namespace {
 
 class FixedActionPreferenceBot : public Bot {
  public:
-  FixedActionPreferenceBot(const Game& game, int player_id,
+  FixedActionPreferenceBot(const Game& game, Player player_id,
                            const std::vector<Action>& actions)
       : Bot(game, player_id), actions_(actions) {}
 
@@ -77,7 +77,7 @@ class FixedActionPreferenceBot : public Bot {
 // A bot with a fixed action preference, for test purposes.
 // Picks the first legal action found in the list of actions.
 std::unique_ptr<Bot> MakeFixedActionPreferenceBot(
-    const Game& game, int player_id, const std::vector<Action>& actions) {
+    const Game& game, Player player_id, const std::vector<Action>& actions) {
   return std::unique_ptr<Bot>(
       new FixedActionPreferenceBot(game, player_id, actions));
 }

--- a/open_spiel/spiel_bots.h
+++ b/open_spiel/spiel_bots.h
@@ -25,7 +25,7 @@ namespace open_spiel {
 
 class Bot {
  public:
-  Bot(const Game& game, int player_id) : game_(game), player_id_(player_id) {}
+  Bot(const Game& game, Player player_id) : game_(game), player_id_(player_id) {}
   virtual ~Bot() = default;
 
   // Override the bot's action choice.
@@ -36,7 +36,7 @@ class Bot {
   virtual std::pair<ActionsAndProbs, Action> Step(const State& state) = 0;
 
   // Which player this bot acts as.
-  int PlayerId() const { return player_id_; }
+  Player PlayerId() const { return player_id_; }
 
   // Restart at a given state of the game.
   // In general, bots can rely on states being presented sequentially as the
@@ -47,17 +47,17 @@ class Bot {
 
  protected:
   const Game& game_;
-  int player_id_;
+  Player player_id_;
 };
 
 // A uniform random bot, for test purposes.
-std::unique_ptr<Bot> MakeUniformRandomBot(const Game& game, int player_id,
+std::unique_ptr<Bot> MakeUniformRandomBot(const Game& game, Player player_id,
                                           int seed);
 
 // A both with a fixed action preference, for test purposes.
 // Picks the first legal action found in the list of actions.
 std::unique_ptr<Bot> MakeFixedActionPreferenceBot(
-    const Game& game, int player_id, const std::vector<Action>& actions);
+    const Game& game, Player player_id, const std::vector<Action>& actions);
 
 }  // namespace open_spiel
 

--- a/open_spiel/spiel_utils.cc
+++ b/open_spiel/spiel_utils.cc
@@ -19,7 +19,7 @@
 
 namespace open_spiel {
 
-int NextPlayerRoundRobin(int player, int nplayers) {
+int NextPlayerRoundRobin(Player player, int nplayers) {
   if (player + 1 < nplayers) {
     return player + 1;
   } else {
@@ -28,7 +28,7 @@ int NextPlayerRoundRobin(int player, int nplayers) {
 }
 
 // Helper function to determine the previous player in a round robin.
-int PreviousPlayerRoundRobin(int player, int nplayers) {
+int PreviousPlayerRoundRobin(Player player, int nplayers) {
   if (player - 1 >= 0) {
     return player - 1;
   } else {

--- a/open_spiel/spiel_utils.h
+++ b/open_spiel/spiel_utils.h
@@ -81,6 +81,8 @@ std::string SpielStrCat(Args&&... args) {
 
 }  // namespace internal
 
+using Player = int;
+
 using Action = int64_t;
 
 // Floating point comparisons use this as a multiplier on the larger of the two
@@ -113,10 +115,10 @@ void UnrankActionMixedBase(Action action, const std::vector<int>& bases,
                            std::vector<int>* digits);
 
 // Helper function to determine the next player in a round robin.
-int NextPlayerRoundRobin(int player, int nplayers);
+int NextPlayerRoundRobin(Player player, int nplayers);
 
 // Helper function to determine the previous player in a round robin.
-int PreviousPlayerRoundRobin(int player, int nplayers);
+int PreviousPlayerRoundRobin(Player player, int nplayers);
 
 // Returns whether the absolute difference between floating point values a and
 // b is less than or equal to FloatingPointThresholdRatio() * max(|a|, |b|).

--- a/open_spiel/tests/basic_tests.cc
+++ b/open_spiel/tests/basic_tests.cc
@@ -41,9 +41,9 @@ constexpr int kInvalidHistoryAction = -301;
 // (state_1, state_1.CurrentPlayer(), action2), ...
 struct HistoryItem {
   std::unique_ptr<State> state;
-  int player;
+  Player player;
   Action action;
-  HistoryItem(std::unique_ptr<State> _state, int _player, int _action)
+  HistoryItem(std::unique_ptr<State> _state, Player _player, int _action)
       : state(std::move(_state)), player(_player), action(_action) {}
 };
 
@@ -80,8 +80,8 @@ void LegalActionsIsEmptyForOtherPlayers(const Game& game, State& state) {
     return;
   }
 
-  int current_player = state.CurrentPlayer();
-  for (int player = 0; player < game.NumPlayers(); ++player) {
+  Player current_player = state.CurrentPlayer();
+  for (Player player = 0; player < game.NumPlayers(); ++player) {
     if (state.IsChanceNode()) {
       continue;
     }
@@ -236,7 +236,7 @@ void RandomSimulation(std::mt19937* rng, const Game& game, bool undo) {
     } else if (state->CurrentPlayer() == open_spiel::kSimultaneousPlayerId) {
       std::vector<double> rewards = state->Rewards();
       std::cout << "Rewards: " << absl::StrJoin(rewards, " ") << std::endl;
-      for (int p = 0; p < game.NumPlayers(); ++p) {
+      for (auto p = Player{0}; p < game.NumPlayers(); ++p) {
         episode_returns[p] += rewards[p];
       }
 
@@ -244,7 +244,7 @@ void RandomSimulation(std::mt19937* rng, const Game& game, bool undo) {
       std::vector<Action> joint_action;
 
       // Sample a action for each player
-      for (int p = 0; p < game.NumPlayers(); p++) {
+      for (auto p = Player{0}; p < game.NumPlayers(); p++) {
         std::vector<Action> actions;
         actions = state->LegalActions(p);
         std::uniform_int_distribution<> dis(0, actions.size() - 1);
@@ -271,12 +271,12 @@ void RandomSimulation(std::mt19937* rng, const Game& game, bool undo) {
     } else {
       std::vector<double> rewards = state->Rewards();
       std::cout << "Rewards: " << absl::StrJoin(rewards, " ") << std::endl;
-      for (int p = 0; p < game.NumPlayers(); ++p) {
+      for (auto p = Player{0}; p < game.NumPlayers(); ++p) {
         episode_returns[p] += rewards[p];
       }
 
       // Decision node.
-      int player = state->CurrentPlayer();
+      Player player = state->CurrentPlayer();
 
       // First, check the information state vector, if supported.
       if (infostate_vector_size > 0) {
@@ -323,7 +323,7 @@ void RandomSimulation(std::mt19937* rng, const Game& game, bool undo) {
 
   // Check the information state of the terminal, too. This is commonly needed,
   // for example, as a final observation in an RL environment.
-  for (int p = 0; p < game.NumPlayers(); p++) {
+  for (auto p = Player{0}; p < game.NumPlayers(); p++) {
     if (infostate_vector_size > 0) {
       std::vector<double> infostate_vector;
       state->InformationStateAsNormalizedVector(p, &infostate_vector);
@@ -332,7 +332,7 @@ void RandomSimulation(std::mt19937* rng, const Game& game, bool undo) {
   }
 
   auto returns = state->Returns();
-  for (int player = 0; player < game.NumPlayers(); player++) {
+  for (Player player = 0; player < game.NumPlayers(); player++) {
     double final_return = returns[player];
     SPIEL_CHECK_FLOAT_EQ(final_return, state->PlayerReturn(player));
     SPIEL_CHECK_GE(final_return, game.MinUtility());

--- a/open_spiel/tests/spiel_test.cc
+++ b/open_spiel/tests/spiel_test.cc
@@ -42,7 +42,7 @@ void KuhnTests() {
   RandomSimTest(*LoadGame("kuhn_poker"), /*num_sims=*/100);
 
   // More than two players.
-  for (int players = 3; players <= 5; players++) {
+  for (Player players = 3; players <= 5; players++) {
     RandomSimTest(
         *LoadGame("kuhn_poker", {{"players", GameParameter(players)}}),
         /*num_sims=*/100);
@@ -62,7 +62,7 @@ class FlatJointActionTestState : public SimMoveState {
       : SimMoveState(/*num_distinct_actions=*/8,
                      /*num_players=*/3) {}
   const std::vector<Action>& JointAction() const { return joint_action_; }
-  std::vector<Action> LegalActions(int player) const override {
+  std::vector<Action> LegalActions(Player player) const override {
     if (player == kSimultaneousPlayerId) return LegalFlatJointActions();
     switch (player) {
       case 0:
@@ -74,8 +74,8 @@ class FlatJointActionTestState : public SimMoveState {
     }
     SpielFatalError("Invalid player id");
   }
-  int CurrentPlayer() const override { return kSimultaneousPlayerId; }
-  std::string ActionToString(int player, Action action_id) const override {
+  Player CurrentPlayer() const override { return kSimultaneousPlayerId; }
+  std::string ActionToString(Player player, Action action_id) const override {
     if (player == kSimultaneousPlayerId)
       return FlatJointActionToString(action_id);
     return absl::StrCat("(p=", player, ",a=", action_id, ")");


### PR DESCRIPTION
Refactor based on #46 

Touches a lot of code. :-)

I found it useful to use a struct for finding out the cases:
```
struct Player {
    int id;

    inline bool operator==(const Player &rhs) const { return id == rhs; }
    inline bool operator==(const int &rhs) const { return id == rhs; }
    inline bool operator!=(const Player &rhs) const { return !(rhs == *this); }
    inline bool operator<(const Player &rhs) const { return id < rhs; }
    inline bool operator<=(const Player &rhs) const { return id <= rhs; }
    inline bool operator>=(const Player &rhs) const { return id >= rhs; }
    inline bool operator<(const int &rhs) const { return id < rhs; }
    inline bool operator<=(const int &rhs) const { return id <= rhs; }
    inline bool operator>=(const int &rhs) const { return id >= rhs; }
    inline bool operator+(const Player &rhs) const { return id + rhs; }
    inline bool operator-(const Player &rhs) const { return id - rhs; }
    inline void operator++(int) { id++; }
    inline void operator++() { id++; }
    friend std::ostream &operator<<(std::ostream &os, const Player &player) {
        os << player;
        return os;
    }
};
```
since the compiler interchanges `Player` and `int` freely ... (unlike for example in Haskell)