### PR TITLE
Fix bug in get_weights when using a2c loss. 

### DIFF
--- a/open_spiel/python/algorithms/policy_gradient.py
+++ b/open_spiel/python/algorithms/policy_gradient.py
@@ -449,7 +449,10 @@ class PolicyGradient(rl_agent.AbstractAgent):
   def get_weights(self):
     variables = [self._session.run(self._net_torso.variables)]
     variables.append(self._session.run(self._policy_logits_layer.variables))
-    variables.append(self._session.run(self._q_values_layer.variables))
+    if self._loss_class.__name__ == "BatchA2CLoss":
+      variables.append(self._session.run(self._baseline_layer.variables))
+    else:
+      variables.append(self._session.run(self._q_values_layer.variables))
     return variables
 
   def _initialize(self):

--- a/open_spiel/python/examples/kuhn_policy_gradient.py
+++ b/open_spiel/python/examples/kuhn_policy_gradient.py
@@ -32,7 +32,7 @@ FLAGS = flags.FLAGS
 
 flags.DEFINE_integer("num_episodes", int(1e6), "Number of train episodes.")
 flags.DEFINE_integer("eval_every", int(1e4), "Eval agents every x episodes.")
-flags.DEFINE_enum("loss_str", "rpg", ["rpg", "qpg", "rm"], "PG loss to use.")
+flags.DEFINE_enum("loss_str", "rpg", ["a2c", "rpg", "qpg", "rm"], "PG loss to use.")
 
 
 class PolicyGradientPolicies(policy.Policy):


### PR DESCRIPTION
Calling get_weights() when using the a2c loss in policy_gradient currently throws: "AttributeError: 'PolicyGradient' object has no attribute '_q_values_layer'". This is because there is no _q_values_layer when using a2c loss, this is instead replaced with _baseline_layer. Updated the get_weights() function to check which loss is being used and append the appropriate weights. Also, added a2c loss into the enum in the kuhn_policy_gradient example. 