### PR TITLE
Fix attempts to make illegal moves

### DIFF
--- a/open_spiel/python/algorithms/best_response.py
+++ b/open_spiel/python/algorithms/best_response.py
@@ -110,8 +110,9 @@ class BestResponsePolicy(openspiel_policy.Policy):
       if parent_state.current_player() == self._player_id:
         yield (parent_state, 1.0)
       for action, p_action in self.transitions(parent_state):
-        for state, p_state in self.decision_nodes(parent_state.child(action)):
-          yield (state, p_state * p_action)
+        if action in parent_state.legal_actions():
+          for state, p_state in self.decision_nodes(parent_state.child(action)):
+            yield (state, p_state * p_action)
 
   def transitions(self, state):
     """Returns a list of (action, cf_prob) pairs from the specifed state."""
@@ -138,7 +139,10 @@ class BestResponsePolicy(openspiel_policy.Policy):
 
   def q_value(self, state, action):
     """Returns the value of the (state, action) to the best-responder."""
-    return self.value(state.child(action))
+    if action in state.legal_actions():
+      return self.value(state.child(action))
+    else:
+      return state.player_return(self._player_id)
 
   @_memoize_method
   def best_response_action(self, infostate):

--- a/open_spiel/python/algorithms/exploitability.py
+++ b/open_spiel/python/algorithms/exploitability.py
@@ -55,7 +55,7 @@ def _state_values(state, num_players, policy):
         state.chance_outcomes() if state.is_chance_node() else
         policy.action_probabilities(state).items())
     return sum(prob * _state_values(state.child(action), num_players, policy)
-               for action, prob in p_action)
+               for action, prob in p_action if action in state.legal_actions())
 
 
 def best_response(game, policy, player_id):


### PR DESCRIPTION
The following code attempts to compute the Nash convergence of a naive random strategy on Leduc poker:
```
import pyspiel
import numpy as np

from open_spiel.python import policy
from open_spiel.python.algorithms import exploitability

game = pyspiel.load_game("leduc_poker")
num_actions = game.num_distinct_actions()

def action_probabilities(state):
    legal_actions = state.legal_actions()
    probs = np.zeros(num_actions)
    probs[legal_actions] = 1 / len(legal_actions)
    return {action: probs[action] for action in range(num_actions)}

conv = exploitability.nash_conv(
    game,
    policy.PolicyFromCallable(game, action_probabilities)
)
```
In this game only 2 raise actions are allowed per round. However, every action is attempted regardless of the round. This results in illegal moves being made and the following error:
```
RuntimeError: ~/open_spiel/open_spiel/games/leduc_poker.cc:156 num_raises_ < kMaxRaises
num_raises_ = 2, kMaxRaises = 2
```