### PR TITLE
Increase Required Pip Version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # The single source of truth for the OpenSpiel pip dependencies.
+pip >= 20.0.2
 absl-py == 0.9.0
 tensorflow < 2.0, >= 1.15.1
 dm-sonnet == 1.32


### PR DESCRIPTION
Tensorflow and jaxlib installs will fail unless latest pip version is installed -- default Windows Ubuntu pip version is very low.