### PR TITLE
Add eigen/libeigen directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ pyspiel.egg-info/
 
  # External git modules
 open_spiel/abseil-cpp/
+open_spiel/eigen/libeigen/
 open_spiel/games/bridge/double_dummy_solver/
 open_spiel/games/universal_poker/double_dummy_solver/
 open_spiel/games/hanabi/hanabi-learning-environment/


### PR DESCRIPTION
When `BUILD_WITH_EIGEN` is `ON`, Eigen will be pulled as `eigen/libeigen` in root directory. Since it is not listed in `.gitignore` file, it may be committed and pushed to server accidentally. Other external modules (like `abseil-cpp`) are already ignored by git.