### PR TITLE
Add complete no limit action space.

### DIFF
--- a/open_spiel/games/universal_poker.h
+++ b/open_spiel/games/universal_poker.h
@@ -44,12 +44,13 @@ constexpr uint8_t kMaxUniversalPokerPlayers = 10;
 // This is the mapping from int to action. E.g. the legal action "0" is fold,
 // the legal action "1" is check/call, etc.
 enum ActionType { kFold = 0, kCall = 1, kBet = 2, kAllIn = 3 };
-enum BettingAbstraction { kFCPA = 0, kFC = 1 };
+enum BettingAbstraction { kFCPA = 0, kFC = 1, kFULLGAME = 2 };
 std::ostream &operator<<(std::ostream &os, const BettingAbstraction &betting);
 
 class UniversalPokerState : public State {
  public:
-  explicit UniversalPokerState(std::shared_ptr<const Game> game);
+  explicit UniversalPokerState(std::shared_ptr<const Game> game,
+                               int big_blind, int starting_stack_big_blinds);
 
   bool IsTerminal() const override;
   bool IsChanceNode() const override;
@@ -75,6 +76,9 @@ class UniversalPokerState : public State {
 
  protected:
   void DoApplyAction(Action action_id) override;
+
+  int big_blind_;
+  int starting_stack_big_blinds_;
 
   enum ActionType {
     ACTION_DEAL = 1,
@@ -113,7 +117,7 @@ class UniversalPokerState : public State {
   const uint32_t &GetPossibleActionsMask() const { return possibleActions_; }
   const int GetPossibleActionCount() const;
 
-  void ApplyChoiceAction(ActionType action_type);
+  void ApplyChoiceAction(ActionType action_type, int size);
   std::string GetActionSequence() const { return actionSequence_; }
 };
 
@@ -140,12 +144,14 @@ class UniversalPokerGame : public Game {
   std::string gameDesc_;
   const acpc_cpp::ACPCGame acpc_game_;
   std::optional<int> max_game_length_;
-  BettingAbstraction betting_abstraction_ = BettingAbstraction::kFCPA;
+  BettingAbstraction betting_abstraction_ = BettingAbstraction::kFULLGAME;
 
  public:
   const acpc_cpp::ACPCGame *GetACPCGame() const { return &acpc_game_; }
 
   std::string parseParameters(const GameParameters &map);
+  int big_blind_;
+  int starting_stack_big_blinds_;
 };
 
 // Only supported for UniversalPoker. Randomly plays an action from a fixed list

--- a/open_spiel/games/universal_poker_test.cc
+++ b/open_spiel/games/universal_poker_test.cc
@@ -134,54 +134,6 @@ void LoadAndRunGameFromGameDef() {
   // testing::RandomSimTest(*holdem_nolimit_6p, 1);
 }
 
-void HUNLRegressionTests() {
-  std::shared_ptr<const Game> game = LoadGame(
-      "universal_poker(betting=nolimit,numPlayers=2,numRounds=4,blind=100 "
-      "50,firstPlayer=2 1 1 "
-      "1,numSuits=4,numRanks=13,numHoleCards=2,numBoardCards=0 3 1 1,stack=400 "
-      "400)");
-  std::unique_ptr<State> state = game->NewInitialState();
-  while (state->IsChanceNode()) {
-    state->ApplyAction(state->LegalActions()[0]);
-  }
-  std::cout << state->InformationStateString() << std::endl;
-  // Pot bet: call 50, and raise by 200.
-  state->ApplyAction(universal_poker::kBet);
-
-  // Now, the minimum bet size is larger than the pot, so player 0 can only
-  // fold, call, or go all-in.
-  std::vector<Action> actions = state->LegalActions();
-  absl::c_sort(actions);
-
-  SPIEL_CHECK_EQ(actions.size(), 3);
-  SPIEL_CHECK_EQ(actions[0], universal_poker::kFold);
-  SPIEL_CHECK_EQ(actions[1], universal_poker::kCall);
-  SPIEL_CHECK_EQ(actions[2], universal_poker::kAllIn);
-
-  // Try a similar test with a stacks of size 300.
-  game = LoadGame(
-      "universal_poker(betting=nolimit,numPlayers=2,numRounds=4,blind=100 "
-      "50,firstPlayer=2 1 1 "
-      "1,numSuits=4,numRanks=13,numHoleCards=2,numBoardCards=0 3 1 1,stack=300 "
-      "300)");
-  state = game->NewInitialState();
-  while (state->IsChanceNode()) {
-    state->ApplyAction(state->LegalActions()[0]);
-  }
-  std::cout << state->InformationStateString() << std::endl;
-
-  // The pot bet exactly matches the number of chips available. This is an edge
-  // case where all-in is not available, only the pot bet.
-
-  actions = state->LegalActions();
-  absl::c_sort(actions);
-
-  SPIEL_CHECK_EQ(actions.size(), 3);
-  SPIEL_CHECK_EQ(actions[0], universal_poker::kFold);
-  SPIEL_CHECK_EQ(actions[1], universal_poker::kCall);
-  SPIEL_CHECK_EQ(actions[2], universal_poker::kBet);
-}
-
 void LoadAndRunGameFromDefaultConfig() {
   std::shared_ptr<const Game> game = LoadGame("universal_poker");
   testing::RandomSimTest(*game, 2);
@@ -242,6 +194,6 @@ int main(int argc, char **argv) {
   open_spiel::universal_poker::LoadAndRunGameFromGameDef();
   open_spiel::universal_poker::LoadAndRunGameFromDefaultConfig();
   open_spiel::universal_poker::BasicUniversalPokerTests();
-  open_spiel::universal_poker::HUNLRegressionTests();
   open_spiel::universal_poker::ChumpPolicyTests();
+  std::cout << "ALl tests passed!!" << std::endl;
 }


### PR DESCRIPTION
@lanctot here's the patch to allow full no limit betting. My guiding philosophy was to make as few changes as possible. It passes all the tests on linux, aside from one which I had to remove because it made assumptions incompatible with the new larger action space. Oddly some tests failed on my mac but the full no limit action space tests work.

Before diving in too much deeper, I think it's worth taking a step back and making some broader design decisions. In particular, do we want to support action abstractions within the universal poker game itself? My answer is no, it doesn't seem like the OpenSpiel way. Action abstractions should be handled on the bot/algo end of things.

The abstractions are sort of baked into the code right now, so I wanted to get the team's input on this before making any further changes. I think I've got a pretty good handle on the OpenSpiel game API, and I'm happy to put a more work into the ACPC interface and build a rigorous test suite.

Submitting this to get the ball rolling, hope it helps!

-John