### PR TITLE
Fix invalid function call in benchmark_game.

### DIFF
--- a/open_spiel/examples/benchmark_game.cc
+++ b/open_spiel/examples/benchmark_game.cc
@@ -43,9 +43,9 @@ int RandomSimulation(std::mt19937* rng, const Game& game, bool verbose) {
 
   int game_length = 0;
   while (!state->IsTerminal()) {
-    if (provides_observations) {
+    if (provides_observations && state->CurrentPlayer() >= 0) {
       state->ObservationTensor(state->CurrentPlayer(), &obs);
-    } else if (provides_info_state) {
+    } else if (provides_info_state && state->CurrentPlayer() >= 0) {
       state->InformationStateTensor(state->CurrentPlayer(), &obs);
     }
     ++game_length;


### PR DESCRIPTION
benchmark_game throws an error on games with chance nodes and simultaneous move games because InformationStateTensor and ObservationTensor are called with kChancePlayerId and kSimultaneousPlayerId. Here's a simple fix.