### PR TITLE
Add xinxin spiel bot

### DIFF
--- a/open_spiel/games/hearts.cc
+++ b/open_spiel/games/hearts.cc
@@ -60,7 +60,7 @@ const GameType kGameType{
         // If aside from QS only hearts remain, player is
         // permitted to lead hearts even if hearts are
         // not broken.
-        {"can_lead_hearts_instead_of_qs", GameParameter(true)},
+        {"can_lead_hearts_instead_of_qs", GameParameter(false)},
     }};
 
 std::shared_ptr<const Game> Factory(const GameParameters& params) {

--- a/open_spiel/games/hearts/CMakeLists.txt
+++ b/open_spiel/games/hearts/CMakeLists.txt
@@ -42,3 +42,8 @@ add_library(xinxin OBJECT
 )
 
 target_include_directories (xinxin PUBLIC hearts)
+
+add_executable (xinxin_bot_test xinxin_bot_test.cc ${OPEN_SPIEL_OBJECTS}
+               $<TARGET_OBJECTS:tests>)
+add_test(xinxin_bot_test xinxin_bot_test)
+

--- a/open_spiel/games/hearts/CMakeLists.txt
+++ b/open_spiel/games/hearts/CMakeLists.txt
@@ -37,6 +37,8 @@ add_library(xinxin OBJECT
   hearts/iiMonteCarlo.h
   hearts/mt_random.cpp
   hearts/mt_random.h
+  xinxin_bot.cc
+  xinxin_bot.h
 )
 
 target_include_directories (xinxin PUBLIC hearts)

--- a/open_spiel/games/hearts/xinxin_bot.cc
+++ b/open_spiel/games/hearts/xinxin_bot.cc
@@ -1,0 +1,180 @@
+// Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "open_spiel/games/hearts/xinxin_bot.h"
+
+namespace open_spiel {
+namespace hearts {
+namespace {
+
+constexpr int kUCTNumRuns = 50;
+constexpr int kUCTcVal = 0.4;
+constexpr int kIIMCNumWorlds = 20;
+constexpr Suit kXinxinSuits[] = { Suit::kSpades, Suit::kDiamonds, Suit::kClubs,
+  Suit::kHearts };
+constexpr ::hearts::tPassDir kXinxinPassDir[] = { ::hearts::tPassDir::kHold,
+  ::hearts::tPassDir::kLeftDir, ::hearts::tPassDir::kAcrossDir,
+  ::hearts::tPassDir::kRightDir};
+
+::hearts::SafeSimpleHeartsPlayer* CreatePlayer() {
+  ::hearts::UCT *uct = new ::hearts::UCT(kUCTNumRuns, kUCTcVal);
+  uct->setPlayoutModule(new ::hearts::HeartsPlayout());
+  ::hearts::iiMonteCarlo *mc = new ::hearts::iiMonteCarlo(uct, kIIMCNumWorlds);
+  // single-threaded xinxin is currently broken
+  // (https://github.com/nathansttt/hearts/issues/5)
+  mc->setUseThreads(true);
+  ::hearts::SafeSimpleHeartsPlayer *p;
+  p = new ::hearts::SafeSimpleHeartsPlayer(mc);
+  p->setModelLevel(2);
+  return p;
+}
+
+int GetXinxinRules(bool pass_cards, bool no_pts_on_first_trick,
+                   bool can_lead_any_club, bool jd_bonus,
+                   bool avoid_all_tricks_bonus, bool qs_breaks_hearts,
+                   bool must_break_hearts, bool can_lead_hearts_instead_of_qs) {
+  int rules = 0;
+  if (pass_cards) rules |= ::hearts::kDoPassCards;
+  if (no_pts_on_first_trick)
+    rules |= ::hearts::kNoHeartsFirstTrick | ::hearts::kNoQueenFirstTrick;
+  if (can_lead_any_club) {
+    rules |= ::hearts::kLeadClubs;
+  } else {
+    rules |= ::hearts::kLead2Clubs;
+  }
+  if (jd_bonus) rules |= ::hearts::kJackBonus;
+  if (!avoid_all_tricks_bonus) rules |= ::hearts::kNoShooting;
+  if (qs_breaks_hearts) rules |= ::hearts::kQueenBreaksHearts;
+  if (must_break_hearts) rules |= ::hearts::kMustBreakHearts;
+  if (can_lead_hearts_instead_of_qs) {
+    SpielFatalError("Xinxin does not support leading hearts instead of qs");
+  }
+  return rules;
+}
+}  // namespace
+
+Action GetOpenSpielAction(::hearts::card card) {
+  // xinxin keeps ranks in the reverse order of open_spiel
+  int rank  = kNumCardsPerSuit - ::hearts::Deck::getrank(card) - 1;
+  Suit suit = kXinxinSuits[::hearts::Deck::getsuit(card)];
+  return Card(suit, rank);
+}
+
+::hearts::card GetXinxinAction(Action action) {
+  int rank = kNumCardsPerSuit - CardRank(action) - 1;
+  int suit = std::find(kXinxinSuits, kXinxinSuits + kNumSuits,
+      CardSuit(action)) - kXinxinSuits;
+  return ::hearts::Deck::getcard(suit, rank);
+}
+
+
+XinxinBot::XinxinBot(int rules, int num_players) :
+  kNumPlayers(num_players) {
+  pass_dir_ = ::hearts::tPassDir::kHold;
+  num_cards_dealt_ = 0;
+  game_state_ = new ::hearts::HeartsGameState();
+  game_state_->setRules(rules);
+  game_state_->deletePlayers();
+  for (int i = 0; i < kNumPlayers; i++) {
+    initial_deal_.push_back(std::vector<::hearts::card>());
+    ::hearts::SafeSimpleHeartsPlayer *p = CreatePlayer();
+    game_state_->addPlayer(p);
+    p->setGameState(game_state_);
+  }
+}
+
+XinxinBot::~XinxinBot() {
+  for (int i = 0; i < kNumPlayers; i++) {
+    delete game_state_->getPlayer(i)->getAlgorithm();
+  }
+  game_state_->deletePlayers();
+  delete game_state_;
+}
+
+void XinxinBot::Restart() {
+  game_state_->Reset();
+  pass_dir_ = ::hearts::tPassDir::kHold;
+  num_cards_dealt_ = 0;
+  for (auto& hand : initial_deal_) {
+    hand.clear();
+  }
+}
+
+void XinxinBot::NewDeal(std::vector<std::vector<::hearts::card>> *initial_cards,
+                        ::hearts::tPassDir pass_dir, int first_player) {
+  // the order in which these are called matters (e.g. setting the cards unsets
+  // the pass dir)
+  game_state_->Reset();
+  game_state_->SetInitialCards(*initial_cards);
+  game_state_->setPassDir(pass_dir);
+  game_state_->setFirstPlayer(first_player);
+}
+
+Action XinxinBot::Step(const State&) {
+  ::hearts::CardMove *move = static_cast<::hearts::CardMove*>(
+      game_state_->getNextPlayer()->Play());
+  game_state_->ApplyMove(move);
+  Action act = GetOpenSpielAction(move->c);
+  game_state_->freeMove(move);
+  return act;
+}
+
+void XinxinBot::InformAction(const State& state, Player player_id,
+                             Action action) {
+  if (player_id == kChancePlayerId) {
+    if (state.ChanceOutcomes().size() == 4 && num_cards_dealt_ == 0) {
+      // this is guaranteed to be the pass dir selection action as long as
+      // that remains as the first optional chance node in the Hearts
+      // implementation
+      pass_dir_ = kXinxinPassDir[action];
+    } else {
+      ::hearts::card card = GetXinxinAction(action);
+      initial_deal_[num_cards_dealt_ % kNumPlayers].push_back(card);
+      if (++num_cards_dealt_ == kNumCards) {
+        NewDeal(&initial_deal_, pass_dir_, 0);
+      }
+    }
+  } else {
+    ::hearts::Move* move = new ::hearts::CardMove(GetXinxinAction(action),
+        player_id);
+    game_state_->ApplyMove(move);
+    game_state_->freeMove(move);
+  }
+}
+
+void XinxinBot::ForceAction(const State& state, Action action) {
+    ::hearts::Move* move = new ::hearts::CardMove(GetXinxinAction(action),
+        game_state_->getNextPlayerNum());
+    game_state_->ApplyMove(move);
+    game_state_->freeMove(move);
+}
+
+int XinxinBot::XinxinRules(GameParameters params) {
+  return GetXinxinRules(params["pass_cards"].bool_value(),
+                        params["no_pts_on_first_trick"].bool_value(),
+                        params["can_lead_any_club"].bool_value(),
+                        params["jd_bonus"].bool_value(),
+                        params["avoid_all_tricks_bonus"].bool_value(),
+                        params["qs_breaks_hearts"].bool_value(),
+                        params["must_break_hearts"].bool_value(),
+                        params["can_lead_hearts_instead_of_qs"].bool_value());
+}
+
+std::unique_ptr<Bot> MakeXinxinBot(GameParameters params, int num_players) {
+  int rules = XinxinBot::XinxinRules(params);
+  return std::make_unique<XinxinBot>(rules, num_players);
+}
+
+}  // namespace hearts
+}  // namespace open_spiel

--- a/open_spiel/games/hearts/xinxin_bot.h
+++ b/open_spiel/games/hearts/xinxin_bot.h
@@ -1,0 +1,63 @@
+
+// Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OPEN_SPIEL_GAMES_HEARTS_XINXIN_BOT_H_
+#define OPEN_SPIEL_GAMES_HEARTS_XINXIN_BOT_H_
+
+#include <vector>
+#include <memory>
+
+#include "open_spiel/games/hearts/hearts/Hearts.h"
+#include "open_spiel/games/hearts/hearts/iiMonteCarlo.h"
+#include "open_spiel/games/hearts.h"
+#include "open_spiel/spiel_bots.h"
+
+namespace open_spiel {
+namespace hearts {
+
+Action GetOpenSpielAction(::hearts::card card);
+::hearts::card GetXinxinAction(Action action);
+
+class XinxinBot : public Bot {
+ public:
+  explicit XinxinBot(int rules, int num_players = 4);
+  ~XinxinBot();
+
+  Action Step(const State& state) override;
+  void InformAction(const State& state, Player player_id,
+                    Action action) override;
+  void Restart() override;
+  bool ProvidesForceAction() override { return true; }
+  void ForceAction(const State& state, Action action) override;
+
+  static int XinxinRules(GameParameters params);
+
+ private:
+  const int kNumPlayers;
+  int num_cards_dealt_;
+  ::hearts::tPassDir pass_dir_;
+  std::vector<std::vector<::hearts::card>> initial_deal_;
+  ::hearts::HeartsGameState *game_state_;
+
+  void NewDeal(std::vector<std::vector<::hearts::card>> *initial_cards,
+               ::hearts::tPassDir pass_dir, int first_player);
+};
+
+std::unique_ptr<Bot> MakeXinxinBot(GameParameters params, int num_players);
+
+}  // namespace hearts
+}  // namespace open_spiel
+
+#endif  // OPEN_SPIEL_GAMES_HEARTS_XINXIN_BOT_H_

--- a/open_spiel/games/hearts/xinxin_bot_test.cc
+++ b/open_spiel/games/hearts/xinxin_bot_test.cc
@@ -1,0 +1,83 @@
+// Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <iostream>
+
+#include "open_spiel/spiel.h"
+#include "open_spiel/spiel_bots.h"
+#include "open_spiel/abseil-cpp/absl/time/clock.h"
+#include "open_spiel/abseil-cpp/absl/time/time.h"
+#include "open_spiel/games/hearts/hearts/Hearts.h"
+#include "open_spiel/games/hearts/xinxin_bot.h"
+
+namespace open_spiel {
+namespace {
+
+uint_fast32_t Seed() {
+  return absl::ToUnixMicros(absl::Now());
+}
+
+void XinxinBot_BasicPlayGame() {
+  int kNumPlayers = 4;
+  int kNumGames = 5;
+  std::mt19937 rng(Seed());
+  auto game = open_spiel::LoadGame("hearts");
+  std::vector<std::unique_ptr<open_spiel::Bot>> bots;
+
+  int xinxin_index = 0;
+  for (int i = 0; i < kNumPlayers; i++) {
+    bots.push_back(open_spiel::hearts::MakeXinxinBot(game->GetParameters(),
+                                                     game->NumPlayers()));
+  }
+
+  for (int i = 0; i < kNumGames; i++) {
+    std::unique_ptr<open_spiel::State> state = game->NewInitialState();
+    for (open_spiel::Player p = 0; p < bots.size(); ++p) bots[p]->Restart();
+
+    while (!state->IsTerminal()) {
+      open_spiel::Player player = state->CurrentPlayer();
+      open_spiel::Action action;
+      if (state->IsChanceNode()) {
+        open_spiel::ActionsAndProbs outcomes = state->ChanceOutcomes();
+        action = open_spiel::SampleAction(outcomes, rng).first;
+      } else {
+        action = bots[player]->Step(*state);
+      }
+
+      for (open_spiel::Player p = 0; p < bots.size(); ++p) {
+        if (p != player) {
+          bots[p]->InformAction(*state, player, action);
+        }
+      }
+      state->ApplyAction(action);
+    }
+  }
+}
+
+void XinxinBot_CardActionTransformationTest() {
+  // exhaustively check if action mapping is a bijection
+  for (Action action = 0; action < hearts::kNumCards; action++) {
+    ::hearts::card card = hearts::GetXinxinAction(action);
+    Action transformed = hearts::GetOpenSpielAction(card);
+    SPIEL_CHECK_EQ(action, transformed);
+  }
+}
+
+}  // namespace
+}  // namespace open_spiel
+
+int main(int argc, char **argv) {
+  open_spiel::XinxinBot_CardActionTransformationTest();
+  open_spiel::XinxinBot_BasicPlayGame();
+}
+


### PR DESCRIPTION
Following up on https://github.com/deepmind/open_spiel/pull/252, this change implements xinxin as an ```open_spiel::Bot```. The bot keeps track of the xinxin-compatible game state internally by translating actions back and forth between the two formats. 

Some basic tests that check the action transformations for consistency and run the bot in some open_spiel hearts games are included. We plan to add more thorough tests for different rulesets and to ensure that the internal xinxin version of the state is consistent with the actual state.