### PR TITLE
Add instructions for using Swift OpenSpiel in XCode

### DIFF
--- a/docs/swift.md
+++ b/docs/swift.md
@@ -54,8 +54,6 @@ let package = Package(
         .package(url: "https://github.com/deepmind/open_spiel.git", .branch("master")),
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "foo",
             dependencies: ["OpenSpiel"]),
@@ -71,6 +69,7 @@ swift package generate-xcodeproj
 open foo.xcodeproj
 ```
 Set the build system to the Legacy Build System (File → Project Settings → Build System), and you are ready to build using XCode.
+
 
 ## A tour through the code
 

--- a/docs/swift.md
+++ b/docs/swift.md
@@ -34,6 +34,16 @@ swift build  # builds the OpenSpiel library
 swift test   # runs all unit tests
 ```
 
+A simple example of using the OpenSpiel package:
+```
+import OpenSpiel
+
+let game = TicTacToe()
+var state = game.initialState
+state.apply(TicTacToe.Action(x: 1, y: 1))
+print(state)
+```
+
 ## Using XCode
 
 To use OpenSpiel as a dependency for an XCode project, you need to use the [Swift Package Manager](https://swift.org/package-manager/) and use it to generate an XCode project. Create an executable package called `foo`:
@@ -44,7 +54,8 @@ swift package init --type executable
 ```
 Now open the file `Package.swift` that was generated, and add OpenSpiel as a dependency. The contents are now:
 ```
-// Package.swift
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
@@ -69,7 +80,6 @@ swift package generate-xcodeproj
 open foo.xcodeproj
 ```
 Set the build system to the Legacy Build System (File → Project Settings → Build System) required by [Swift for Tensorflow](https://github.com/tensorflow/swift/blob/master/Installation.md#installation), and you are ready to build using XCode.
-
 
 ## A tour through the code
 

--- a/docs/swift.md
+++ b/docs/swift.md
@@ -68,7 +68,7 @@ An XCode project can be generated from this package:
 swift package generate-xcodeproj
 open foo.xcodeproj
 ```
-Set the build system to the Legacy Build System (File → Project Settings → Build System), and you are ready to build using XCode.
+Set the build system to the Legacy Build System (File → Project Settings → Build System) required by [Swift for Tensorflow](https://github.com/tensorflow/swift/blob/master/Installation.md#installation), and you are ready to build using XCode.
 
 
 ## A tour through the code

--- a/docs/swift.md
+++ b/docs/swift.md
@@ -34,6 +34,44 @@ swift build  # builds the OpenSpiel library
 swift test   # runs all unit tests
 ```
 
+## Using XCode
+
+To use OpenSpiel as a dependency for an XCode project, you need to use the [Swift Package Manager](https://swift.org/package-manager/) and use it to generate an XCode project. Create an executable package called `foo`:
+```
+mkdir foo
+cd foo
+swift package init --type executable
+```
+Now open the file `Package.swift` that was generated, and add OpenSpiel as a dependency. The contents are now:
+```
+// Package.swift
+
+import PackageDescription
+
+let package = Package(
+    name: "foo",
+    dependencies: [
+        .package(url: "https://github.com/deepmind/open_spiel.git", .branch("master")),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "foo",
+            dependencies: ["OpenSpiel"]),
+        .testTarget(
+            name: "fooTests",
+            dependencies: ["foo"]),
+    ]
+)
+```
+An XCode project can be generated from this package:
+```
+swift package generate-xcodeproj
+open foo.xcodeproj
+```
+Set the build system to the Legacy Build System (File → Project Settings → Build System), and you are ready to build using XCode.
+
 ## A tour through the code
 
 *   `Spiel.swift` contains the primary abstractions common to all games, such as


### PR DESCRIPTION
This adds information for developers to workaround the issue #124. This workaround was suggested by @dan-zheng and @saeta. Also a simple example of using Swift OpenSpiel is added.