### PR TITLE
Fix: Returns of non-terminal KuhnState was hardcoded for 2 players

### DIFF
--- a/open_spiel/games/kuhn_poker.cc
+++ b/open_spiel/games/kuhn_poker.cc
@@ -156,7 +156,7 @@ bool KuhnState::IsTerminal() const { return winner_ != kInvalidPlayer; }
 
 std::vector<double> KuhnState::Returns() const {
   if (!IsTerminal()) {
-    return {0.0, 0.0};
+    return std::vector<double>(num_players_, 0.0);
   }
 
   std::vector<double> returns(num_players_);


### PR DESCRIPTION
KuhnState::Returns should return a std::vector with an entry for every player, but for any number of players this returns {0.0, 0.0} if the game isn't terminal. This was changed to return a vector of size num_players_