### PR TITLE
Remove python version specifier from Nox tests definition

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -27,7 +27,7 @@ def get_distutils_tempdir():
   )
 
 
-@nox.session
+@nox.session(python="3")
 def tests(session):
   session.install("-r", "requirements.txt")
   session.run("python3", "setup.py", "build")

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,7 +27,7 @@ def get_distutils_tempdir():
   )
 
 
-@nox.session(python="3.6")
+@nox.session
 def tests(session):
   session.install("-r", "requirements.txt")
   session.run("python3", "setup.py", "build")


### PR DESCRIPTION
There is no need to specify the Python version for Nox tests. Without a specific version, Nox will use whatever Python interpreter its parent environment has.

So, if we only have Python 3.6 on Travis, and Python 3.7 or 3.8 on other deployments, tests will run using the same interpreter.