### PR TITLE
feat: add GitOps CICD

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,67 @@
+name: Docker
+
+on:
+  push:
+    # Publish `master` as Docker `latest` image.
+    branches:
+      - master
+
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+  # Run tests for any PRs.
+  pull_request:
+
+env:
+  IMAGE_NAME: open_spiel
+
+jobs:
+  # Run tests.
+  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run tests
+        run: |
+          if [ -f docker-compose.test.yml ]; then
+            docker-compose --file docker-compose.test.yml build
+            docker-compose --file docker-compose.test.yml run sut
+          else
+            docker build . --file Dockerfile
+          fi
+  # Push image to GitHub Package Registry.
+  # See also https://docs.docker.com/docker-hub/builds/
+  push:
+    # Ensure test job passes before pushing image.
+    needs: test
+
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker build . --file Dockerfile --tag image
+
+      # https://help.github.com/en/packages/publishing-and-managing-packages/about-github-packages
+      - name: Log into registry 
+        run: echo "${{ secrets.GITHUB_PERSONAL_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+
+      - name: Push image
+        run: |
+          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+          docker tag image $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,8 @@ RUN pip3 install --upgrade cmake
 RUN mkdir -p build
 WORKDIR /repo/build
 RUN cmake -DPython_TARGET_VERSION=${PYVERSION} -DCMAKE_CXX_COMPILER=`which clang++` ../open_spiel 
-RUN make -j12
-RUN ctest -j12
+RUN make -j2
+RUN ctest -j2
 ENV PYTHONPATH=${PYTHONPATH}:/repo
 ENV PYTHONPATH=${PYTHONPATH}:/repo/build/python
 WORKDIR /repo/open_spiel

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# base image (3.13 GB)
+FROM ubuntu:18.04 as base
+RUN apt update
+RUN dpkg --add-architecture i386 && apt update
+RUN apt-get -y install \
+    clang \
+    curl \
+    git \
+    python3 \
+    python3-dev \
+    python3-pip \
+    python3-setuptools \
+    python3-wheel \
+    sudo
+RUN mkdir repo
+WORKDIR /repo
+
+RUN sudo pip3 install --upgrade pip
+RUN sudo pip3 install matplotlib
+
+# install
+COPY . .
+RUN ./install.sh
+RUN pip3 install --upgrade setuptools testresources 
+RUN pip3 install --upgrade -r requirements.txt
+RUN pip3 install --upgrade cmake
+
+# build and test
+RUN mkdir -p build
+WORKDIR /repo/build
+RUN cmake -DPython_TARGET_VERSION=${PYVERSION} -DCMAKE_CXX_COMPILER=`which clang++` ../open_spiel 
+RUN make -j12
+RUN ctest -j12
+ENV PYTHONPATH=${PYTHONPATH}:/repo
+ENV PYTHONPATH=${PYTHONPATH}:/repo/build/python
+WORKDIR /repo/open_spiel
+
+# slim image (2.26GB) for development in Python
+FROM python:3.6-slim-buster as python-minimal
+RUN mkdir repo
+WORKDIR /repo
+COPY --from=base /repo .
+RUN pip3 install --upgrade -r requirements.txt
+RUN pip3 install matplotlib
+ENV PYTHONPATH=${PYTHONPATH}:/repo
+ENV PYTHONPATH=${PYTHONPATH}:/repo/build/python
+WORKDIR /repo/open_spiel


### PR DESCRIPTION
In order to have a working GitOps CICD pipeline (for free), I provide you with a GitHub Actions YAML to deploy the Docker Image to your Github Package Registry (GPR). Since the Dockerfile was added prior to this PR, the setup is really easy and _provides you with an automated way to check if everything still works when pushing to the Master branch._ In the case that nothing fails, the Docker image will be published to the organisation's Package Registry and people will be able to pull it (_thus without the need for a local build_).

The single thing left **TODO** is to create a GITHUB_PERSONAL_TOKEN secret with the following scopes:
- read_packages
- write_packages
- edit_packages
(- repo)

More info can be found here: https://help.github.com/en/packages/publishing-and-managing-packages/about-github-packages