### PR TITLE
Fix unsorted legal actions.

### DIFF
--- a/open_spiel/games/efg_game.cc
+++ b/open_spiel/games/efg_game.cc
@@ -14,6 +14,7 @@
 
 #include "open_spiel/games/efg_game.h"
 
+#include <algorithm>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
@@ -434,6 +435,7 @@ void EFGGame::ParseChanceNode(Node* parent, Node* child, int depth) {
     chance_outcomes++;
   }
   SPIEL_CHECK_GT(child->actions.size(), 0);
+  std::sort(child->action_ids.begin(), child->action_ids.end());
   SPIEL_CHECK_TRUE(Near(prob_sum, 1.0));
   SPIEL_CHECK_TRUE(NextToken() == "}");
   SPIEL_CHECK_TRUE(absl::SimpleAtoi(NextToken(), &child->outcome_number));
@@ -516,6 +518,7 @@ void EFGGame::ParsePlayerNode(Node* parent, Node* child, int depth) {
     actions++;
   }
   SPIEL_CHECK_GT(child->actions.size(), 0);
+  std::sort(child->action_ids.begin(), child->action_ids.end());
   max_actions_ = std::max(max_actions_, actions);
   SPIEL_CHECK_TRUE(NextToken() == "}");
   SPIEL_CHECK_TRUE(absl::SimpleAtoi(NextToken(), &child->outcome_number));


### PR DESCRIPTION
The last update broke compatibility with some of my EFG files that used to work. The EFG file specification does not guarantee the action names will be sorted. And even if the action names are always sorted within a given node, they may not have been first encountered in that order, so the `action_ids` they map to may be unsorted. Consider first encountering the infoset with actions {"B" "C"}, followed by {"A" "B" "C"}. The `action_ids` are then B->0, C->1, A->2. So when calling `LegalActions()` on the second infoset, we get [2, 0, 1]. Sorting the `action_ids` after parsing all the actions within each node fixed the issue.
