### PR TITLE
Wrapping docker build in compose file to put configuration in code

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.7"
+
+services:
+  openspiel:
+    build:
+      context: .
+      dockerfile: open_spiel/Dockerfile
+    image: openspiel

--- a/docs/install.md
+++ b/docs/install.md
@@ -92,8 +92,7 @@ Linux versions).
 In the top-level directory:
 
 ```bash
-docker build -t openspiel .
-docker run openspiel python3 python/examples/matrix_game_example.py
+docker-compose run openspiel python3 python/examples/matrix_game_example.py
 ```
 
 ## Running the first examples


### PR DESCRIPTION
In line 19 and 20 of your Dockerfile, you expect the 'install.sh' file to be in the top directory of you docker build context.
In your install docs, you tell the user to build the Docker file using the default build context (which is the directory that the Dockerfile is located in), but this location does not have a 'install.sh' file available.

To solve this issue without changing the Dockerfile, I've created a docker-compose file in the top directory. This compose file has the correct and expected context (which includes the 'install.sh' file) and points to the location of the Dockerfile in the subdirectory.

I've also changed the install documentation accordingly, which accidentally also reduces it to a oneliner ;)