### PR TITLE
DeepCFR bug fixes

### DIFF
--- a/open_spiel/python/algorithms/deep_cfr.py
+++ b/open_spiel/python/algorithms/deep_cfr.py
@@ -297,9 +297,12 @@ class DeepCFRSolver(policy.Policy):
         sampled_regret[action] = expected_payoff[action]
         for a_ in state.legal_actions():
           sampled_regret[action] -= strategy[a_] * expected_payoff[a_]
+      sampled_regret_arr = [0] * self._num_actions
+      for action in sampled_regret:
+        sampled_regret_arr[action] = sampled_regret[action]
       self._advantage_memories[player].add(
           AdvantageMemory(state.information_state_tensor(), self._iteration,
-                          [r for _,r in sorted(sampled_regret.items())], action))
+                          sampled_regret_arr, action))
       return max(expected_payoff.values())
     else:
       other_player = state.current_player()

--- a/open_spiel/python/examples/deep_cfr.py
+++ b/open_spiel/python/examples/deep_cfr.py
@@ -27,7 +27,7 @@ import tensorflow.compat.v1 as tf
 
 from open_spiel.python import policy
 from open_spiel.python.algorithms import deep_cfr
-from open_spiel.python.algorithms import exploitability
+from open_spiel.python.algorithms import exploitability, expected_game_score
 import pyspiel
 
 FLAGS = flags.FLAGS
@@ -44,14 +44,16 @@ def main(unused_argv):
     deep_cfr_solver = deep_cfr.DeepCFRSolver(
         sess,
         game,
-        policy_network_layers=(32, 32),
-        advantage_network_layers=(16, 16),
+        policy_network_layers=(16, ),
+        advantage_network_layers=(16, ),
         num_iterations=FLAGS.num_iterations,
         num_traversals=FLAGS.num_traversals,
         learning_rate=1e-3,
-        batch_size_advantage=None,
-        batch_size_strategy=None,
-        memory_capacity=1e7)
+        batch_size_advantage=128,
+        batch_size_strategy=1024,
+        memory_capacity=1e7,
+        policy_network_epochs=400,
+        advantage_network_epochs=20)
     sess.run(tf.global_variables_initializer())
     _, advantage_losses, policy_loss = deep_cfr_solver.solve()
     for player, losses in six.iteritems(advantage_losses):
@@ -62,11 +64,19 @@ def main(unused_argv):
     logging.info("Strategy Buffer Size: '%s'",
                  len(deep_cfr_solver.strategy_buffer))
     logging.info("Final policy loss: '%s'", policy_loss)
-    conv = exploitability.nash_conv(
-        game,
-        policy.tabular_policy_from_callable(
-            game, deep_cfr_solver.action_probabilities))
+
+    average_policy = policy.tabular_policy_from_callable(
+            game, deep_cfr_solver.action_probabilities)
+
+    conv = exploitability.nash_conv(game, average_policy)
     logging.info("Deep CFR in '%s' - NashConv: %s", FLAGS.game_name, conv)
+
+    average_policy_values = expected_game_score.policy_value(
+      game.new_initial_state(), [average_policy] * 2)
+    print("Computed player 0 value: {}".format(average_policy_values[0]))
+    print("Expected player 0 value: {}".format(-1 / 18))
+    print("Computed player 1 value: {}".format(average_policy_values[1]))
+    print("Expected player 1 value: {}".format(1 / 18))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I wasn't able to get a proper policy for Kuhn Poker before making these changes.

1. Predicted advantages were being inserted into advantage memory instead of sampled regret.
1. The same info was inserted into advantage memory multiple times. (wrong loop)
1. Using multiple epochs to train advantage networks and the policy network. Not sure if there was a reason for doing only one pass?
1. Reset advantage network for the current player only. This doesn't matter in two-player games but does in 3+ player games. Otherwise "other player" (unless it's the last one trained) will always act randomly in the traversal.