### PR TITLE
Install CMake if it is not present (macOS install.sh)

### DIFF
--- a/open_spiel/scripts/install.sh
+++ b/open_spiel/scripts/install.sh
@@ -153,6 +153,7 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
   fi
 elif [[ "$OSTYPE" == "darwin"* ]]; then  # Mac OSX
   [[ -x `which realpath` ]] || brew install coreutils || echo "** Warning: failed 'brew install coreutils' -- continuing"
+  [[ -x `which cmake` ]] || brew install cmake || echo "** Warning: failed 'brew install cmake' -- continuing"
   [[ -x `which python3` ]] || brew install python3 || echo "** Warning: failed 'brew install python3' -- continuing"
   `python3 -c "import tkinter" > /dev/null 2>&1` || brew install tcl-tk || echo "** Warning: failed 'brew install tcl-tk' -- continuing"
   [[ -x `which clang++` ]] || die "Clang not found. Please install or upgrade XCode and run the command-line developer tools"


### PR DESCRIPTION
The installation script does not check CMake presence on macOS (`darwin`). `brew install cmake` is added to install it in case it is not available.