### PR TITLE
catan-support

### DIFF
--- a/open_spiel/games/CMakeLists.txt
+++ b/open_spiel/games/CMakeLists.txt
@@ -11,6 +11,8 @@ set(GAME_SOURCES
   bridge/bridge_scoring.h
   bridge_uncontested_bidding.cc
   bridge_uncontested_bidding.h
+  catan.cc
+  catan.h
   catch.cc
   catch.h
   chess.cc
@@ -196,6 +198,10 @@ add_test(breakthrough_test breakthrough_test)
 add_executable(bridge_test bridge_test.cc ${OPEN_SPIEL_OBJECTS}
                $<TARGET_OBJECTS:tests>)
 add_test(bridge_test bridge_test)
+
+add_executable(catan_test catan_test.cc ${OPEN_SPIEL_OBJECTS}
+               $<TARGET_OBJECTS:tests>)
+add_test(catan_test catan_test)
 
 add_executable(catch_test catch_test.cc ${OPEN_SPIEL_OBJECTS}
                $<TARGET_OBJECTS:tests>)

--- a/open_spiel/games/catan.cc
+++ b/open_spiel/games/catan.cc
@@ -1,0 +1,341 @@
+// Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "open_spiel/games/catan.h"
+
+#include <utility>
+#include <random>
+
+#include "open_spiel/game_parameters.h"
+#include "open_spiel/spiel.h"
+#include "open_spiel/spiel_utils.h"
+#include "open_spiel/utils/tensor_view.h"
+
+namespace open_spiel {
+namespace catan {
+namespace {
+
+// Facts about the game.
+const GameType kGameType{
+    /*short_name=*/"catan",
+    /*long_name=*/"The Settlers of Catan",
+    GameType::Dynamics::kSequential,
+    GameType::ChanceMode::kExplicitStochastic,
+    GameType::Information::kImperfectInformation,
+    GameType::Utility::kGeneralSum,
+    GameType::RewardModel::kRewards,
+    /*max_num_players=*/4,
+    /*min_num_players=*/2,
+    /*provides_information_state_string=*/false,
+    /*provides_information_state_tensor=*/false,
+    /*provides_observation_string=*/true,
+    /*provides_observation_tensor=*/true,
+    /*parameter_specification=*/
+    {
+      {"players", GameParameter(4, false)},
+      {"max_turns", GameParameter(72, false)},
+      {"random_start_player", GameParameter(false, false)},
+      {"example_board", GameParameter(true, false)},
+      {"example_starting_positions", GameParameter(true, false)},
+      {"harbor_support", GameParameter(true, false)},
+      {"robber_support", GameParameter(true, false)},
+      {"development_card_support", GameParameter(true, false)},
+    }
+};
+
+std::shared_ptr<const Game> Factory(const GameParameters& params) {
+  return std::shared_ptr<const Game>(new CatanGame(params));
+}
+
+REGISTER_SPIEL_GAME(kGameType, Factory);
+
+}  // namespace
+
+CatanGame::CatanGame(const GameParameters& params) : Game(kGameType, params){
+  this->num_players_ = ParameterValue<int>("players");
+}
+
+std::unique_ptr<State> CatanGame::NewInitialState() const {
+   return std::unique_ptr<State>(new CatanState(shared_from_this(),
+      ParameterValue<int>("players"),
+      ParameterValue<int>("max_turns"),
+      ParameterValue<bool>("random_start_player"),
+      ParameterValue<bool>("example_board"),
+      ParameterValue<bool>("example_starting_positions"),
+      ParameterValue<bool>("harbor_support"),
+      ParameterValue<bool>("robber_support"),
+      ParameterValue<bool>("development_card_support")));
+}
+
+std::shared_ptr<const Game> CatanGame::Clone() const {
+  return std::shared_ptr<Game>(new CatanGame(GetParameters()));
+}
+
+CatanState::CatanState(std::shared_ptr<const Game> game,
+  int players,
+  int max_turns,
+  bool random_start_player,
+  bool example_board,
+  bool example_starting_positions,
+  bool harbor_support,
+  bool robber_support,
+  bool development_card_support):
+  State(game), catan_env_(players, example_board, example_starting_positions, harbor_support, robber_support, development_card_support),
+  prev_state_score_(players, 0), enc_(&catan_env_) {
+
+  this->max_turns = max_turns;
+  if (random_start_player) {
+    if (example_starting_positions) {
+      this->previous_player_ = this->RandomPlayer();
+    }
+    else {
+      this->current_player_ = this->RandomPlayer();
+    }
+  }
+
+  if (example_starting_positions) {
+    for (int i = 0; i < players; i++) {
+      this->prev_state_score_[i] = 2.0; // the first two settlements are already placed
+    }
+    this->current_player_ = kChancePlayerId; // we start with a dice roll
+  }
+}
+
+Player CatanState::RandomPlayer() const {
+  std::random_device rd;
+  std::mt19937 eng(rd());
+  std::uniform_int_distribution<> distr(0, this->catan_env_.players.size()-1);
+
+  return distr(eng);
+}
+
+std::vector<Action> CatanState::LegalActions() const {
+  if (this->IsTerminal()){
+    return {};
+  } else if (IsChanceNode()) {
+    ActionsAndProbs outcomes_and_probs = this->ChanceOutcomes();
+    const int n = outcomes_and_probs.size();
+    std::vector<Action> chance_outcomes;
+    chance_outcomes.reserve(n);
+    for (int i = 0; i < n; i++) {
+      chance_outcomes.emplace_back(outcomes_and_probs.at(i).first);
+    }
+    return chance_outcomes;
+  } else {
+    return this->catan_env_.get_legal_actions(this->CurrentPlayer());
+  }
+}
+
+std::string CatanState::ActionToString(Player player,Action action_id) const {
+  return this->catan_env_.action_to_string(player, action_id);
+}
+
+std::vector<double> CatanState::Rewards() const {
+  std::vector<double> rewards;
+  for (int i = 0; i < this->catan_env_.players.size(); i++){
+    rewards.emplace_back(this->catan_env_.players[i].get_VP(true) - this->prev_state_score_[i]);
+  }
+  return rewards;
+}
+
+std::vector<double> CatanState::Returns() const {
+  std::vector<double> returns;
+  for (int i = 0; i < this->catan_env_.players.size(); i++){
+    if (this->setup_phase_counter_ == 0) { //if there we use the example_starting_positions, so there was no setup phase
+      returns.emplace_back(this->catan_env_.players[i].get_VP(true) - 2); // the players start with two settlements and therefore two victory points
+    }
+    else {
+      returns.emplace_back(this->catan_env_.players[i].get_VP(true));
+    }
+  }
+  return returns;
+}
+
+void CatanState::DoApplyAction(Action move) {
+  if (this->turns_ >= this->max_turns) {
+    this->catan_env_.has_ended = true; // end the game if the max_turns are reached
+  }
+  if (move == 0) {
+    this->turns_++; // a player ends his turn
+  }
+  if (!IsChanceNode()){
+    for (int i = 0; i < this->catan_env_.players.size(); i++){
+      this->prev_state_score_[i] = this->catan_env_.players[i].get_VP(true);
+    }
+  }
+
+  // if we are resolving a road building card decrease the roads to build value
+  if (this->catan_env_.resolve_road_building) {
+    this->catan_env_.roads_to_build--;
+  }
+
+  // apply the action
+  this->catan_env_.apply_action(this->current_player_, move);
+
+  // if we are in the setup phase
+  if (this->catan_env_.is_starting) {
+    // check if a settlement was placed and if yes switch to road placement
+    if (this->catan_env_.is_starting_settlement_placement) {
+      this->catan_env_.is_starting_settlement_placement = false;
+      this->catan_env_.is_starting_road_placement = true;
+    }
+    // check if a road was placed
+    else if (this->catan_env_.is_starting_road_placement) {
+      // switch to settlement placement
+      this->catan_env_.is_starting_road_placement = false;
+      this->catan_env_.is_starting_settlement_placement = true;
+      // check if players are placing their second road
+      if (this->catan_env_.is_starting_round_two) {
+        //check if everyone placed their second road and settlement if yes end the setup phase
+        if (this->setup_phase_counter_ == 4 * this->catan_env_.players.size() - 1) {
+          this->catan_env_.is_starting = false;
+          this->catan_env_.is_starting_round_two = false;
+          this->catan_env_.is_starting_road_placement = false;
+          this->catan_env_.is_starting_settlement_placement = false;
+          this->previous_player_ = PreviousPlayerRoundRobin(this->current_player_, this->catan_env_.players.size());
+          this->current_player_ = kChancePlayerId;
+          return;
+        }
+        // we are in the second round and go select the next player backwards
+        this->current_player_ = PreviousPlayerRoundRobin(this->current_player_, this->catan_env_.players.size());
+      }
+      // check if the last player placed his first road if yes switch to second round
+      if (this->setup_phase_counter_ == 2 * this->catan_env_.players.size() - 1) {
+        this->catan_env_.is_starting_round_two = true;
+      }
+      // if we are not in the second round switch to the next player
+      else if (!this->catan_env_.is_starting_round_two){
+        this->current_player_ = NextPlayerRoundRobin(this->current_player_, this->catan_env_.players.size());
+      }
+    }
+    // increment the counter so we can determine when the setup phase should end
+    this->setup_phase_counter_++;
+    return;
+  }
+
+  // if we are resolving road building unset the boolean if all roads were build otherwise return, to start next road building action
+  if (this->catan_env_.resolve_road_building) {
+    if (this->catan_env_.roads_to_build == 0) {
+      this->catan_env_.resolve_road_building = false;
+    }
+    return;
+  }
+
+  // if we are currently resolving a seven discard we count down the discards
+  if(this->to_discard_counter_ > 0) {
+    this->to_discard_counter_--;
+    return;
+  }
+
+
+  // if we are resolving a seven everyone with more than 7 cards needs to discard half his cards (rounded down)
+  if(this->catan_env_.resolving_seven) {
+    this->catan_env_.resolving_seven = false;
+    for (unsigned int i = 0; i < this->catan_env_.players.size(); i++){
+      int handsize = this->catan_env_.players.at(i).cards.size();
+      if (handsize >= 8) {
+        this->catan_env_.resolving_seven = true;
+        this->to_discard_counter_ = (int)std::floor(handsize/2) -1;
+        this->current_player_ = i;
+        return;
+      }
+    }
+    // resolving seven is over, next player's turn starts
+    this->current_player_ = NextPlayerRoundRobin(this->previous_player_, this->catan_env_.players.size());
+    return;
+  }
+
+  // card stealing with robber needs to be resolved, this is a chance node
+  if (this->catan_env_.resolve_stealing) {
+    this->previous_player_ = this->current_player_;
+    this->current_player_ = kChancePlayerId;
+    return;
+  }
+
+  // after chance node stealing a card, back to the player who's turn it is
+  if (333 <= move && move <= 338) {
+    this->current_player_ = this->previous_player_;
+    return;
+  }
+
+  // if the player buys a development card we go to a chance node
+  if (move == 339) {
+    this->catan_env_.current_player = this->current_player_;
+    this->previous_player_ = this->current_player_;
+    this->current_player_ = kChancePlayerId;
+    this->buying_a_development_card = true;
+    return;
+  }
+
+  // after chance node drawing a development card, back to the player who's turn it is
+  if (363 <= move && move <= 367) {
+    this->buying_a_development_card = false;
+    this->current_player_ = this->previous_player_;
+    return;
+  }
+
+  // if we rolled the dice the next player's turn starts
+  if (IsChanceNode()) {
+    this->current_player_ = NextPlayerRoundRobin(this->previous_player_, this->catan_env_.players.size());
+  }
+  if (move == 0) {
+    this->previous_player_ = this->current_player_;
+    this->current_player_ = kChancePlayerId;
+  }
+}
+
+std::string CatanState::ObservationString(Player player) const {
+  SPIEL_CHECK_GE(player, 0);
+  SPIEL_CHECK_LT(player, this->catan_env_.players.size());
+
+  return this->ToString();
+}
+
+void CatanState::ObservationTensor(Player player, std::vector<double>* values) const {
+  SPIEL_CHECK_GE(player, 0);
+  SPIEL_CHECK_LT(player, this->catan_env_.players.size());
+
+  auto obs = this->enc_.Encode(player);
+  values->resize(obs.size());
+  for (int i = 0; i < obs.size(); ++i) values->at(i) = obs[i];
+}
+
+std::unique_ptr<State> CatanState::Clone() const {
+  return std::unique_ptr<State>(new CatanState(*this));
+}
+
+ActionsAndProbs CatanState::ChanceOutcomes() const {
+  SPIEL_CHECK_TRUE(IsChanceNode());
+
+  if (this->catan_env_.resolve_stealing) {
+    return catan_env_.random_card_actions_and_probs_from_victim();
+  }
+  else if (this->buying_a_development_card) {
+    return catan_env_.dev_cards_actions_and_probs();
+  }
+  else {
+    return this->catan_env_.dice_roll_actions_and_probs();
+  }
+}
+
+std::string CatanState::ToString() const {
+  return this->catan_env_.to_string();
+}
+
+bool CatanState::IsTerminal() const {
+  return this->catan_env_.has_ended;
+}
+
+}  // namespace catan
+}  // namespace open_spiel

--- a/open_spiel/games/catan.h
+++ b/open_spiel/games/catan.h
@@ -1,0 +1,104 @@
+// Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OPEN_SPIEL_GAMES_CATAN_H_
+#define OPEN_SPIEL_GAMES_CATAN_H_
+
+#include <string>
+#include <vector>
+
+#include "open_spiel/spiel.h"
+
+#include "open_spiel/games/catan/PyCatanToC-/CatanGameEnv.h"
+#include "open_spiel/games/catan/PyCatanToC-/CatanEncoder.h"
+
+// CATAN, formerly The Settlers of Catan
+// https://www.catan.com/
+//
+// Parameters:
+//    "players"                     int      number of players in the game              (default=4)
+//    "max_turns"                   int      maximal number of turns a game should last (default=72)
+//    "random_start_player"         bool     if the start player is random              (default=false)
+//    "example_board"               bool     if the example board is used               (default=true)
+//    "example_starting_positions"  bool     if the start positions are fixed           (default=false)
+//    "harbor_support"              bool     if harbors can be used                     (default=true)
+//    "robber_support"              bool     if the robber can be used                  (default=true)
+//    "development_card_support"    bool     if development cards can be bought         (default=true)
+
+namespace open_spiel {
+namespace catan {
+
+// Game object.
+class CatanGame : public Game {
+  public:
+    explicit CatanGame(const GameParameters& params);
+    int NumDistinctActions() const override { return 368; } // hardcoded because CatanGame can not access catan_env_
+    std::unique_ptr<State> NewInitialState() const override;
+    int NumPlayers() const override { return this->num_players_; }
+    double MinUtility() const override { return 0; } // with setup phase players can have a minimum of 2,
+                                                     // with the example_starting_positions enabled players can have a minimum of 0
+    double MaxUtility() const override { return 10; } // like with the min utility player can reach 8 or 10
+    std::shared_ptr<const Game> Clone() const override;
+    std::vector<int> ObservationTensorShape() const override {
+      return {2576}; // hardcoded because CatanGame can not access catan_env_
+    }
+    int MaxGameLength() const override { return 100000; } // a game could take forever,
+                                                          // with random action selection a game with 4 players takes on average about 1145 actions
+                                                          // through the max_turns parameter it is also capped
+    int num_players_;
+  };
+
+// State of an in-play game.
+class CatanState : public State {
+ public:
+  explicit CatanState(std::shared_ptr<const Game> game, int players, int max_turns,
+     bool random_start_player, bool example_board, bool example_starting_positions,
+     bool harbor_support, bool robber_support, bool development_card_support);
+  explicit CatanState(const CatanState&) = default;
+  Player RandomPlayer() const;
+  Player CurrentPlayer() const override {
+    return this->IsTerminal() ? kTerminalPlayerId : this->current_player_;
+  }
+  std::vector<Action> LegalActions() const override;
+  std::string ActionToString(Player player, Action action_id) const override;
+  std::vector<double> Rewards() const override;
+  std::vector<double> Returns() const override;
+  std::string ObservationString(Player player) const override;
+  void ObservationTensor(Player player,std::vector<double>* values) const override;
+  std::unique_ptr<State> Clone() const override;
+  ActionsAndProbs ChanceOutcomes() const;
+  std::string ToString() const override;
+  bool IsTerminal() const override;
+
+ protected:
+  void DoApplyAction(Action move) override;
+
+ private:
+  CatanGameEnv catan_env_;
+  CatanEncoder enc_;
+  Player current_player_ = 0;
+  Player previous_player_ = 0; // used to determine the next player or return to the previous in chance nodes
+  std::vector<double> prev_state_score_; //saves the last score to calculate the next in the reward function
+  int turns_ = 0; // counts the number of player turns, a turn ends if a player selects action 0
+  int to_discard_counter_ = 0; // the amount of cards the current player has
+                               // still to discard due to a seven
+  bool buying_a_development_card = false; //for the chance node to distinguish between chance events
+  int setup_phase_counter_ = 0; // for the setup phase to determine when the player have place their second settlement and road
+  int max_turns = 72; // to cap the maximum number of turns
+};
+
+}  // namespace catan
+}  // namespace open_spiel
+
+#endif  // OPEN_SPIEL_GAMES_CATAN_H_

--- a/open_spiel/games/catan_test.cc
+++ b/open_spiel/games/catan_test.cc
@@ -1,0 +1,36 @@
+// Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "open_spiel/spiel.h"
+#include "open_spiel/tests/basic_tests.h"
+
+namespace open_spiel {
+namespace catan {
+namespace {
+
+namespace testing = open_spiel::testing;
+
+void BasicCatanTests() {
+  testing::LoadGameTest("catan");
+  testing::NoChanceOutcomesTest(*LoadGame("catan"));
+  testing::RandomSimTest(*LoadGame("catan"), 100);
+}
+
+}  // namespace
+}  // namespace catan
+}  // namespace open_spiel
+
+int main(int argc, char** argv) {
+  open_spiel::catan::BasicCatanTests();
+}

--- a/open_spiel/python/tests/pyspiel_test.py
+++ b/open_spiel/python/tests/pyspiel_test.py
@@ -38,6 +38,7 @@ class PyspielTest(absltest.TestCase):
         "breakthrough",
         "bridge",
         "bridge_uncontested_bidding",
+        "catan",
         "catch",
         "chess",
         "cliff_walking",


### PR DESCRIPTION
Pull request for deepmind/open_spiel#192 .
I omitted the CATAN implementation since it is not clear if I am allowed to upload it. These files are able to handle all features of the CATAN base game with my implementation, except players trading with each other. I am looking forward to suggestions and corrections.