### PR TITLE
Swift TicTacToe maximum number of players is 2

### DIFF
--- a/swift/Sources/OpenSpiel/TicTacToe.swift
+++ b/swift/Sources/OpenSpiel/TicTacToe.swift
@@ -28,7 +28,7 @@ public class TicTacToe: GameProtocol {
     information: .perfect,
     utility: .zeroSum,
     rewardModel: .terminal,
-    maxPlayers: 10,
+    maxPlayers: 2,
     minPlayers: 2,
     providesInformationState: true,
     providesInformationStateAsNormalizedVector: true


### PR DESCRIPTION
This matches the Swift implementation limits, and also matches the C++ version of TicTacToe's GameInfo.