### PR TITLE
Only build and register `run_python_test` when `BUILD_WITH_PYTHON=ON`

### DIFF
--- a/open_spiel/utils/CMakeLists.txt
+++ b/open_spiel/utils/CMakeLists.txt
@@ -42,9 +42,11 @@ add_executable(lru_cache_test lru_cache_test.cc ${OPEN_SPIEL_OBJECTS}
                $<TARGET_OBJECTS:tests>)
 add_test(lru_cache_test lru_cache_test)
 
-add_executable(run_python_test run_python_test.cc ${OPEN_SPIEL_OBJECTS}
-               $<TARGET_OBJECTS:tests>)
-add_test(run_python_test run_python_test)
+if (BUILD_WITH_PYTHON)
+  add_executable(run_python_test run_python_test.cc ${OPEN_SPIEL_OBJECTS}
+                 $<TARGET_OBJECTS:tests>)
+  add_test(run_python_test run_python_test)
+endif()
 
 add_executable(stats_test stats_test.cc ${OPEN_SPIEL_OBJECTS}
                $<TARGET_OBJECTS:tests>)


### PR DESCRIPTION
While `run_python_test` doesn't depend on `pyspiel`, it still requires setting the python path to include the `open_spiel` directory, which is probably not necessary if one isn't using `pyspiel`. An alternative would be to change `run_python_test` to not run a local module, but from the comment in `RunPython` and the test, it looks like this is the main purpose of `RunPython`. 