### PR TITLE
fix build directory name

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -32,7 +32,7 @@
     # For the python modules in open_spiel.
     export PYTHONPATH=$PYTHONPATH:/<path_to_open_spiel>
     # For the Python bindings of Pyspiel
-    export PYTHONPATH=$PYTHONPATH:/<path_to_open_spiel>/build/python
+    export PYTHONPATH=$PYTHONPATH:/<path_to_open_spiel>/build_python_3/python
     ```
 
     to `./venv/bin/activate` or your `~/.bashrc` to be able to import OpenSpiel
@@ -111,7 +111,7 @@ or `.profile`.
 # For the python modules in open_spiel.
 export PYTHONPATH=$PYTHONPATH:/<path_to_open_spiel>
 # For the Python bindings of Pyspiel
-export PYTHONPATH=$PYTHONPATH:/<path_to_open_spiel>/build/python
+export PYTHONPATH=$PYTHONPATH:/<path_to_open_spiel>/build_python_3/python
 ```
 
 # Running the first example


### PR DESCRIPTION
I think the build script actually appends the python version to the build directory name here https://github.com/deepmind/open_spiel/blob/9a0848880400eb26e481ddfdc558b1b3d075e154/open_spiel/scripts/build_and_run_tests.sh#L44 so if we are assuming python 3 I think the build directory would actually be called "build_python_3".  This is what happened when I built it.