### PR TITLE
Call `GetStatePolicy` with `State` instead of `std::string`.

### DIFF
--- a/open_spiel/algorithms/best_response.cc
+++ b/open_spiel/algorithms/best_response.cc
@@ -79,7 +79,7 @@ double TabularBestResponse::HandleDecisionCase(HistoryNode* node) {
   // expected utility of that node by looking at their policy.
   // We take child probabilities from the policy as that is what we are
   // calculating a best response to.
-  ActionsAndProbs state_policy = policy_->GetStatePolicy(node->GetInfoState());
+  ActionsAndProbs state_policy = policy_->GetStatePolicy(*node->GetState());
   if (state_policy.empty())
     SpielFatalError(absl::StrCat("InfoState ", node->GetInfoState(),
                                  " not found in policy."));

--- a/open_spiel/algorithms/history_tree.cc
+++ b/open_spiel/algorithms/history_tree.cc
@@ -177,7 +177,7 @@ ActionsAndProbs GetSuccessorsWithProbs(const State& state,
   } else {
     // Finally, we look at the policy we are finding a best response to, and
     // get our probabilities from there.
-    auto state_policy = policy->GetStatePolicy(state.InformationState());
+    auto state_policy = policy->GetStatePolicy(state);
     if (state_policy.empty()) {
       SpielFatalError(state.InformationState() + " not found in policy.");
     }


### PR DESCRIPTION
This allows one to compute best responses for `Policy`s that do not implement `GetStatePolicy` with an info state string, e.g., non-tabular policies that choose action distributions accoring to state features. Since the default version of `GetStatePolicy` given a `State` defers to the string version, this does not require changes in any current `Policy` classes.