### PR TITLE
bugfix in connect_four

### DIFF
--- a/open_spiel/games/connect_four.h
+++ b/open_spiel/games/connect_four.h
@@ -88,7 +88,7 @@ class ConnectFourState : public State {
 class ConnectFourGame : public Game {
  public:
   explicit ConnectFourGame(const GameParameters& params);
-  int NumDistinctActions() const override { return kNumCells; }
+  int NumDistinctActions() const override { return kCols; }
   std::unique_ptr<State> NewInitialState() const override {
     return std::unique_ptr<State>(new ConnectFourState(NumDistinctActions()));
   }

--- a/open_spiel/integration_tests/playthroughs/connect_four.txt
+++ b/open_spiel/integration_tests/playthroughs/connect_four.txt
@@ -16,7 +16,7 @@ GameType.reward_model = RewardModel.TERMINAL
 GameType.short_name = "connect_four"
 GameType.utility = Utility.ZERO_SUM
 
-NumDistinctActions() = 42
+NumDistinctActions() = 7
 MaxChanceOutcomes() = 0
 GetParameters() = {}
 NumPlayers() = 2


### PR DESCRIPTION
If I understand the meaning of NumDistinctActions correctly, this should be the number of columns for connect four.