### PR TITLE
FIX: Logging in tic_tac_toe example to print correct cross/nought info

### DIFF
--- a/open_spiel/python/examples/tic_tac_toe_dqn_vs_tabular.py
+++ b/open_spiel/python/examples/tic_tac_toe_dqn_vs_tabular.py
@@ -145,7 +145,7 @@ def main(_):
     # Play from the command line against the trained DQN agent.
     human_player = 1
     while True:
-      logging.info("You are playing as %s", "O" if human_player else "X")
+      logging.info("You are playing as %s", "X" if human_player else "0")
       time_step = env.reset()
       while not time_step.last():
         player_id = time_step.observations["current_player"]


### PR DESCRIPTION
Fix a small bug about the logging info being twisted (showing "You are playing as X" when actually the player plays 0) in the tic_tac_toe_dqn_vs_tabular.py example