### PR TITLE
Add python bindings for MCCFR solvers

### DIFF
--- a/open_spiel/python/examples/mccfr_cpp_example.py
+++ b/open_spiel/python/examples/mccfr_cpp_example.py
@@ -1,0 +1,59 @@
+# Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Example use of the External Sampling MCCCFR algorithm on Kuhn Poker."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from absl import app
+from absl import flags
+
+import pyspiel
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_enum(
+    'sampling', 'external',
+    ['external', 'outcome'],
+    'Sampling for the MCCFR solver',
+)
+flags.DEFINE_integer("iterations", 50, "Number of iterations")
+flags.DEFINE_string("game", "kuhn_poker", "Name of the game")
+flags.DEFINE_integer("players", 2, "Number of players")
+
+
+def main(_):
+    game = pyspiel.load_game(
+        FLAGS.game,
+        {"players": pyspiel.GameParameter(FLAGS.players)},
+    )
+
+    if (FLAGS.sampling == 'external'):
+        solver = pyspiel.ExternalSamplingMCCFRSolver(
+            game,
+            avg_type=pyspiel.MCCFRAverageType.FULL,
+        )
+    elif(FLAGS.sampling == 'outcome'):
+        solver = pyspiel.OutcomeSamplingMCCFRSolver(game)
+
+    for i in range(FLAGS.iterations):
+        solver.run_iteration()
+        print("Iteration {} exploitability: {:.6f}".format(
+            i, pyspiel.exploitability(game, solver.average_policy())))
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/open_spiel/python/pybind11/policy.cc
+++ b/open_spiel/python/pybind11/policy.cc
@@ -21,8 +21,10 @@
 #include "open_spiel/algorithms/cfr_br.h"
 #include "open_spiel/algorithms/deterministic_policy.h"
 #include "open_spiel/algorithms/expected_returns.h"
+#include "open_spiel/algorithms/external_sampling_mccfr.h"
 #include "open_spiel/algorithms/is_mcts.h"
 #include "open_spiel/algorithms/mcts.h"
+#include "open_spiel/algorithms/outcome_sampling_mccfr.h"
 #include "open_spiel/algorithms/tabular_exploitability.h"
 #include "open_spiel/policy.h"
 #include "open_spiel/spiel.h"
@@ -113,6 +115,33 @@ void init_pyspiel_policy(py::module& m) {
       .def("current_policy", &open_spiel::algorithms::CFRSolver::CurrentPolicy)
       .def("average_policy",
            &open_spiel::algorithms::CFRPlusSolver::AveragePolicy);
+
+  py::enum_<open_spiel::algorithms::AverageType>(m, "MCCFRAverageType")
+      .value("SIMPLE", open_spiel::algorithms::AverageType::kSimple)
+      .value("FULL", open_spiel::algorithms::AverageType::kFull);
+
+  py::class_<open_spiel::algorithms::ExternalSamplingMCCFRSolver>(
+      m, "ExternalSamplingMCCFRSolver")
+      .def(py::init<const Game&, int, open_spiel::algorithms::AverageType>(),
+           py::arg("game"), py::arg("seed") = 0,
+           py::arg("avg_type") = open_spiel::algorithms::AverageType::kSimple)
+      .def("run_iteration",
+           py::overload_cast<>(&open_spiel::algorithms::
+                                   ExternalSamplingMCCFRSolver::RunIteration))
+      .def("average_policy",
+           &open_spiel::algorithms::ExternalSamplingMCCFRSolver::AveragePolicy);
+
+  py::class_<open_spiel::algorithms::OutcomeSamplingMCCFRSolver>(
+      m, "OutcomeSamplingMCCFRSolver")
+      .def(py::init<const Game&, double, int>(), py::arg("game"),
+           py::arg("epsilon") = open_spiel::algorithms::
+               OutcomeSamplingMCCFRSolver::kDefaultEpsilon,
+           py::arg("seed") = -1)
+      .def("run_iteration",
+           py::overload_cast<>(&open_spiel::algorithms::
+                                   OutcomeSamplingMCCFRSolver::RunIteration))
+      .def("average_policy",
+           &open_spiel::algorithms::OutcomeSamplingMCCFRSolver::AveragePolicy);
 
   m.def("expected_returns",
         py::overload_cast<const State&, const std::vector<const Policy*>&, int,


### PR DESCRIPTION
It is a bit cumbersome to expose the second constructor for both types since they accept a shared pointer to a custom default `Policy` instance and the default binding holder type for `Policy` is a unique pointer. Changing the holder type to a shared pointer works but breaks at least all CFR solvers `AveragePolicy()` bindings since unique pointers are returned. For this reason, I didn't add bindings for these two constructors and it is thus only possible to construct instances with the default `UniformPolicy` within python. Please let me know if there is a known, simpler solution for this.