### PR TITLE
Use `open_spiel` namespace prefix for float assertions

### DIFF
--- a/open_spiel/spiel_utils.h
+++ b/open_spiel/spiel_utils.h
@@ -196,12 +196,12 @@ bool Near(T a, T b, T epsilon) {
 // Checks that x and y are equal to the default dynamic threshold proportional
 // to max(|x|, |y|).
 #define SPIEL_CHECK_FLOAT_EQ(x, y) \
-  SPIEL_CHECK_FN2(static_cast<float>(x), static_cast<float>(y), Near)
+  SPIEL_CHECK_FN2(static_cast<float>(x), static_cast<float>(y), open_spiel::Near)
 
 // Checks that x and y are epsilon apart or closer.
 #define SPIEL_CHECK_FLOAT_NEAR(x, y, epsilon)                   \
   SPIEL_CHECK_FN3(static_cast<float>(x), static_cast<float>(y), \
-                  static_cast<float>(epsilon), Near)
+                  static_cast<float>(epsilon), open_spiel::Near)
 
 #define SPIEL_CHECK_TRUE(x)                                      \
   while (!(x))                                                   \


### PR DESCRIPTION
This is to allow float assertion macros to be used without using the `open_spiel` namespace itself. Most of the other macros use the `open_spiel` prefixes in this way so I think these two were just missed.