### PR TITLE
goofspiel: fix current point card

### DIFF
--- a/open_spiel/games/goofspiel.cc
+++ b/open_spiel/games/goofspiel.cc
@@ -432,8 +432,15 @@ std::string GoofspielState::ObservationString(Player player) const {
   //   - everyone's current points
   //   - my current hand
   //   - current win sequence
+  int curr_point_card_;
+  if (!point_card_sequence_.empty()) {
+	curr_point_card_ = point_card_sequence_.back();
+  }
+  else {
+	curr_point_card_ = 0;
+  }
   std::string current_trick =
-      absl::StrCat("Current point card: ", point_card_sequence_.back());
+      absl::StrCat("Current point card: ", curr_point_card_);
   std::string points_line = "Points: ";
   std::string hands = "";
   std::string win_seq = "Win Sequence: ";
@@ -576,9 +583,18 @@ void GoofspielState::ObservationTensor(Player player,
   //   - current win sequence
 
   // Current point card.
-  for (int i = 0; i < num_cards_; ++i) {
-    values->push_back(i == point_card_sequence_.back() ? 1.0 : 0.0);
+  int curr_point_card_;
+  if (!point_card_sequence_.empty()) {
+	curr_point_card_ = point_card_sequence_.back();
   }
+  else {
+	curr_point_card_ = 0;
+  }
+	
+  for (int i = 0; i < num_cards_; ++i) {
+	values->push_back(i == (curr_point_card_ - 1) ? 1.0 : 0.0);
+  }
+
 
   // Point totals: one-hot vector encoding points, per player.
   Player p = player;

--- a/open_spiel/games/goofspiel.cc
+++ b/open_spiel/games/goofspiel.cc
@@ -433,7 +433,7 @@ std::string GoofspielState::ObservationString(Player player) const {
   //   - my current hand
   //   - current win sequence
   std::string current_trick =
-      absl::StrCat("Current point card: ", point_card_index_ + 1);
+      absl::StrCat("Current point card: ", point_card_sequence_.back());
   std::string points_line = "Points: ";
   std::string hands = "";
   std::string win_seq = "Win Sequence: ";
@@ -577,7 +577,7 @@ void GoofspielState::ObservationTensor(Player player,
 
   // Current point card.
   for (int i = 0; i < num_cards_; ++i) {
-    values->push_back(i == point_card_index_ ? 1.0 : 0.0);
+    values->push_back(i == point_card_sequence_.back() ? 1.0 : 0.0);
   }
 
   // Point totals: one-hot vector encoding points, per player.


### PR DESCRIPTION
When returning the current point card, the methods `ObservationString` and `ObservationTensor` look at the index of the current point card in a data structure that contains only the remaining cards, and increment it. The returned value does not always correspond to the actual value of the current point card however, especially after the first couple of moves.

One way to fix that is what I did: `ObservationString` and `ObservationTensor` now access the last element of the same vector that is also accessed by `InformationStateString` and `InformationStateTensor,` which contains the values of the point card sequence.

It is my first time contributing to a public repo. I'm sorry if I unknowingly breached some guidelines or rules.