### PR TITLE
Additional configurations for Leduc poker

### DIFF
--- a/open_spiel/games/leduc_poker.h
+++ b/open_spiel/games/leduc_poker.h
@@ -24,8 +24,15 @@
 //
 // So the maximin sequence is of the form:
 // private card player 0, private card player 1, [bets], public card, [bets]
+//
 // Parameters:
-//     "players"       int    number of players               (default = 2)
+//     "players"           int    number of players          (default = 2)
+//     "action_mapping"    bool   regard all actions as legal and internally
+//                                map otherwise illegal actions to check/call
+//                                                           (default = false)
+//     "suit_isomorphism"  bool   player observations do not distinguish
+//                                between cards of different suits with
+//                                the same rank              (default = false)
 
 #ifndef OPEN_SPIEL_GAMES_LEDUC_POKER_H_
 #define OPEN_SPIEL_GAMES_LEDUC_POKER_H_
@@ -33,6 +40,7 @@
 #include <array>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "open_spiel/spiel.h"
@@ -53,7 +61,7 @@ inline constexpr int kTotalRaisesPerRound = 2;
 inline constexpr int kMaxRaises = 2;
 inline constexpr int kStartingMoney = 100;
 inline constexpr int kNumInfoStates =
-    936;  // Number of info state in the 2P game.
+    936;  // Number of info states in the 2P game with default params.
 
 class LeducGame;
 
@@ -61,7 +69,8 @@ enum ActionType { kFold = 0, kCall = 1, kRaise = 2 };
 
 class LeducState : public State {
  public:
-  explicit LeducState(std::shared_ptr<const Game> game);
+  explicit LeducState(std::shared_ptr<const Game> game,
+                      bool action_mapping, bool suit_isomorphism);
 
   Player CurrentPlayer() const override;
   std::string ActionToString(Player player, Action move) const override;
@@ -151,6 +160,12 @@ class LeducState : public State {
   // Sequence of actions for each round. Needed to report information state.
   std::vector<int> round1_sequence_;
   std::vector<int> round2_sequence_;
+  // Always regard all actions as legal, and internally map otherwise illegal
+  // actions to check/call.
+  bool action_mapping_;
+  // Players cannot distinguish between cards of different suits with the same
+  // rank.
+  bool suit_isomorphism_;
 };
 
 class LeducGame : public Game {
@@ -159,7 +174,7 @@ class LeducGame : public Game {
 
   int NumDistinctActions() const override { return 3; }
   std::unique_ptr<State> NewInitialState() const override;
-  int MaxChanceOutcomes() const override { return total_cards_; }
+  int MaxChanceOutcomes() const override;
   int NumPlayers() const override { return num_players_; }
   double MinUtility() const override;
   double MaxUtility() const override;
@@ -179,6 +194,12 @@ class LeducGame : public Game {
  private:
   int num_players_;  // Number of players.
   int total_cards_;  // Number of cards total cards in the game.
+  // Always regard all actions as legal, and internally map otherwise illegal
+  // actions to check/call.
+  bool action_mapping_;
+  // Players cannot distinguish between cards of different suits with the same
+  // rank.
+  bool suit_isomorphism_;
 };
 
 }  // namespace leduc_poker

--- a/open_spiel/games/leduc_poker_test.cc
+++ b/open_spiel/games/leduc_poker_test.cc
@@ -25,6 +25,10 @@ void BasicLeducTests() {
   testing::LoadGameTest("leduc_poker");
   testing::ChanceOutcomesTest(*LoadGame("leduc_poker"));
   testing::RandomSimTest(*LoadGame("leduc_poker"), 100);
+  testing::RandomSimTest(*LoadGame("leduc_poker",
+                         {{"action_mapping", GameParameter(true)}}), 100);
+  testing::RandomSimTest(*LoadGame("leduc_poker",
+                         {{"suit_isomorphism", GameParameter(true)}}), 100);
   for (Player players = 3; players <= 5; players++) {
     testing::RandomSimTest(
         *LoadGame("leduc_poker", {{"players", GameParameter(players)}}), 100);

--- a/open_spiel/integration_tests/playthroughs/leduc_poker_1540482260.txt
+++ b/open_spiel/integration_tests/playthroughs/leduc_poker_1540482260.txt
@@ -6,7 +6,7 @@ GameType.information = Information.IMPERFECT_INFORMATION
 GameType.long_name = "Leduc Poker"
 GameType.max_num_players = 10
 GameType.min_num_players = 2
-GameType.parameter_specification = ["players"]
+GameType.parameter_specification = ["action_mapping", "players", "suit_isomorphism"]
 GameType.provides_information_state_string = True
 GameType.provides_information_state_tensor = True
 GameType.provides_observation_string = True
@@ -18,7 +18,7 @@ GameType.utility = Utility.ZERO_SUM
 NumDistinctActions() = 3
 PolicyTensorShape() = [3]
 MaxChanceOutcomes() = 6
-GetParameters() = {players=2}
+GetParameters() = {action_mapping=False,players=2,suit_isomorphism=False}
 NumPlayers() = 2
 MinUtility() = -13.0
 MaxUtility() = 13.0

--- a/open_spiel/integration_tests/playthroughs/leduc_poker_3977671846.txt
+++ b/open_spiel/integration_tests/playthroughs/leduc_poker_3977671846.txt
@@ -6,7 +6,7 @@ GameType.information = Information.IMPERFECT_INFORMATION
 GameType.long_name = "Leduc Poker"
 GameType.max_num_players = 10
 GameType.min_num_players = 2
-GameType.parameter_specification = ["players"]
+GameType.parameter_specification = ["action_mapping", "players", "suit_isomorphism"]
 GameType.provides_information_state_string = True
 GameType.provides_information_state_tensor = True
 GameType.provides_observation_string = True
@@ -18,7 +18,7 @@ GameType.utility = Utility.ZERO_SUM
 NumDistinctActions() = 3
 PolicyTensorShape() = [3]
 MaxChanceOutcomes() = 6
-GetParameters() = {players=2}
+GetParameters() = {action_mapping=False,players=2,suit_isomorphism=False}
 NumPlayers() = 2
 MinUtility() = -13.0
 MaxUtility() = 13.0

--- a/open_spiel/integration_tests/playthroughs/leduc_poker_3p.txt
+++ b/open_spiel/integration_tests/playthroughs/leduc_poker_3p.txt
@@ -6,7 +6,7 @@ GameType.information = Information.IMPERFECT_INFORMATION
 GameType.long_name = "Leduc Poker"
 GameType.max_num_players = 10
 GameType.min_num_players = 2
-GameType.parameter_specification = ["players"]
+GameType.parameter_specification = ["action_mapping", "players", "suit_isomorphism"]
 GameType.provides_information_state_string = True
 GameType.provides_information_state_tensor = True
 GameType.provides_observation_string = True
@@ -18,7 +18,7 @@ GameType.utility = Utility.ZERO_SUM
 NumDistinctActions() = 3
 PolicyTensorShape() = [3]
 MaxChanceOutcomes() = 8
-GetParameters() = {players=3}
+GetParameters() = {action_mapping=False,players=3,suit_isomorphism=False}
 NumPlayers() = 3
 MinUtility() = -13.0
 MaxUtility() = 26.0

--- a/open_spiel/integration_tests/playthroughs/leduc_poker_773740114.txt
+++ b/open_spiel/integration_tests/playthroughs/leduc_poker_773740114.txt
@@ -6,7 +6,7 @@ GameType.information = Information.IMPERFECT_INFORMATION
 GameType.long_name = "Leduc Poker"
 GameType.max_num_players = 10
 GameType.min_num_players = 2
-GameType.parameter_specification = ["players"]
+GameType.parameter_specification = ["action_mapping", "players", "suit_isomorphism"]
 GameType.provides_information_state_string = True
 GameType.provides_information_state_tensor = True
 GameType.provides_observation_string = True
@@ -18,7 +18,7 @@ GameType.utility = Utility.ZERO_SUM
 NumDistinctActions() = 3
 PolicyTensorShape() = [3]
 MaxChanceOutcomes() = 6
-GetParameters() = {players=2}
+GetParameters() = {action_mapping=False,players=2,suit_isomorphism=False}
 NumPlayers() = 2
 MinUtility() = -13.0
 MaxUtility() = 13.0


### PR DESCRIPTION
These modifications to Leduc are useful for reproducibility purposes. Leduc is commonly used with suit isomorphisms, and at least one important paper (the original NFSP paper) uses action mapping where all actions are regarded as legal, and otherwise illegal folds and raises are internally mapped to checks/calls by the game environment.

I’ve tried to implement these features with a light touch. None of the underlying game mechanics were changed. When the parameters are set to false, the game should function exactly as it did previously. 