### PR TITLE
NFSP updates

### DIFF
--- a/open_spiel/python/algorithms/nfsp.py
+++ b/open_spiel/python/algorithms/nfsp.py
@@ -24,6 +24,8 @@ from __future__ import print_function
 import collections
 import contextlib
 import enum
+import os
+from absl import logging
 import random
 import numpy as np
 import tensorflow.compat.v1 as tf
@@ -115,6 +117,11 @@ class NFSP(rl_agent.AbstractAgent):
                                         self._layer_sizes, num_actions)
     self._avg_policy = self._avg_network(self._info_state_ph)
     self._avg_policy_probs = tf.nn.softmax(self._avg_policy)
+
+    self._savers = [("q_network",
+                     tf.train.Saver(self._rl_agent._q_network.variables)),
+                    ("avg_network",
+                     tf.train.Saver(self._avg_network.variables))]
 
     # Loss
     self._loss = tf.reduce_mean(
@@ -263,6 +270,53 @@ class NFSP(rl_agent.AbstractAgent):
             self._legal_actions_mask_ph: legal_actions_mask,
         })
     return loss
+
+  def _full_checkpoint_name(self, checkpoint_dir, name):
+    checkpoint_filename = "_".join([name, "pid" + str(self.player_id)])
+    return os.path.join(checkpoint_dir, checkpoint_filename)
+
+  def _latest_checkpoint_filename(self, name):
+    checkpoint_filename = "_".join([name, "pid" + str(self.player_id)])
+    return checkpoint_filename + "_latest"
+
+  def save(self, checkpoint_dir):
+    """Saves the average policy network and the inner RL agent's q-network.
+    
+    Note that this does not save the experience replay buffers and should
+    only be used to restore the agent's policy, not resume training.
+
+    Args:
+      checkpoint_dir: directory where checkpoints will be saved. 
+    """
+    for name, saver in self._savers:
+      path = saver.save(
+          self._session,
+          self._full_checkpoint_name(checkpoint_dir, name),
+          latest_filename=self._latest_checkpoint_filename(name))
+      logging.info("Saved to path: %s", path)
+
+  def has_checkpoint(self, checkpoint_dir):
+    for name, _ in self._savers:
+      if tf.train.latest_checkpoint(
+          self._full_checkpoint_name(checkpoint_dir, name),
+          os.path.join(checkpoint_dir,
+                       self._latest_checkpoint_filename(name))) is None:
+        return False
+    return True
+
+  def restore(self, checkpoint_dir):
+    """Restores the average policy network and the inner RL agent's q-network.
+    
+    Note that this does not restore the experience replay buffers and should
+    only be used to restore the agent's policy, not resume training.
+
+    Args:
+      checkpoint_dir: directory from which checkpoints will be restored. 
+    """
+    for name, saver in self._savers:
+      full_checkpoint_dir = self._full_checkpoint_name(checkpoint_dir, name)
+      logging.info("Restoring checkpoint: %s", (full_checkpoint_dir))
+      saver.restore(self._session, full_checkpoint_dir)
 
 
 class ReservoirBuffer(object):

--- a/open_spiel/python/examples/leduc_nfsp.py
+++ b/open_spiel/python/examples/leduc_nfsp.py
@@ -67,6 +67,8 @@ flags.DEFINE_float("epsilon_start", 0.06,
                    "Starting exploration parameter.")
 flags.DEFINE_float("epsilon_end", 0.001,
                    "Final exploration parameter.")
+flags.DEFINE_string("evaluation_metric", "nash_conv",
+                    "Choose from 'exploitability', 'nash_conv'.")
 
 
 class NFSPPolicies(policy.Policy):
@@ -74,11 +76,14 @@ class NFSPPolicies(policy.Policy):
 
   def __init__(self, env, nfsp_policies, mode):
     game = env.game
-    player_ids = [0, 1]
+    player_ids = list(range(FLAGS.num_players))
     super(NFSPPolicies, self).__init__(game, player_ids)
     self._policies = nfsp_policies
     self._mode = mode
-    self._obs = {"info_state": [None, None], "legal_actions": [None, None]}
+    self._obs = {
+        "info_state": [None] * FLAGS.num_players,
+        "legal_actions": [None] * FLAGS.num_players
+    }
 
   def action_probabilities(self, state, player_id=None):
     cur_player = state.current_player()
@@ -89,8 +94,10 @@ class NFSPPolicies(policy.Policy):
         state.information_state_tensor(cur_player))
     self._obs["legal_actions"][cur_player] = legal_actions
 
-    info_state = rl_environment.TimeStep(
-        observations=self._obs, rewards=None, discounts=None, step_type=None)
+    info_state = rl_environment.TimeStep(observations=self._obs,
+                                         rewards=None,
+                                         discounts=None,
+                                         step_type=None)
 
     with self._policies[cur_player].temp_mode_as(self._mode):
       p = self._policies[cur_player].step(info_state, is_evaluation=True).probs
@@ -133,15 +140,24 @@ def main(unused_argv):
         nfsp.NFSP(sess, idx, info_state_size, num_actions, hidden_layers_sizes,
                   **kwargs) for idx in range(num_players)
     ]
-    expl_policies_avg = NFSPPolicies(env, agents, nfsp.MODE.average_policy)
+    joint_avg_policy = NFSPPolicies(env, agents, nfsp.MODE.average_policy)
 
     sess.run(tf.global_variables_initializer())
     for ep in range(FLAGS.num_train_episodes):
       if (ep + 1) % FLAGS.eval_every == 0:
         losses = [agent.loss for agent in agents]
         logging.info("Losses: %s", losses)
-        expl = exploitability.exploitability(env.game, expl_policies_avg)
-        logging.info("[%s] Exploitability AVG %s", ep + 1, expl)
+        if FLAGS.evaluation_metric == "exploitability":
+          # Avg exploitability is implemented only for 2 players constant-sum
+          # games, use nash_conv otherwise.
+          expl = exploitability.exploitability(env.game, joint_avg_policy)
+          logging.info("[%s] Exploitability AVG %s", ep + 1, expl)
+        elif FLAGS.evaluation_metric == "nash_conv":
+          nash_conv = exploitability.nash_conv(env.game, joint_avg_policy)
+          logging.info("[%s] NashConv %s", ep + 1, nash_conv)
+        else:
+          raise ValueError(" ".join(("Invalid evaluation metric, choose from",
+                                     "'exploitability', 'nash_conv'.")))
         logging.info("_____________________________________________")
 
       time_step = env.reset()


### PR DESCRIPTION
Adds support for more than 2 players in the leduc_nfsp.py example and checkpointing for NFSP policies. 

NFSP converges in 3p Kuhn poker. 

Checkpoints load successfully. After restoring checkpoints and evaluating the agents' joint policy, the NashConv was the same as the most recent saved policy.