### PR TITLE
ConvNet DQN example for ConnectFour

### DIFF
--- a/open_spiel/python/algorithms/dqn_conv.py
+++ b/open_spiel/python/algorithms/dqn_conv.py
@@ -1,0 +1,444 @@
+# Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DQN agent implemented in TensorFlow for simple convolutional network."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import collections
+import random
+import numpy as np
+import sonnet as snt
+import tensorflow as tf
+import tensorflow.contrib.slim as slim
+
+from open_spiel.python import rl_agent
+
+Transition = collections.namedtuple(
+    "Transition",
+    "info_state action reward next_info_state is_final_step legal_actions_mask")
+
+ILLEGAL_ACTION_LOGITS_PENALTY = -1e9
+
+
+class ReplayBuffer(object):
+  """ReplayBuffer of fixed size with a FIFO replacement policy.
+
+  Stored transitions can be sampled uniformly.
+
+  The underlying datastructure is a ring buffer, allowing 0(1) adding and
+  sampling.
+  """
+
+  def __init__(self, replay_buffer_capacity):
+    self._replay_buffer_capacity = replay_buffer_capacity
+    self._data = []
+    self._next_entry_index = 0
+
+  def add(self, element):
+    """Adds `element` to the buffer.
+
+    If the buffer is full, the oldest element will be replaced.
+
+    Args:
+      element: data to be added to the buffer.
+    """
+    if len(self._data) < self._replay_buffer_capacity:
+      self._data.append(element)
+      #print(len(self._data))
+    else:
+      self._data[self._next_entry_index] = element
+      self._next_entry_index += 1
+      self._next_entry_index %= self._replay_buffer_capacity
+
+  def sample(self, num_samples):
+    """Returns `num_samples` uniformly sampled from the buffer.
+
+    Args:
+      num_samples: `int`, number of samples to draw.
+
+    Returns:
+      An iterable over `num_samples` random elements of the buffer.
+
+    Raises:
+      ValueError: If there are less than `num_samples` elements in the buffer
+    """
+    if len(self._data) < num_samples:
+      raise ValueError("{} elements could not be sampled from size {}".format(
+          num_samples, len(self._data)))
+    return random.sample(self._data, num_samples)
+
+  def __len__(self):
+    return len(self._data)
+
+  def __iter__(self):
+    return iter(self._data)
+
+
+class DQN(rl_agent.AbstractAgent):
+  """DQN Agent implementation in TensorFlow.
+
+  See open_spiel/python/examples/breakthrough_dqn.py for an usage example.
+  """
+
+  def __init__(self,
+               session,
+               player_id,
+               state_representation_size,
+               num_actions,
+               convolutional_layers_sizes,
+               kernal_shape,
+               fully_connected_layers_sizes,
+               state_representation_shape,
+               replay_buffer_capacity=10000,
+               batch_size=128,
+               replay_buffer_class=ReplayBuffer,
+               learning_rate=0.01,
+               update_target_network_every=1000,
+               learn_every=10,
+               discount_factor=1.0,
+               min_buffer_size_to_learn=1000,
+               epsilon_start=1.0,
+               epsilon_end=0.1,
+               epsilon_decay_duration=int(1e6),
+               optimizer_str="sgd",
+               loss_str="mse"
+               ):
+    """Initialize the DQN agent."""
+    self.player_id = player_id
+    self._session = session
+    self._num_actions = num_actions
+
+    self._convolutional_layers_sizes=convolutional_layers_sizes
+    self._kernal_shape=kernal_shape
+    self._fully_connected_layers_sizes=fully_connected_layers_sizes + [num_actions]
+    self._state_representation_shape=state_representation_shape
+    self._batch_size = batch_size
+    self._update_target_network_every = update_target_network_every
+    self._learn_every = learn_every
+    self._min_buffer_size_to_learn = min_buffer_size_to_learn
+    self._discount_factor = discount_factor
+
+    self._epsilon_start = epsilon_start
+    self._epsilon_end = epsilon_end
+    self._epsilon_decay_duration = epsilon_decay_duration
+
+    # TODO(author6) Allow for optional replay buffer config.
+    self._replay_buffer = replay_buffer_class(replay_buffer_capacity)
+    self._prev_timestep = None
+    self._prev_action = None
+
+    # Step counter to keep track of learning, eps decay and target network.
+    self._step_counter = 0
+
+    # Keep track of the last training loss achieved in an update step.
+    self._last_loss_value = None
+
+    # Create required TensorFlow placeholders to perform the Q-network updates.
+    self._info_state_ph = tf.placeholder(
+        shape=[None, *state_representation_shape],
+        dtype=tf.float32,
+        name="info_state_ph")
+    self._action_ph = tf.placeholder(
+        shape=[None], dtype=tf.int32, name="action_ph")
+    self._reward_ph = tf.placeholder(
+        shape=[None], dtype=tf.float32, name="reward_ph")
+    self._is_final_step_ph = tf.placeholder(
+        shape=[None], dtype=tf.float32, name="is_final_step_ph")
+    self._next_info_state_ph = tf.placeholder(
+        shape=[None, *state_representation_shape],
+        dtype=tf.float32,
+        name="next_info_state_ph")
+    self._legal_actions_mask_ph = tf.placeholder(
+        shape=[None, num_actions],
+        dtype=tf.float32,
+        name="legal_actions_mask_ph")
+
+    self._convolutional_layers_sizes=convolutional_layers_sizes
+    self._kernal_shape=kernal_shape
+    self._fully_connected_layers_sizes
+
+    self._q_network = snt.Sequential([
+      snt.nets.ConvNet2D(
+            output_channels=self._convolutional_layers_sizes, 
+            kernel_shapes=self._kernal_shape,
+            strides=[1, 1],
+            paddings=[snt.SAME],
+            activate_final=True,
+            name='convolutional_module'
+        )
+      ,snt.BatchFlatten()
+      ,snt.nets.MLP(  # Fully Connected layer
+            output_sizes=self._fully_connected_layers_sizes,
+            name='fully_connected_module'
+        )
+      ])
+
+    print("\nTF Print\n")  
+    model_vars = tf.trainable_variables()
+    slim.model_analyzer.analyze_vars(model_vars, print_info=True)
+    print("\nPython Print\n")  
+
+    # snt.nets.MLP(output_sizes=self._layer_sizes)
+    self._q_values = self._q_network(self._info_state_ph)
+
+    self._target_q_network = snt.Sequential([
+      snt.nets.ConvNet2D(
+            output_channels=self._convolutional_layers_sizes, 
+            kernel_shapes=self._kernal_shape,
+            strides=[1, 1],
+            paddings=[snt.SAME],
+            activate_final=True,
+            name='convolutional_module'
+        )
+      ,snt.BatchFlatten()
+      ,snt.nets.MLP(  # Fully Connected layer
+            output_sizes=self._fully_connected_layers_sizes,
+            name='fully_connected_module'
+        )
+      ])
+
+    self._target_q_values = self._target_q_network(self._next_info_state_ph)
+
+    # Stop gradient to prevent updates to the target network while learning
+    self._target_q_values = tf.stop_gradient(self._target_q_values)
+
+    self._update_target_network = self._create_target_network_update_op(
+        self._q_network, self._target_q_network)
+
+    # Create the loss operations.
+    # Sum a large negative constant to illegal action logits before taking the
+    # max. This prevents illegal action values from being considered as target.
+    illegal_actions = 1 - self._legal_actions_mask_ph
+    illegal_logits = illegal_actions * ILLEGAL_ACTION_LOGITS_PENALTY
+    max_next_q = tf.reduce_max(
+        tf.math.add(tf.stop_gradient(self._target_q_values), illegal_logits),
+        axis=-1)
+    target = (
+        self._reward_ph +
+        (1 - self._is_final_step_ph) * self._discount_factor * max_next_q)
+
+    action_indices = tf.stack(
+        [tf.range(tf.shape(self._q_values)[0]), self._action_ph], axis=-1)
+    predictions = tf.gather_nd(self._q_values, action_indices)
+
+    if loss_str == "mse":
+      loss_class = tf.losses.mean_squared_error
+    elif loss_str == "huber":
+      loss_class = tf.losses.huber_loss
+    else:
+      raise ValueError("Not implemented, choose from 'mse', 'huber'.")
+
+    self._loss = tf.reduce_mean(
+        loss_class(labels=target, predictions=predictions))
+
+    if optimizer_str == "adam":
+      optimizer = tf.train.AdamOptimizer(learning_rate=learning_rate)
+    elif optimizer_str == "sgd":
+      optimizer = tf.train.GradientDescentOptimizer(learning_rate=learning_rate)
+    else:
+      raise ValueError("Not implemented, choose from 'adam' and 'sgd'.")
+
+    self._learn_step = optimizer.minimize(self._loss)
+
+  def step(self, time_step, is_evaluation=False, add_transition_record=True):
+    """Returns the action to be taken and updates the Q-network if needed.
+
+    Args:
+      time_step: an instance of rl_environment.TimeStep.
+      is_evaluation: bool, whether this is a training or evaluation call.
+      add_transition_record: Whether to add to the replay buffer on this step.
+
+    Returns:
+      A `rl_agent.StepOutput` containing the action probs and chosen action.
+    """
+    # Act step: don't act at terminal info states or if its not our turn.
+    if (not time_step.last()) and (
+        time_step.is_simultaneous_move() or
+        self.player_id == time_step.current_player()):
+      info_state = time_step.observations["info_state"][self.player_id]
+      legal_actions = time_step.observations["legal_actions"][self.player_id]
+      epsilon = self._get_epsilon(is_evaluation)
+      action, probs = self._epsilon_greedy(info_state, legal_actions, epsilon)
+    else:
+      action = None
+      probs = []
+
+    # Don't mess up with the state during evaluation.
+    if not is_evaluation:
+      self._step_counter += 1
+
+      if self._step_counter % self._learn_every == 0:
+        self._last_loss_value = self.learn()
+
+      if self._step_counter % self._update_target_network_every == 0:
+        self._session.run(self._update_target_network)
+
+      if self._prev_timestep and add_transition_record:
+        # We may omit record adding here if it's done elsewhere.
+        self.add_transition(self._prev_timestep, self._prev_action, time_step)
+
+      if time_step.last():  # prepare for the next episode.
+        self._prev_timestep = None
+        self._prev_action = None
+        return
+      else:
+        self._prev_timestep = time_step
+        self._prev_action = action
+
+    return rl_agent.StepOutput(action=action, probs=probs)
+
+  def add_transition(self, prev_time_step, prev_action, time_step):
+    """Adds the new transition using `time_step` to the replay buffer.
+
+    Adds the transition from `self._prev_timestep` to `time_step` by
+    `self._prev_action`.
+
+    Args:
+      prev_time_step: prev ts, an instance of rl_environment.TimeStep.
+      prev_action: int, action taken at `prev_time_step`.
+      time_step: current ts, an instance of rl_environment.TimeStep.
+    """
+    assert prev_time_step is not None
+    legal_actions = (
+        prev_time_step.observations["legal_actions"][self.player_id])
+    legal_actions_mask = np.zeros(self._num_actions)
+    legal_actions_mask[legal_actions] = 1.0
+    transition = Transition(
+        info_state=(
+            prev_time_step.observations["info_state"][self.player_id][:]),
+        action=prev_action,
+        reward=time_step.rewards[self.player_id],
+        next_info_state=time_step.observations["info_state"][self.player_id][:],
+        is_final_step=float(time_step.last()),
+        legal_actions_mask=legal_actions_mask)
+    self._replay_buffer.add(transition)
+
+  def _create_target_network_update_op(self, q_network, target_q_network):
+    """Create TF ops copying the params of the Q-network to the target network.
+
+    Args:
+      q_network: `snt.AbstractModule`. Values are copied from this network.
+      target_q_network: `snt.AbstractModule`. Values are copied to this network.
+
+    Returns:
+      A `tf.Operation` that updates the variables of the target.
+    """
+    variables = q_network.get_variables()
+    target_variables = target_q_network.get_variables()
+    return tf.group([
+        tf.assign(target_v, v)
+        for (target_v, v) in zip(target_variables, variables)
+    ])
+
+  def _epsilon_greedy(self, info_state, legal_actions, epsilon):
+    """Returns a valid epsilon-greedy action and valid action probs.
+
+    Action probabilities are given by a softmax over legal q-values.
+
+    Args:
+      info_state: hashable representation of the information state.
+      legal_actions: list of legal actions at `info_state`.
+      epsilon: float, probability of taking an exploratory action.
+
+    Returns:
+      A valid epsilon-greedy action and valid action probabilities.
+    """
+    probs = np.zeros(self._num_actions)
+    if np.random.rand() < epsilon:
+      action = np.random.choice(legal_actions)
+      probs[legal_actions] = 1.0 / len(legal_actions)
+    else:
+      info_state = np.reshape(info_state, [-1,  *self._state_representation_shape])
+      q_values = self._session.run(
+          self._q_values, feed_dict={self._info_state_ph: info_state})[0]
+      legal_q_values = q_values[legal_actions]
+      action = legal_actions[np.argmax(legal_q_values)]
+      probs[action] = 1.0
+    return action, probs
+
+  def _get_epsilon(self, is_evaluation, power=1.0):
+    """Returns the evaluation or decayed epsilon value."""
+    if is_evaluation:
+      return 0.0
+    decay_steps = min(self._step_counter, self._epsilon_decay_duration)
+    decayed_epsilon = (
+        self._epsilon_end + (self._epsilon_start - self._epsilon_end) *
+        (1 - decay_steps / self._epsilon_decay_duration)**power)
+    return decayed_epsilon
+
+  def learn(self):
+    """Compute the loss on sampled transitions and perform a Q-network update.
+
+    If there are not enough elements in the buffer, no loss is computed and
+    `None` is returned instead.
+
+    Returns:
+      The average loss obtained on this batch of transitions or `None`.
+    """
+
+    if (len(self._replay_buffer) < self._batch_size or
+        len(self._replay_buffer) < self._min_buffer_size_to_learn):
+      return None
+
+    transitions = self._replay_buffer.sample(self._batch_size)
+    info_states = np.reshape( [t.info_state for t in transitions],  [-1,  *self._state_representation_shape])
+    actions = [t.action for t in transitions]
+    rewards = [t.reward for t in transitions]
+    next_info_states = np.reshape( [t.next_info_state for t in transitions],  [-1,  *self._state_representation_shape])
+    are_final_steps = [t.is_final_step for t in transitions]
+    legal_actions_mask = [t.legal_actions_mask for t in transitions]
+
+    loss, _ = self._session.run(
+        [self._loss, self._learn_step],
+        feed_dict={
+            self._info_state_ph: info_states,
+            self._action_ph: actions,
+            self._reward_ph: rewards,
+            self._is_final_step_ph: are_final_steps,
+            self._next_info_state_ph: next_info_states,
+            self._legal_actions_mask_ph: legal_actions_mask,
+        })
+
+    return loss
+
+  @property
+  def q_values(self):
+    return self._q_values
+
+  @property
+  def replay_buffer(self):
+    return self._replay_buffer
+
+  @property
+  def info_state_ph(self):
+    return self._info_state_ph
+
+  @property
+  def loss(self):
+    return self._last_loss_value
+
+  @property
+  def prev_timestep(self):
+    return self._prev_timestep
+
+  @property
+  def prev_action(self):
+    return self._prev_action
+
+  @property
+  def step_counter(self):
+    return self._step_counter

--- a/open_spiel/python/algorithms/dqn_conv.py
+++ b/open_spiel/python/algorithms/dqn_conv.py
@@ -100,7 +100,7 @@ class DQN(rl_agent.AbstractAgent):
                state_representation_size,
                num_actions,
                convolutional_layers_sizes,
-               kernal_shape,
+               kernel_shape,
                fully_connected_layers_sizes,
                state_representation_shape,
                replay_buffer_capacity=10000,
@@ -123,7 +123,7 @@ class DQN(rl_agent.AbstractAgent):
     self._num_actions = num_actions
 
     self._convolutional_layers_sizes=convolutional_layers_sizes
-    self._kernal_shape=kernal_shape
+    self._kernel_shape=kernel_shape
     self._fully_connected_layers_sizes=fully_connected_layers_sizes + [num_actions]
     self._state_representation_shape=state_representation_shape
     self._batch_size = batch_size
@@ -168,13 +168,13 @@ class DQN(rl_agent.AbstractAgent):
         name="legal_actions_mask_ph")
 
     self._convolutional_layers_sizes=convolutional_layers_sizes
-    self._kernal_shape=kernal_shape
+    self._kernel_shape=kernel_shape
     self._fully_connected_layers_sizes
 
     self._q_network = snt.Sequential([
       snt.nets.ConvNet2D(
             output_channels=self._convolutional_layers_sizes, 
-            kernel_shapes=self._kernal_shape,
+            kernel_shapes=self._kernel_shape,
             strides=[1, 1],
             paddings=[snt.SAME],
             activate_final=True,
@@ -198,7 +198,7 @@ class DQN(rl_agent.AbstractAgent):
     self._target_q_network = snt.Sequential([
       snt.nets.ConvNet2D(
             output_channels=self._convolutional_layers_sizes, 
-            kernel_shapes=self._kernal_shape,
+            kernel_shapes=self._kernel_shape,
             strides=[1, 1],
             paddings=[snt.SAME],
             activate_final=True,

--- a/open_spiel/python/algorithms/dqn_conv.py
+++ b/open_spiel/python/algorithms/dqn_conv.py
@@ -58,7 +58,6 @@ class ReplayBuffer(object):
     """
     if len(self._data) < self._replay_buffer_capacity:
       self._data.append(element)
-      #print(len(self._data))
     else:
       self._data[self._next_entry_index] = element
       self._next_entry_index += 1
@@ -187,12 +186,11 @@ class DQN(rl_agent.AbstractAgent):
         )
       ])
 
-    print("\nTF Print\n")  
-    model_vars = tf.trainable_variables()
-    slim.model_analyzer.analyze_vars(model_vars, print_info=True)
-    print("\nPython Print\n")  
+    # print("\n----Network Definition----\n")  
+    # model_vars = tf.trainable_variables()
+    # slim.model_analyzer.analyze_vars(model_vars, print_info=True)
+    # print("\n----Network Definition----\n")  
 
-    # snt.nets.MLP(output_sizes=self._layer_sizes)
     self._q_values = self._q_network(self._info_state_ph)
 
     self._target_q_network = snt.Sequential([

--- a/open_spiel/python/algorithms/dqn_conv_test.py
+++ b/open_spiel/python/algorithms/dqn_conv_test.py
@@ -1,0 +1,140 @@
+# Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for open_spiel.python.algorithms.dqn."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+
+from open_spiel.python import rl_environment
+from open_spiel.python.algorithms import dqn_conv as dqn
+import pyspiel
+
+
+class DQNTest(tf.test.TestCase):
+
+  def test_run_connect_four(self):
+    env = rl_environment.Environment("connect_four")
+    state_size = env.observation_spec()["info_state"][0]
+    num_actions = env.action_spec()["num_actions"]
+    state_shape = env.observation_spec()["info_state_shape"][0]
+
+    with self.session() as sess:
+      agents = [
+          dqn.DQN(  # pylint: disable=g-complex-comprehension
+              sess,
+              player_id,
+              state_representation_size=state_size,
+              num_actions=num_actions,
+              convolutional_layers_sizes=[64,32],
+              kernel_shape=[3,3],
+              fully_connected_layers_sizes=[16],
+              replay_buffer_capacity=10,
+              batch_size=5,
+              state_representation_shape=state_shape) for player_id in [0, 1]
+      ]
+      sess.run(tf.global_variables_initializer())
+      time_step = env.reset()
+      while not time_step.last():
+        current_player = time_step.observations["current_player"]
+        current_agent = agents[current_player]
+        agent_output = current_agent.step(time_step)
+        time_step = env.step([agent_output.action])
+
+      for agent in agents:
+        agent.step(time_step)
+
+  def test_run_hanabi(self):
+    # Hanabi is an optional game, so check we have it before running the test.
+    game = "hanabi"
+    if game not in pyspiel.registered_names():
+      return
+
+    num_players = 3
+    env_configs = {
+        "players": num_players,
+        "max_life_tokens": 1,
+        "colors": 2,
+        "ranks": 3,
+        "hand_size": 2,
+        "max_information_tokens": 3,
+        "discount": 0.
+    }
+    env = rl_environment.Environment(game, **env_configs)
+    state_size = env.observation_spec()["info_state"][0]
+    num_actions = env.action_spec()["num_actions"]
+
+    with self.session() as sess:
+      agents = [
+          dqn.DQN(  # pylint: disable=g-complex-comprehension
+              sess,
+              player_id,
+              state_representation_size=state_size,
+              num_actions=num_actions,
+              hidden_layers_sizes=[16],
+              replay_buffer_capacity=10,
+              batch_size=5) for player_id in range(num_players)
+      ]
+      sess.run(tf.global_variables_initializer())
+      time_step = env.reset()
+      while not time_step.last():
+        current_player = time_step.observations["current_player"]
+        agent_output = [agent.step(time_step) for agent in agents]
+        time_step = env.step([agent_output[current_player].action])
+
+      for agent in agents:
+        agent.step(time_step)
+
+
+class ReplayBufferTest(tf.test.TestCase):
+
+  def test_replay_buffer_add(self):
+    replay_buffer = dqn.ReplayBuffer(replay_buffer_capacity=10)
+    self.assertEqual(len(replay_buffer), 0)
+    replay_buffer.add("entry1")
+    self.assertEqual(len(replay_buffer), 1)
+    replay_buffer.add("entry2")
+    self.assertEqual(len(replay_buffer), 2)
+
+    self.assertIn("entry1", replay_buffer)
+    self.assertIn("entry2", replay_buffer)
+
+  def test_replay_buffer_max_capacity(self):
+    replay_buffer = dqn.ReplayBuffer(replay_buffer_capacity=2)
+    replay_buffer.add("entry1")
+    replay_buffer.add("entry2")
+    replay_buffer.add("entry3")
+    self.assertEqual(len(replay_buffer), 2)
+
+    self.assertIn("entry2", replay_buffer)
+    self.assertIn("entry3", replay_buffer)
+
+  def test_replay_buffer_sample(self):
+    replay_buffer = dqn.ReplayBuffer(replay_buffer_capacity=3)
+    replay_buffer.add("entry1")
+    replay_buffer.add("entry2")
+    replay_buffer.add("entry3")
+
+    samples = replay_buffer.sample(3)
+
+    self.assertIn("entry1", samples)
+    self.assertIn("entry2", samples)
+    self.assertIn("entry3", samples)
+
+
+if __name__ == "__main__":
+  tf.test.main()

--- a/open_spiel/python/examples/connect_four_dqn.py
+++ b/open_spiel/python/examples/connect_four_dqn.py
@@ -1,0 +1,133 @@
+# Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DQN agents trained on Connect Four by independent Q-learning."""
+# Feedforward network. For convolutional example see connect_four_dqn_conv.py
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from absl import app
+from absl import flags
+from absl import logging
+import numpy as np
+import tensorflow as tf
+
+from open_spiel.python import rl_environment
+from open_spiel.python.algorithms import dqn
+from open_spiel.python.algorithms import random_agent
+
+FLAGS = flags.FLAGS
+
+# Training parameters
+flags.DEFINE_string("checkpoint_dir", "/tmp/dqn_test",
+                    "Directory to save/load the agent.")
+flags.DEFINE_integer("num_train_episodes", int(1e6),
+                     "Number of training episodes.")
+flags.DEFINE_integer(
+    "eval_every", 1000,
+    "Episode frequency at which the DQN agents are evaluated.")
+
+# DQN model hyper-parameters
+flags.DEFINE_list("hidden_layers_sizes", [64, 64],
+                  "Number of hidden units in the Q-Network MLP.")
+flags.DEFINE_integer("replay_buffer_capacity", int(1e5),
+                     "Size of the replay buffer.")
+flags.DEFINE_integer("batch_size", 32,
+                     "Number of transitions to sample at each learning step.")
+
+
+def eval_against_random_bots(env, trained_agents, random_agents, num_episodes):
+  """Evaluates `trained_agents` against `random_agents` for `num_episodes`."""
+  num_players = len(trained_agents)
+  sum_episode_rewards = np.zeros(num_players)
+  for player_pos in range(num_players):
+    cur_agents = random_agents[:]
+    cur_agents[player_pos] = trained_agents[player_pos]
+    for _ in range(num_episodes):
+      time_step = env.reset()
+      episode_rewards = 0
+      while not time_step.last():
+        player_id = time_step.observations["current_player"]
+        if env.is_turn_based:
+          agent_output = cur_agents[player_id].step(
+              time_step, is_evaluation=True)
+          action_list = [agent_output.action]
+        else:
+          agents_output = [
+              agent.step(time_step, is_evaluation=True) for agent in cur_agents
+          ]
+          action_list = [agent_output.action for agent_output in agents_output]
+        time_step = env.step(action_list)
+        episode_rewards += time_step.rewards[player_pos]
+      sum_episode_rewards[player_pos] += episode_rewards
+  return sum_episode_rewards / num_episodes
+
+
+def main(_):
+  game = "connect_four"
+  num_players = 2
+
+  env_configs = {}
+  env = rl_environment.Environment(game, **env_configs)
+  info_state_size = env.observation_spec()["info_state"][0]
+  num_actions = env.action_spec()["num_actions"]
+
+  # random agents for evaluation
+  random_agents = [
+      random_agent.RandomAgent(player_id=idx, num_actions=num_actions)
+      for idx in range(num_players)
+  ]
+
+  with tf.Session() as sess:
+    hidden_layers_sizes = [int(l) for l in FLAGS.hidden_layers_sizes]
+    # pylint: disable=g-complex-comprehension
+    agents = [
+        dqn.DQN(
+            session=sess,
+            player_id=idx,
+            state_representation_size=info_state_size,
+            num_actions=num_actions,
+            hidden_layers_sizes=hidden_layers_sizes,
+            replay_buffer_capacity=FLAGS.replay_buffer_capacity,
+            batch_size=FLAGS.batch_size) for idx in range(num_players)
+    ]
+    saver = tf.train.Saver()
+    sess.run(tf.global_variables_initializer())
+
+    for ep in range(FLAGS.num_train_episodes):
+      if (ep + 1) % FLAGS.eval_every == 0:
+        r_mean = eval_against_random_bots(env, agents, random_agents, 1000)
+        logging.info("[%s] Mean episode rewards %s", ep + 1, r_mean)
+        saver.save(sess, FLAGS.checkpoint_dir, ep)
+
+      time_step = env.reset()
+      while not time_step.last():
+        player_id = time_step.observations["current_player"]
+        if env.is_turn_based:
+          agent_output = agents[player_id].step(time_step)
+          action_list = [agent_output.action]
+        else:
+          agents_output = [agent.step(time_step) for agent in agents]
+          action_list = [agent_output.action for agent_output in agents_output]
+        time_step = env.step(action_list)
+
+      # Episode is over, step all agents with final info state.
+      for agent in agents:
+        agent.step(time_step)
+
+
+if __name__ == "__main__":
+  app.run(main)

--- a/open_spiel/python/examples/connect_four_dqn_conv.py
+++ b/open_spiel/python/examples/connect_four_dqn_conv.py
@@ -1,0 +1,145 @@
+# Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DQN agents trained on Connect Four by independent Q-learning."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from absl import app
+from absl import flags
+from absl import logging
+import numpy as np
+import tensorflow as tf
+
+from open_spiel.python import rl_environment
+from open_spiel.python.algorithms import dqn_conv as dqn
+from open_spiel.python.algorithms import random_agent
+
+FLAGS = flags.FLAGS
+
+# Training parameters
+flags.DEFINE_string("checkpoint_dir", "/tmp/dqn_test",
+                    "Directory to save/load the agent.")
+flags.DEFINE_integer("num_train_episodes", int(1e6),
+                     "Number of training episodes.")
+flags.DEFINE_integer(
+    "eval_every", 1000,
+    "Episode frequency at which the DQN agents are evaluated.")
+
+# DQN model hyper-parameters
+flags.DEFINE_list("convolutional_layers_sizes", [64,32],
+                  "Number of hidden convolutional units in the Q-Network MLP.")
+flags.DEFINE_list("kernal_shape", [3,3],
+                  "Convolutional Kernal Shape")
+flags.DEFINE_list("fully_connected_layers_sizes", [64, 16],
+                  "Number of hidden fully connected units in the Q-Network MLP. Note last layer comes from the number of possible moves in the game itself")
+flags.DEFINE_integer("replay_buffer_capacity", int(1e5),
+                     "Size of the replay buffer.")
+flags.DEFINE_integer("batch_size", 32,
+                     "Number of transitions to sample at each learning step.")
+
+
+def eval_against_random_bots(env, trained_agents, random_agents, num_episodes):
+  """Evaluates `trained_agents` against `random_agents` for `num_episodes`."""
+  num_players = len(trained_agents)
+  sum_episode_rewards = np.zeros(num_players)
+  for player_pos in range(num_players):
+    cur_agents = random_agents[:]
+    cur_agents[player_pos] = trained_agents[player_pos]
+    for _ in range(num_episodes):
+      time_step = env.reset()
+      episode_rewards = 0
+      while not time_step.last():
+        player_id = time_step.observations["current_player"]
+        if env.is_turn_based:
+          agent_output = cur_agents[player_id].step(
+              time_step, is_evaluation=True)
+          action_list = [agent_output.action]
+        else:
+          agents_output = [
+              agent.step(time_step, is_evaluation=True) for agent in cur_agents
+          ]
+          action_list = [agent_output.action for agent_output in agents_output]
+        time_step = env.step(action_list)
+        episode_rewards += time_step.rewards[player_pos]
+      sum_episode_rewards[player_pos] += episode_rewards
+  return sum_episode_rewards / num_episodes
+
+
+def main(_):
+  game = "connect_four"
+  num_players = 2
+
+  env_configs = {}
+  env = rl_environment.Environment(game, **env_configs)
+  info_state_size = env.observation_spec()["info_state"][0]
+  num_actions = env.action_spec()["num_actions"]
+  info_state_shape = env.observation_spec()["info_state_shape"][0]
+  
+  # random agents for evaluation
+  random_agents = [
+      random_agent.RandomAgent(player_id=idx, num_actions=num_actions)
+      for idx in range(num_players)
+  ]
+
+  with tf.Session() as sess:
+
+    convolutional_layers_sizes = [int(l) for l in FLAGS.convolutional_layers_sizes]
+    kernal_shape = [int(l) for l in FLAGS.kernal_shape]
+    fully_connected_layers_sizes = [int(l) for l in FLAGS.fully_connected_layers_sizes]
+
+    
+    # pylint: disable=g-complex-comprehension
+    agents = [
+        dqn.DQN(
+            session=sess,
+            player_id=idx,
+            state_representation_size=info_state_size,
+            num_actions=num_actions,
+            convolutional_layers_sizes=convolutional_layers_sizes,
+            kernal_shape=kernal_shape,
+            fully_connected_layers_sizes=fully_connected_layers_sizes,
+            replay_buffer_capacity=FLAGS.replay_buffer_capacity,
+            batch_size=FLAGS.batch_size,
+            state_representation_shape=info_state_shape) for idx in range(num_players)
+    ]
+    saver = tf.train.Saver()
+    sess.run(tf.global_variables_initializer())
+
+    for ep in range(FLAGS.num_train_episodes):
+      if (ep + 1) % FLAGS.eval_every == 0:
+        r_mean = eval_against_random_bots(env, agents, random_agents, 1000)
+        logging.info("[%s] Mean episode rewards %s", ep + 1, r_mean)
+        saver.save(sess, FLAGS.checkpoint_dir, ep)
+
+      time_step = env.reset()
+      while not time_step.last():
+        player_id = time_step.observations["current_player"]
+        if env.is_turn_based:
+          agent_output = agents[player_id].step(time_step)
+          action_list = [agent_output.action]
+        else:
+          agents_output = [agent.step(time_step) for agent in agents]
+          action_list = [agent_output.action for agent_output in agents_output]
+        time_step = env.step(action_list)
+
+      # Episode is over, step all agents with final info state.
+      for agent in agents:
+        agent.step(time_step)
+
+
+if __name__ == "__main__":
+  app.run(main)

--- a/open_spiel/python/examples/connect_four_dqn_conv.py
+++ b/open_spiel/python/examples/connect_four_dqn_conv.py
@@ -42,7 +42,7 @@ flags.DEFINE_integer(
 # DQN model hyper-parameters
 flags.DEFINE_list("convolutional_layers_sizes", [64,32],
                   "Number of hidden convolutional units in the Q-Network MLP.")
-flags.DEFINE_list("kernal_shape", [3,3],
+flags.DEFINE_list("kernel_shape", [3,3],
                   "Convolutional Kernal Shape")
 flags.DEFINE_list("fully_connected_layers_sizes", [64, 16],
                   "Number of hidden fully connected units in the Q-Network MLP. Note last layer comes from the number of possible moves in the game itself")
@@ -98,7 +98,7 @@ def main(_):
   with tf.Session() as sess:
 
     convolutional_layers_sizes = [int(l) for l in FLAGS.convolutional_layers_sizes]
-    kernal_shape = [int(l) for l in FLAGS.kernal_shape]
+    kernel_shape = [int(l) for l in FLAGS.kernel_shape]
     fully_connected_layers_sizes = [int(l) for l in FLAGS.fully_connected_layers_sizes]
 
     
@@ -110,7 +110,7 @@ def main(_):
             state_representation_size=info_state_size,
             num_actions=num_actions,
             convolutional_layers_sizes=convolutional_layers_sizes,
-            kernal_shape=kernal_shape,
+            kernel_shape=kernel_shape,
             fully_connected_layers_sizes=fully_connected_layers_sizes,
             replay_buffer_capacity=FLAGS.replay_buffer_capacity,
             batch_size=FLAGS.batch_size,

--- a/open_spiel/python/rl_environment.py
+++ b/open_spiel/python/rl_environment.py
@@ -290,6 +290,11 @@ class Environment(object):
         ]),
         legal_actions=(self._game.num_distinct_actions(),),
         current_player=(),
+        info_state_shape=tuple([
+            self._game.observation_normalized_vector_shape()
+            if self._use_observation else
+            self._game.information_state_normalized_vector_shape()
+        ]),
     )
 
   def action_spec(self):

--- a/open_spiel/python/tests/rl_environment_test.py
+++ b/open_spiel/python/tests/rl_environment_test.py
@@ -78,11 +78,12 @@ class RLEnvironmentTest(absltest.TestCase):
 
     ttt_max_actions = 9
     ttt_normalized_info_set_shape = (27,)
-
+    ttt_info_set_shape = ([3,3,3],)
     self.assertEqual(action_spec["num_actions"], ttt_max_actions)
     self.assertEqual(env_spec["info_state"], ttt_normalized_info_set_shape)
+    self.assertEqual(env_spec["info_state_shape"], ttt_info_set_shape)
     self.assertCountEqual(env_spec.keys(),
-                          ["current_player", "info_state", "legal_actions"])
+                          ["current_player", "info_state", "legal_actions","info_state_shape"])
     self.assertCountEqual(action_spec.keys(),
                           ["dtype", "max", "min", "num_actions"])
 


### PR DESCRIPTION
I've implemented a simple ConvNet example which is based on the DQN Algorithm. 

The algorithm is called DQN_Conv.py and has the following differences from the fully connected example:

instead of taking just one array of hidden_layers_sizes it takes the following:
- convolutional_layers_sizes      (e.g. [64,32] )
- kernel_shape                           (e.g. [3,3] )
- fully_connected_layers_sizes   (e.g. [64,16] )

it also takes the state_representation_shape instead of the state_representation_size to ensure the inputs are formatted correctly. (this necessitated a change to rl_environment to return this.

At the moment I've stuck with Sonnet for defining the network, but that seems to have a limitation in the construction of convolutional layers, which must number 2 currently. Will look at this in a future revision.

Have implemented both a feedforward and convolutional version of connect_four so the two networks can be compared. To run, type:

```bash
python3 open_spiel/python/examples/connect_four_dqn_conv.py
python3 open_spiel/python/examples/connect_four_dqn.py
```

