### PR TITLE
Improve Swift Breakthrough Performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ cmake-build-*/
 dist/
 pyspiel.egg-info/
 
+# Swift build directory
+.build
+
  # External git modules
 open_spiel/abseil-cpp/
 open_spiel/games/bridge/double_dummy_solver/
@@ -38,8 +41,11 @@ open_spiel/scripts/jill.sh
 # julia wrapper
 Manifest.toml
 
+
 # IDE
 .idea/
 .vscode/
+*~
+
 
 open_spiel/cmake-build-debug/

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,25 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
+        "state": {
+          "branch": null,
+          "revision": "223d62adc52d51669ae2ee19bdb8b7d9fd6fcd9c",
+          "version": "0.0.6"
+        }
+      },
+      {
+        "package": "Benchmark",
+        "repositoryURL": "https://github.com/google/swift-benchmark.git",
+        "state": {
+          "branch": "master",
+          "revision": "f1e8d9a67d47fe51e9a2d7e5f2444a643db38277",
+          "version": null
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -34,6 +34,9 @@ let package = Package(
       name: "TexasHoldemBenchmark",
       targets: ["TexasHoldemBenchmark"]),
   ],
+  dependencies: [
+    .package(url: "https://github.com/google/swift-benchmark.git", .branch("master")),
+  ],
   targets: [
     .target(
       name: "OpenSpiel",
@@ -55,5 +58,9 @@ let package = Package(
       name: "TexasHoldemBenchmark",
       dependencies: ["OpenSpiel"],
       path: "swift/Examples/TexasHoldemBenchmark"),
+    .target(
+      name: "Benchmarks",
+      dependencies: ["OpenSpiel", "Benchmark"],
+      path: "swift/Benchmarks"),
   ]
 )

--- a/swift/Benchmarks/main.swift
+++ b/swift/Benchmarks/main.swift
@@ -1,0 +1,40 @@
+/// Benchmarks for OpenSpiel.
+///
+/// To run these from SwiftPM, execute:
+///
+///    swift run -c release -Xswiftc -cross-module-optimization Benchmarks
+///
+
+import Benchmark
+import OpenSpiel
+
+func playRandomGame<T: GameProtocol>(_ game: T) {
+  // TODO: Add custom benchmark metric tracking the number of turns done,
+  // which would be a far more fair comparison. For additional context,
+  // see: https://github.com/google/swift-benchmark/issues/11
+
+  var actionLimit = 1000  // Prevents some games from looping infinitely.
+  var state = game.initialState
+  while !state.isTerminal && actionLimit > 0 {
+    state.apply(state.legalActions.randomElement()!)
+    actionLimit -= 1
+  }
+}
+
+benchmark("random game: TicTacToe") {
+  playRandomGame(TicTacToe())
+}
+
+benchmark("random game: Kuhn Poker") {
+  playRandomGame(KuhnPoker())
+}
+
+benchmark("random game: Breakthrough") {
+  playRandomGame(Breakthrough())
+}
+
+benchmark("random game: Texas Hold'em") {
+  playRandomGame(TexasHoldem(playerCount: 3))
+}
+
+Benchmark.main()

--- a/swift/Sources/OpenSpiel/Breakthrough.swift
+++ b/swift/Sources/OpenSpiel/Breakthrough.swift
@@ -253,6 +253,7 @@ public extension Breakthrough.State {
   
   var legalActions: [Game.Action] {
     var actions = [Game.Action]()
+    actions.reserveCapacity(Int(game.boardWidth * game.boardHeight))
     let curBTPlayer = currentBTPlayer!
     for i in 0..<game.boardWidth {
       for j in 0..<game.boardHeight {

--- a/swift/Sources/OpenSpiel/Breakthrough.swift
+++ b/swift/Sources/OpenSpiel/Breakthrough.swift
@@ -250,6 +250,32 @@ public extension Breakthrough.State {
   var currentBTPlayer: Breakthrough.BreakthroughPlayer? {
     Breakthrough.BreakthroughPlayer(currentPlayer)
   }
+  
+  var legalActions: [Game.Action] {
+    var actions = [Game.Action]()
+    let curBTPlayer = currentBTPlayer!
+    for i in 0..<game.boardWidth {
+      for j in 0..<game.boardHeight {
+        let boardLoc = Breakthrough.BoardLocation(x: i, y: j)
+        // Skip all board locations that don't have a pawn that corresponds to the current player.
+        if self[boardLoc] != curBTPlayer { continue }
+        // Iterate across all possible directions.
+        for direction in Breakthrough.Direction.allCases {
+          // Compute the moved board location & verify it's still on the board.
+          guard case let movedBoardLoc? = boardLoc.move(in: direction, for: curBTPlayer),
+              game.isValid(location: movedBoardLoc) else { continue }
+          // If the moved board location is already occupied by one of our own pawns, it's
+          // not an available move.
+          if self[movedBoardLoc] == curBTPlayer { continue }
+          // If we're trying to move forward and it's not empty, it's not a valid move.
+          if direction == .forward && self[movedBoardLoc] != nil { continue }
+          // Append the available actions to the possible actions list.
+          actions.append(Game.Action(location: boardLoc, direction: direction))
+        }
+      }
+    }
+    return actions
+  }
 
   var legalActionsMask: [Bool] {
     let directionCount = Breakthrough.Direction.allCases.count

--- a/swift/Sources/OpenSpiel/Spiel.swift
+++ b/swift/Sources/OpenSpiel/Spiel.swift
@@ -109,6 +109,11 @@ public protocol StateProtocol: Hashable {
   /// the sampling of an outcome should be done in this function and then applied.
   mutating func apply(_ action: Game.Action)
 
+  /// All actions that are legal for the current player in this state.
+  ///
+  /// Default implementation provided.
+  var legalActions: [Game.Action] { get }
+
   /// An array of the same length as `game.allActions` representing which of those
   /// actions are legal for the current player in this state. Not valid in chance nodes.
   var legalActionsMask: [Bool] { get }


### PR DESCRIPTION
This PR defines some benchmarks for Swift OpenSpiel, and modestly improves Swift's `Breakthrough` performance.

On my machine, performance improves by ~1.65x based on the benchmarks:

Before:

```
name                      time        std        iterations
-----------------------------------------------------------
random game: Breakthrough 173380.0 ns ±  24.30 %       7276
```

After:

```
name                      time        std        iterations
-----------------------------------------------------------
random game: Breakthrough 104894.5 ns ±  24.74 %      13624
```

I suspect future optimizations are quite possible. In particular, I suspect flattening out `State.board` from being: `Array<Optional<BreakthroughPlayer>>` to `Array<FlattenedEnum>` might help, but have not tried that yet.

Issue: https://github.com/deepmind/open_spiel/issues/228