### PR TITLE
Remove necessity to keep explicit default policy for MCCFR solvers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,6 @@ open_spiel/scripts/jill.sh
 
 # IDE
 .idea/
+.vscode/
 
 open_spiel/cmake-build-debug/

--- a/open_spiel/algorithms/cfr.cc
+++ b/open_spiel/algorithms/cfr.cc
@@ -24,8 +24,22 @@ namespace algorithms {
 
 CFRAveragePolicy::CFRAveragePolicy(
     const CFRInfoStateValuesTable& info_states,
-    std::shared_ptr<TabularPolicy> default_policy)
+    std::shared_ptr<Policy> default_policy)
     : info_states_(info_states), default_policy_(default_policy) {}
+
+ActionsAndProbs CFRAveragePolicy::GetStatePolicy(const State& state) const {
+  ActionsAndProbs actions_and_probs;
+  auto entry = info_states_.find(state.InformationStateString());
+  if (entry == info_states_.end()) {
+    if (default_policy_) {
+      return default_policy_->GetStatePolicy(state);
+    } else {
+      return actions_and_probs;
+    }
+  }
+  return GetStatePolicyFromInformationStateValues(entry->second,
+                                                  actions_and_probs);
+}
 
 ActionsAndProbs CFRAveragePolicy::GetStatePolicy(
     const std::string& info_state) const {
@@ -38,9 +52,13 @@ ActionsAndProbs CFRAveragePolicy::GetStatePolicy(
       return actions_and_probs;
     }
   }
+  return GetStatePolicyFromInformationStateValues(entry->second,
+                                                  actions_and_probs);
+}
 
-  const CFRInfoStateValues& is_vals = entry->second;
-
+ActionsAndProbs CFRAveragePolicy::GetStatePolicyFromInformationStateValues(
+    const CFRInfoStateValues& is_vals,
+    ActionsAndProbs& actions_and_probs) const {
   double sum_prob = 0.0;
   for (int aidx = 0; aidx < is_vals.num_actions(); ++aidx) {
     sum_prob += is_vals.cumulative_policy[aidx];
@@ -64,8 +82,22 @@ ActionsAndProbs CFRAveragePolicy::GetStatePolicy(
 
 CFRCurrentPolicy::CFRCurrentPolicy(
     const CFRInfoStateValuesTable& info_states,
-    std::shared_ptr<TabularPolicy> default_policy)
+    std::shared_ptr<Policy> default_policy)
     : info_states_(info_states), default_policy_(default_policy) {}
+
+ActionsAndProbs CFRCurrentPolicy::GetStatePolicy(const State& state) const {
+  ActionsAndProbs actions_and_probs;
+  auto entry = info_states_.find(state.InformationStateString());
+  if (entry == info_states_.end()) {
+    if (default_policy_) {
+      return default_policy_->GetStatePolicy(state);
+    } else {
+      return actions_and_probs;
+    }
+  }
+  return GetStatePolicyFromInformationStateValues(entry->second,
+                                                  actions_and_probs);
+}
 
 ActionsAndProbs CFRCurrentPolicy::GetStatePolicy(
     const std::string& info_state) const {
@@ -78,8 +110,13 @@ ActionsAndProbs CFRCurrentPolicy::GetStatePolicy(
       return actions_and_probs;
     }
   }
+  return GetStatePolicyFromInformationStateValues(entry->second,
+                                                  actions_and_probs);
+}
 
-  const CFRInfoStateValues& is_vals = entry->second;
+ActionsAndProbs CFRCurrentPolicy::GetStatePolicyFromInformationStateValues(
+    const CFRInfoStateValues& is_vals,
+    ActionsAndProbs& actions_and_probs) const {
   for (int aidx = 0; aidx < is_vals.num_actions(); ++aidx) {
     actions_and_probs.push_back(
         {is_vals.legal_actions[aidx], is_vals.current_policy[aidx]});

--- a/open_spiel/algorithms/cfr.h
+++ b/open_spiel/algorithms/cfr.h
@@ -57,17 +57,22 @@ using CFRInfoStateValuesTable =
 class CFRAveragePolicy : public Policy {
  public:
   // Returns the average policy from the CFR values.
-  // If an info state is not found, return the default policy for the info state
-  // (or an empty policy if default_policy is nullptr). If an info state has
-  // zero cumulative regret for all actions, return a uniform policy.
+  // If a state/info state is not found, return the default policy for the
+  // state/info state (or an empty policy if default_policy is nullptr).
+  // If an info state has zero cumulative regret for all actions,
+  // return a uniform policy.
   CFRAveragePolicy(const CFRInfoStateValuesTable& info_states,
-                   std::shared_ptr<TabularPolicy> default_policy);
+                   std::shared_ptr<Policy> default_policy);
+  ActionsAndProbs GetStatePolicy(const State& state) const override;
   ActionsAndProbs GetStatePolicy(const std::string& info_state) const override;
 
  private:
   const CFRInfoStateValuesTable& info_states_;
   bool default_to_uniform_;
-  std::shared_ptr<TabularPolicy> default_policy_;
+  std::shared_ptr<Policy> default_policy_;
+  ActionsAndProbs GetStatePolicyFromInformationStateValues(
+    const CFRInfoStateValues& is_vals,
+    ActionsAndProbs& actions_and_probs) const;
 };
 
 // A policy that extracts the current policy from the CFR table values.
@@ -77,12 +82,16 @@ class CFRCurrentPolicy : public Policy {
   // passed in, then it means that it is used if the lookup fails (use nullptr
   // to not use a default policy).
   CFRCurrentPolicy(const CFRInfoStateValuesTable& info_states,
-                   std::shared_ptr<TabularPolicy> default_policy);
+                   std::shared_ptr<Policy> default_policy);
+  ActionsAndProbs GetStatePolicy(const State& state) const override;
   ActionsAndProbs GetStatePolicy(const std::string& info_state) const override;
 
  private:
   const CFRInfoStateValuesTable& info_states_;
-  std::shared_ptr<TabularPolicy> default_policy_;
+  std::shared_ptr<Policy> default_policy_;
+  ActionsAndProbs GetStatePolicyFromInformationStateValues(
+    const CFRInfoStateValues& is_vals,
+    ActionsAndProbs& actions_and_probs) const;
 };
 
 // Base class supporting different flavours of the Counterfactual Regret

--- a/open_spiel/algorithms/external_sampling_mccfr.cc
+++ b/open_spiel/algorithms/external_sampling_mccfr.cc
@@ -27,12 +27,22 @@ namespace algorithms {
 ExternalSamplingMCCFRSolver::ExternalSamplingMCCFRSolver(const Game& game,
                                                          int seed,
                                                          AverageType avg_type)
+  : ExternalSamplingMCCFRSolver(
+      game,
+      std::shared_ptr<TabularPolicy>(new TabularPolicy(GetUniformPolicy(game))),
+      seed,
+      avg_type) {}
+
+ExternalSamplingMCCFRSolver::ExternalSamplingMCCFRSolver(
+    const Game& game,
+    std::shared_ptr<Policy> uniform_policy,
+    int seed,
+    AverageType avg_type)
     : game_(game.Clone()),
+      uniform_policy_(uniform_policy),
       rng_(new std::mt19937(seed)),
       avg_type_(avg_type),
-      dist_(0.0, 1.0),
-      uniform_policy_(std::shared_ptr<TabularPolicy>(
-          new TabularPolicy(GetUniformPolicy(game)))) {
+      dist_(0.0, 1.0) {
   if (game_->GetType().dynamics != GameType::Dynamics::kSequential) {
     SpielFatalError(
         "MCCFR requires sequential games. If you're trying to run it "

--- a/open_spiel/algorithms/external_sampling_mccfr.h
+++ b/open_spiel/algorithms/external_sampling_mccfr.h
@@ -58,8 +58,21 @@ class ExternalSamplingMCCFRSolver {
  public:
   static inline constexpr double kInitialTableValues = 0.000001;
 
-  // Creates a solver with a specific seed and average type.
+  // Creates a solver with a specific seed, average type and an explicit
+  // default uniform policy
   ExternalSamplingMCCFRSolver(const Game& game, int seed = 0,
+                              AverageType avg_type = AverageType::kSimple);
+
+  // Creates a solver with a specific seed and average type and also allows
+  // for a custom default uniform policy. This constructor is only useful when
+  // it is not feasible to keep an explicit default policy due to memory
+  // constraints in large games. A UniformPolicy could be used in cases where
+  // the inferred CFRAveragePolicy/CFRCurrentPolicy would only ever be queried
+  // with a state and a nullptr could be used in cases where info state lookup
+  // fails are expected to be handled externally by the caller
+  ExternalSamplingMCCFRSolver(const Game& game,
+                              std::shared_ptr<Policy> uniform_policy,
+                              int seed = 0,
                               AverageType avg_type = AverageType::kSimple);
 
   // Performs one iteration of external sampling MCCFR, updating the regrets
@@ -88,7 +101,7 @@ class ExternalSamplingMCCFRSolver {
   AverageType avg_type_;
   CFRInfoStateValuesTable info_states_;
   std::uniform_real_distribution<double> dist_;
-  std::shared_ptr<TabularPolicy> uniform_policy_;
+  std::shared_ptr<Policy> uniform_policy_;
 };
 
 }  // namespace algorithms

--- a/open_spiel/algorithms/outcome_sampling_mccfr.cc
+++ b/open_spiel/algorithms/outcome_sampling_mccfr.cc
@@ -28,14 +28,31 @@ namespace algorithms {
 
 OutcomeSamplingMCCFRSolver::OutcomeSamplingMCCFRSolver(const Game& game,
                                                        double epsilon, int seed)
+  : OutcomeSamplingMCCFRSolver(
+      game,
+      std::shared_ptr<TabularPolicy>(new TabularPolicy(GetUniformPolicy(game))),
+      epsilon,
+      seed) {}
+
+OutcomeSamplingMCCFRSolver::OutcomeSamplingMCCFRSolver(
+    const Game& game,
+    std::shared_ptr<Policy> uniform_policy,
+    double epsilon,
+    int seed)
     : game_(game),
+      uniform_policy_(uniform_policy),
       epsilon_(epsilon),
       num_players_(game.NumPlayers()),
       update_player_(-1),
       rng_(seed >= 0 ? seed : std::mt19937::default_seed),
-      dist_(0.0, 1.0),
-      uniform_policy_(std::shared_ptr<TabularPolicy>(
-          new TabularPolicy(GetUniformPolicy(game)))) {}
+      dist_(0.0, 1.0) {
+  if (game_.GetType().dynamics != GameType::Dynamics::kSequential) {
+    SpielFatalError(
+        "MCCFR requires sequential games. If you're trying to run it "
+        "on a simultaneous (or normal-form) game, please first transform it "
+        "using turn_based_simultaneous_game.");
+  }
+}
 
 void OutcomeSamplingMCCFRSolver::RunIteration(std::mt19937* rng) {
   update_player_ = (update_player_ + 1) % num_players_;

--- a/open_spiel/algorithms/outcome_sampling_mccfr.h
+++ b/open_spiel/algorithms/outcome_sampling_mccfr.h
@@ -45,6 +45,18 @@ class OutcomeSamplingMCCFRSolver {
   OutcomeSamplingMCCFRSolver(const Game& game, double epsilon = kDefaultEpsilon,
                              int seed = -1);
 
+  // Creates a solver that allows for a custom default uniform policy.
+  // This constructor is only useful when it is not feasible to keep an
+  // explicit default policy due to memory constraints in large games.
+  // A UniformPolicy could be used in cases where the inferred
+  // CFRAveragePolicy/CFRCurrentPolicy would only ever be queried with a state
+  // and a nullptr could be used in cases where info state lookup fails are
+  // expected to be handled externally by the caller
+  OutcomeSamplingMCCFRSolver(const Game& game,
+                             std::shared_ptr<Policy> uniform_policy,
+                             double epsilon = kDefaultEpsilon,
+                             int seed = -1);
+
   // Performs one iteration of outcome sampling.
   void RunIteration() { RunIteration(&rng_); }
 
@@ -82,7 +94,7 @@ class OutcomeSamplingMCCFRSolver {
   int update_player_;
   std::mt19937 rng_;
   absl::uniform_real_distribution<double> dist_;
-  std::shared_ptr<TabularPolicy> uniform_policy_;
+  std::shared_ptr<Policy> uniform_policy_;
 };
 
 }  // namespace algorithms


### PR DESCRIPTION
These changes are based on discussions in https://github.com/deepmind/open_spiel/issues/149. The idea is to remove the need to keep an explicit default policy within MCCFR solvers and thus make them feasible to run on large games where memory constraints are tighter.

The proposed changes allow for usage of:
- `TabularPolicy` which is the default behavior and the current state
- `UniformPolicy` for cases where the inferred average CFR policy will only ever be queried with a `State` instance
- `nullptr` which will enable to also query the inferred policy with an `info state string` but move the handling of info state lookup fails to the external caller (empty policy would be returned in that case)