### PR TITLE
move python path commands to before tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,9 @@ RUN mkdir -p build
 WORKDIR /repo/build
 RUN cmake -DPython_TARGET_VERSION=${PYVERSION} -DCMAKE_CXX_COMPILER=`which clang++` ../open_spiel 
 RUN make -j12
-RUN ctest -j12
 ENV PYTHONPATH=${PYTHONPATH}:/repo
 ENV PYTHONPATH=${PYTHONPATH}:/repo/build/python
+RUN ctest -j12
 WORKDIR /repo/open_spiel
 
 # minimal image for development in Python


### PR DESCRIPTION
This dockerfile build has been failing for me on the run_python_tests test. This edit fixes it.