### PR TITLE
fixed SampleCards bug in universal_poker/card_set

### DIFF
--- a/open_spiel/games/universal_poker/logic/card_set.cc
+++ b/open_spiel/games/universal_poker/logic/card_set.cc
@@ -136,7 +136,7 @@ std::vector<CardSet> CardSet::SampleCards(int nbCards) {
 
   for (uint64_t n = bit_twiddle_permute(p); n > p;
        p = n, n = bit_twiddle_permute(p)) {
-    uint64_t combo = n & cs.cards;
+    uint64_t combo = p & cs.cards;
     if (__builtin_popcountl(combo) == nbCards) {
       CardSet c;
       c.cs.cards = combo;


### PR DESCRIPTION
According to universal_poker_card_set_test,

>  ./universal_poker_card_set_test
CardSet: AhKsQhJhTh
Card: "
Card: &
Card: *
Card: /
Card: 2
Rank: 9632
Count Cards: 5
CardSet: AsAhAdAcKsKhKdKcQsQhQdQcJsJhJdJcTsThTdTc9s9h9d9c8s8h8d8c7s7h7d7c6s6h6d6c5s5h5d5c4s4h4d4c3s3h3d3c2s2h2d2c
Rank: 12115
Count Cards: 52
CardSet: 5c3c2c
CardSet: 5c4c2c
...

the first CardSet `4c3c2c` is missed.  After fixing, it looks like this

> ./universal_poker_card_set_test
CardSet: AhKsQhJhTh
Card: "
Card: &
Card: *
Card: /
Card: 2
Rank: 9632
Count Cards: 5
CardSet: AsAhAdAcKsKhKdKcQsQhQdQcJsJhJdJcTsThTdTc9s9h9d9c8s8h8d8c7s7h7d7c6s6h6d6c5s5h5d5c4s4h4d4c3s3h3d3c2s2h2d2c
Rank: 12115
Count Cards: 52
CardSet: 4c3c2c
CardSet: 5c3c2c
...

