### PR TITLE
Issue about the "action_probabilities" in Python implementation of Deep CFR

### DIFF
--- a/open_spiel/python/algorithms/deep_cfr.py
+++ b/open_spiel/python/algorithms/deep_cfr.py
@@ -331,12 +331,14 @@ class DeepCFRSolver(policy.Policy):
 
   def action_probabilities(self, state):
     """Returns action probabilities dict for a single batch."""
+    cur_player = state.current_player()
+    legal_actions = state.legal_actions(cur_player)
     info_state_vector = np.array(state.information_state_as_normalized_vector())
     if len(info_state_vector.shape) == 1:
       info_state_vector = np.expand_dims(info_state_vector, axis=0)
     probs = self._session.run(
         self._action_probs, feed_dict={self._info_state_ph: info_state_vector})
-    return {i: probs[0][i] for i in range(self._num_actions)}
+    return {action: probs[0][action] for i, action in enumerate(legal_actions)}
 
   def _learn_advantage_network(self, player):
     """Compute the loss on sampled transitions and perform a Q-network update.


### PR DESCRIPTION
The action probabilities used to get the NashConv/Exploitability should be defined on legal actions. Current version only seems to work well in kuhn poker and the NashConv of deep CFR will report a runtime error when switching to leduc poker. 