### PR TITLE
Added a PolicyBot for python

### DIFF
--- a/open_spiel/algorithms/cfr.h
+++ b/open_spiel/algorithms/cfr.h
@@ -127,15 +127,15 @@ class CFRSolverBase {
   // Computes the average policy, containing the policy for all players.
   // The returned policy instance should only be used during the lifetime of
   // the CFRSolver object.
-  std::unique_ptr<Policy> AveragePolicy() const {
-    return std::unique_ptr<Policy>(new CFRAveragePolicy(info_states_, nullptr));
+  std::shared_ptr<Policy> AveragePolicy() const {
+    return std::shared_ptr<Policy>(new CFRAveragePolicy(info_states_, nullptr));
   }
 
   // Computes the current policy, containing the policy for all players.
   // The returned policy instance should only be used during the lifetime of
   // the CFRSolver object.
-  std::unique_ptr<Policy> CurrentPolicy() const {
-    return std::unique_ptr<Policy>(new CFRCurrentPolicy(info_states_, nullptr));
+  std::shared_ptr<Policy> CurrentPolicy() const {
+    return std::shared_ptr<Policy>(new CFRCurrentPolicy(info_states_, nullptr));
   }
 
  protected:

--- a/open_spiel/algorithms/cfr_br.cc
+++ b/open_spiel/algorithms/cfr_br.cc
@@ -37,7 +37,7 @@ void CFRBRSolver::EvaluateAndUpdatePolicy() {
   ++iteration_;
 
   std::vector<TabularPolicy> br_policies(game_.NumPlayers());
-  std::unique_ptr<Policy> current_policy = CurrentPolicy();
+  std::shared_ptr<Policy> current_policy = CurrentPolicy();
 
   // Set all the player's policies first.
   for (int p = 0; p < game_.NumPlayers(); ++p) {

--- a/open_spiel/algorithms/cfr_br_test.cc
+++ b/open_spiel/algorithms/cfr_br_test.cc
@@ -40,7 +40,7 @@ void CFRBRTest_KuhnPoker() {
   for (int i = 0; i < 300; i++) {
     solver.EvaluateAndUpdatePolicy();
   }
-  const std::unique_ptr<Policy> average_policy = solver.AveragePolicy();
+  const std::shared_ptr<Policy> average_policy = solver.AveragePolicy();
   // 1/18 is the Nash value. See https://en.wikipedia.org/wiki/Kuhn_poker
   CheckNashValues(*game, *average_policy, -1.0 / 18, 0.001);
   SPIEL_CHECK_LE(Exploitability(*game, *average_policy), 0.05);
@@ -53,7 +53,7 @@ void CFRBRTest_LeducPoker() {
   for (int i = 0; i < num_iters; i++) {
     solver.EvaluateAndUpdatePolicy();
   }
-  const std::unique_ptr<Policy> average_policy = solver.AveragePolicy();
+  const std::shared_ptr<Policy> average_policy = solver.AveragePolicy();
   double nash_conv = NashConv(*game, *average_policy);
   std::cout << "Iters " << num_iters << ", nash_conv = " << nash_conv
             << std::endl;

--- a/open_spiel/algorithms/cfr_test.cc
+++ b/open_spiel/algorithms/cfr_test.cc
@@ -56,7 +56,7 @@ void CFRTest_KuhnPoker() {
   for (int i = 0; i < 300; i++) {
     solver.EvaluateAndUpdatePolicy();
   }
-  const std::unique_ptr<Policy> average_policy = solver.AveragePolicy();
+  const std::shared_ptr<Policy> average_policy = solver.AveragePolicy();
   CheckNashKuhnPoker(*game, *average_policy);
   CheckExploitabilityKuhnPoker(*game, *average_policy);
 }
@@ -73,7 +73,7 @@ void CFRTest_IIGoof4() {
     solver.EvaluateAndUpdatePolicy();
   }
   // Values checked with Marc's thesis implementation.
-  const std::unique_ptr<Policy> average_policy = solver.AveragePolicy();
+  const std::shared_ptr<Policy> average_policy = solver.AveragePolicy();
   SPIEL_CHECK_LE(Exploitability(*game, *average_policy), 0.1);
 
   // Fixed points order.
@@ -87,7 +87,7 @@ void CFRTest_IIGoof4() {
     solver2.EvaluateAndUpdatePolicy();
   }
   // Values checkes with Marc's thesis implementation.
-  const std::unique_ptr<Policy> average_policy2 = solver2.AveragePolicy();
+  const std::shared_ptr<Policy> average_policy2 = solver2.AveragePolicy();
   SPIEL_CHECK_LE(Exploitability(*game, *average_policy2), 0.01);
 }
 
@@ -97,7 +97,7 @@ void CFRPlusTest_KuhnPoker() {
   for (int i = 0; i < 200; i++) {
     solver.EvaluateAndUpdatePolicy();
   }
-  const std::unique_ptr<Policy> average_policy = solver.AveragePolicy();
+  const std::shared_ptr<Policy> average_policy = solver.AveragePolicy();
   CheckNashKuhnPoker(*game, *average_policy);
   CheckExploitabilityKuhnPoker(*game, *average_policy);
 }
@@ -113,7 +113,7 @@ void CFRTest_KuhnPokerRunsWithThreePlayers(bool linear_averaging,
   for (int i = 0; i < 10; i++) {
     solver.EvaluateAndUpdatePolicy();
   }
-  std::unique_ptr<Policy> average_policy = solver.AveragePolicy();
+  std::shared_ptr<Policy> average_policy = solver.AveragePolicy();
   // Value upper-bounds inspired by Fig 2 of (Srinivasan et al., Actor-Critic
   // Policy Optimization in Partially Observable Multiagent Environments, 2018)
   // https://arxiv.org/abs/1810.09026
@@ -136,7 +136,7 @@ void CFRTest_GeneralMultiplePlayerTest(const std::string& game_name,
   }
 
   if (nashconv_upper_bound > 0) {
-    std::unique_ptr<Policy> average_policy = solver.AveragePolicy();
+    std::shared_ptr<Policy> average_policy = solver.AveragePolicy();
     SPIEL_CHECK_LE(NashConv(*game, *average_policy), nashconv_upper_bound);
   }
 }
@@ -156,7 +156,7 @@ void CFRTest_OneShotGameTest(int iterations, std::string one_shot_game,
   for (int i = 0; i < iterations; i++) {
     solver.EvaluateAndUpdatePolicy();
     if (i % 10 == 0) {
-      std::unique_ptr<Policy> average_policy = solver.AveragePolicy();
+      std::shared_ptr<Policy> average_policy = solver.AveragePolicy();
       nash_conv = NashConv(*game, *average_policy);
       std::cout << "iter " << i << ", nashconv = " << nash_conv << std::endl;
     }
@@ -177,7 +177,7 @@ void CFRTest_TicTacToe(int num_iterations, double nashconv_upper_bound) {
   }
 
   if (nashconv_upper_bound > 0) {
-    std::unique_ptr<Policy> average_policy = solver.AveragePolicy();
+    std::shared_ptr<Policy> average_policy = solver.AveragePolicy();
     SPIEL_CHECK_LE(NashConv(*game, *average_policy), nashconv_upper_bound);
   }
 }

--- a/open_spiel/python/bots/policy.py
+++ b/open_spiel/python/bots/policy.py
@@ -1,0 +1,69 @@
+# Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A bot that samples from legal actions based on a policy."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import pyspiel
+
+
+class PolicyBot(pyspiel.Bot):
+  """Samples an action from action probabilities based on a policy."""
+
+  def __init__(self, player_id, rng, policy):
+    """Initializes a policy bot.
+
+    Args:
+      player_id: The integer id of the player for this bot, e.g. `0` if acting
+        as the first player.
+      rng: A random number generator supporting a `choice` method, e.g.
+        `np.random`
+      policy: A policy to get action distributions
+    """
+    pyspiel.Bot.__init__(self)
+    self._player_id = player_id
+    self._rng = rng
+    self._policy = policy
+
+  def player_id(self):
+    return self._player_id
+
+  def restart_at(self, state):
+    pass
+
+  def step_with_policy(self, state):
+    """Returns the stochastic policy and selected action in the given state.
+
+    Args:
+      state: The current state of the game.
+
+    Returns:
+      A `(policy, action)` pair, where policy is a `list` of
+      `(action, probability)` pairs for each legal action, with
+      `probability` defined by the policy action probabilities.
+      The `action` is sampled from the distribution,
+      or `pyspiel.INVALID_ACTION` if there are no legal actions available.
+    """
+    legal_actions = state.legal_actions(self._player_id)
+    if not legal_actions:
+      return [], pyspiel.INVALID_ACTION
+    policy = self._policy.action_probabilities(state, self._player_id)
+    action = self._rng.choice(legal_actions, p=list(policy.values()))
+    return list(policy.items()), action
+
+  def step(self, state):
+    return self.step_with_policy(state)[1]

--- a/open_spiel/python/pybind11/bots.cc
+++ b/open_spiel/python/pybind11/bots.cc
@@ -215,5 +215,8 @@ void init_pyspiel_bots(py::module& m) {
 
   m.def("make_stateful_random_bot", open_spiel::MakeStatefulRandomBot,
         "A stateful random bot, for test purposes.");
+  
+  m.def("make_policy_bot", open_spiel::MakePolicyBot,
+        "A bot that samples from a policy.");
 }
 }  // namespace open_spiel

--- a/open_spiel/python/pybind11/policy.cc
+++ b/open_spiel/python/pybind11/policy.cc
@@ -61,7 +61,8 @@ void init_pyspiel_policy(py::module& m) {
       .def("set_policy",
            py::overload_cast<const Policy*>(&TabularBestResponse::SetPolicy));
 
-  py::class_<open_spiel::Policy>(m, "Policy")
+  py::class_<open_spiel::Policy, 
+             std::shared_ptr<open_spiel::Policy>>(m, "Policy")
       .def("action_probabilities",
            (std::unordered_map<Action, double>(open_spiel::Policy::*)(
                const open_spiel::State&) const) &
@@ -80,14 +81,18 @@ void init_pyspiel_policy(py::module& m) {
   // [num_states, num_actions], while this is implemented as a map. It is
   // non-trivial to convert between the two, but we have a function that does so
   // in the open_spiel/python/policy.py file.
-  py::class_<open_spiel::TabularPolicy, open_spiel::Policy>(m, "TabularPolicy")
+  py::class_<open_spiel::TabularPolicy, 
+             std::shared_ptr<open_spiel::TabularPolicy>, 
+             open_spiel::Policy>(m, "TabularPolicy")
       .def(py::init<const std::unordered_map<std::string, ActionsAndProbs>&>())
       .def("get_state_policy", &open_spiel::TabularPolicy::GetStatePolicy)
       .def("policy_table",
            py::overload_cast<>(&open_spiel::TabularPolicy::PolicyTable));
 
   m.def("UniformRandomPolicy", &open_spiel::GetUniformPolicy);
-  py::class_<open_spiel::UniformPolicy, open_spiel::Policy>(m, "UniformPolicy")
+  py::class_<open_spiel::UniformPolicy, 
+             std::shared_ptr<open_spiel::UniformPolicy>, 
+             open_spiel::Policy>(m, "UniformPolicy")
       .def(py::init<>())
       .def("get_state_policy", &open_spiel::UniformPolicy::GetStatePolicy);
 

--- a/open_spiel/spiel_bots.cc
+++ b/open_spiel/spiel_bots.cc
@@ -103,7 +103,7 @@ class StatefulRandomBot : public UniformRandomBot {
 
 class PolicyBot : public Bot {
  public:
-  PolicyBot(int seed, std::unique_ptr<Policy> policy)
+  PolicyBot(int seed, std::shared_ptr<Policy> policy)
       : Bot(), rng_(seed), policy_(std::move(policy)) {}
   ~PolicyBot() = default;
 
@@ -124,7 +124,7 @@ class PolicyBot : public Bot {
 
  private:
   std::mt19937 rng_;
-  std::unique_ptr<Policy> policy_;
+  std::shared_ptr<Policy> policy_;
 };
 
 class FixedActionPreferenceBot : public Bot {
@@ -170,7 +170,7 @@ std::unique_ptr<Bot> MakeUniformRandomBot(Player player_id, int seed) {
 
 // A bot that samples from a policy.
 std::unique_ptr<Bot> MakePolicyBot(const Game& game, Player player_id, int seed,
-                                   std::unique_ptr<Policy> policy) {
+                                   std::shared_ptr<Policy> policy) {
   return std::make_unique<PolicyBot>(seed, std::move(policy));
 }
 // A bot with a fixed action preference, for test purposes.

--- a/open_spiel/spiel_bots.h
+++ b/open_spiel/spiel_bots.h
@@ -150,7 +150,7 @@ std::unique_ptr<Bot> MakeStatefulRandomBot(const Game& game, Player player_id,
 
 // A bot that samples from a policy.
 std::unique_ptr<Bot> MakePolicyBot(const Game& game, Player player_id, int seed,
-                                   std::unique_ptr<Policy> policy);
+                                   std::shared_ptr<Policy> policy);
 
 // A bot with a fixed action preference, for test purposes.
 // Picks the first legal action found in the list of actions.


### PR DESCRIPTION
- Added a bot that takes a policy. 
- added `open_spiel::MakePolicyBot` to pyspiel, had to change a few policy `unique_ptr`s to `shared_ptr` for this. 
