### PR TITLE
use C++17 for external linkage of inline functions

### DIFF
--- a/open_spiel/CMakeLists.txt
+++ b/open_spiel/CMakeLists.txt
@@ -8,7 +8,7 @@ Any Python library found with CMake modules FindPython2/FindPython3 that \
 agrees  with the major version and is at least as high for minor version and \
 patch number is accepted. If the variable is not set, we use the FindPython \
 module which favours Python 3 over Python 2 if both are available.")
-set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD 17)
 if(APPLE)
   set (CMAKE_CXX_FLAGS "-Werror -undefined dynamic_lookup")
 else()


### PR DESCRIPTION
`GameParametersToString` is declared inline in `open_spiel/game_parameters.cc`. This doesn't compile with C++11 and requires C++17.