### PR TITLE
Support chance nodes in LegalActionsMask

### DIFF
--- a/open_spiel/games/first_sealed_auction.h
+++ b/open_spiel/games/first_sealed_auction.h
@@ -83,7 +83,7 @@ class FPSBAGame : public Game {
     return std::unique_ptr<State>(new FPSBAState(shared_from_this()));
   }
   int MaxChanceOutcomes() const override {
-    return std::max(max_value_, num_players_);
+    return std::max(max_value_, num_players_) + 1;
   }
   int NumPlayers() const override { return num_players_; }
   double MinUtility() const override { return 0; }

--- a/open_spiel/games/first_sealed_auction.h
+++ b/open_spiel/games/first_sealed_auction.h
@@ -83,7 +83,7 @@ class FPSBAGame : public Game {
     return std::unique_ptr<State>(new FPSBAState(shared_from_this()));
   }
   int MaxChanceOutcomes() const override {
-    return std::max(max_value_, num_players_) + 1;
+    return std::max(max_value_+1, num_players_);
   }
   int NumPlayers() const override { return num_players_; }
   double MinUtility() const override { return 0; }

--- a/open_spiel/games/liars_dice.cc
+++ b/open_spiel/games/liars_dice.cc
@@ -410,7 +410,7 @@ std::unique_ptr<State> LiarsDiceGame::NewInitialState() const {
   return state;
 }
 
-int LiarsDiceGame::MaxChanceOutcomes() const { return kDiceSides + 1; }
+int LiarsDiceGame::MaxChanceOutcomes() const { return kDiceSides; }
 
 int LiarsDiceGame::MaxGameLength() const {
   // A bet for each side and number of total dice, plus "liar" action.

--- a/open_spiel/games/liars_dice.cc
+++ b/open_spiel/games/liars_dice.cc
@@ -139,7 +139,7 @@ void LiarsDiceState::DoApplyAction(Action action) {
     int slot = num_dice_rolled_[cur_roller_];
 
     // Assign the roll.
-    dice_outcomes_[cur_roller_][slot] = action;
+    dice_outcomes_[cur_roller_][slot] = action + 1;
     num_dice_rolled_[cur_roller_]++;
 
     // Check to see if we must change the roller.
@@ -212,7 +212,7 @@ std::vector<std::pair<Action, double>> LiarsDiceState::ChanceOutcomes() const {
   // A chance node is a single die roll.
   outcomes.reserve(kDiceSides);
   for (int i = 0; i < kDiceSides; i++) {
-    outcomes.emplace_back(1 + i, 1.0 / kDiceSides);
+    outcomes.emplace_back(i, 1.0 / kDiceSides);
   }
 
   return outcomes;
@@ -410,7 +410,7 @@ std::unique_ptr<State> LiarsDiceGame::NewInitialState() const {
   return state;
 }
 
-int LiarsDiceGame::MaxChanceOutcomes() const { return kDiceSides; }
+int LiarsDiceGame::MaxChanceOutcomes() const { return kDiceSides + 1; }
 
 int LiarsDiceGame::MaxGameLength() const {
   // A bet for each side and number of total dice, plus "liar" action.

--- a/open_spiel/games/pig.cc
+++ b/open_spiel/games/pig.cc
@@ -201,7 +201,7 @@ void PigState::DoApplyAction(Action move) {
   } else if (IsChanceNode()) {
     // Resolve chance node outcome. If 1, reset turn total and change players;
     // else, add to total and keep going.
-    if (move == 1) {
+    if (move == 0) {
       // Reset turn total and loses turn!
       turn_total_ = 0;
       turn_player_ = NextPlayerRoundRobin(turn_player_, num_players_);
@@ -237,7 +237,7 @@ std::vector<std::pair<Action, double>> PigState::ChanceOutcomes() const {
   // All the chance outcomes come after roll and stop.
   outcomes.reserve(dice_outcomes_);
   for (int i = 0; i < dice_outcomes_; i++) {
-    outcomes.push_back(std::make_pair(i + 1, 1.0 / dice_outcomes_));
+    outcomes.push_back(std::make_pair(i, 1.0 / dice_outcomes_));
   }
 
   return outcomes;

--- a/open_spiel/games/trade_comm.h
+++ b/open_spiel/games/trade_comm.h
@@ -96,7 +96,7 @@ class TradeCommGame : public Game {
     return std::unique_ptr<State>(
         new TradeCommState(shared_from_this(), num_items_));
   }
-  int MaxChanceOutcomes() const override { return num_items_; }
+  int MaxChanceOutcomes() const override { return num_items_ * num_items_; }
 
   int MaxGameLength() const override { return 4; }
 

--- a/open_spiel/spiel.cc
+++ b/open_spiel/spiel.cc
@@ -207,6 +207,7 @@ std::shared_ptr<const Game> LoadGame(GameParameters params) {
 State::State(std::shared_ptr<const Game> game)
     : num_distinct_actions_(game->NumDistinctActions()),
       num_players_(game->NumPlayers()),
+      max_chance_outcomes_(game->MaxChanceOutcomes()),
       game_(game) {}
 
 template <>

--- a/open_spiel/spiel.h
+++ b/open_spiel/spiel.h
@@ -253,7 +253,7 @@ class State {
   // legal actions and 0 for illegal actions. For chances nodes, the length
   // is `game.MaxChanceOutcomes()`.
   std::vector<int> LegalActionsMask(Player player) const {
-    int length = IsChanceNode() ? max_chance_outcomes_ : num_distinct_actions_;
+    int length = player == kChancePlayerId ? max_chance_outcomes_ : num_distinct_actions_;
     std::vector<int> mask(length, 0);
     std::vector<Action> legal_actions = LegalActions(player);
 

--- a/open_spiel/spiel.h
+++ b/open_spiel/spiel.h
@@ -250,9 +250,11 @@ class State {
   virtual std::vector<Action> LegalActions() const = 0;
 
   // Returns a vector of length `game.NumDistinctActions()` containing 1 for
-  // legal actions and 0 for illegal actions.
+  // legal actions and 0 for illegal actions. For chances nodes, the length
+  // is `game.MaxChanceOutcomes()`.
   std::vector<int> LegalActionsMask(Player player) const {
-    std::vector<int> mask(num_distinct_actions_, 0);
+    int length = IsChanceNode() ? max_chance_outcomes_ : num_distinct_actions_;
+    std::vector<int> mask(length, 0);
     std::vector<Action> legal_actions = LegalActions(player);
 
     for (auto const& value : legal_actions) {
@@ -729,6 +731,7 @@ class State {
   // Fields common to every game state.
   int num_distinct_actions_;
   int num_players_;
+  int max_chance_outcomes_;
   std::vector<PlayerAction> history_;  // Actions taken so far.
 
   // A pointer to the game that created this state.

--- a/open_spiel/spiel.h
+++ b/open_spiel/spiel.h
@@ -766,7 +766,7 @@ class Game : public std::enable_shared_from_this<Game> {
   // Returns a newly allocated initial state.
   virtual std::unique_ptr<State> NewInitialState() const = 0;
 
-  // Maximum number of chance outcomes for each chance node.
+  // Maximum number of distinct chance outcomes for chance nodes in the game.
   virtual int MaxChanceOutcomes() const { return 0; }
 
   // If the game is parameterizable, returns an object with the current

--- a/open_spiel/tests/basic_tests.cc
+++ b/open_spiel/tests/basic_tests.cc
@@ -119,8 +119,7 @@ void LegalActionsAreSorted(const Game& game, State& state) {
 
 void LegalActionsMaskTest(const Game& game, const State& state,
                           const std::vector<Action>& legal_actions) {
-  std::vector<int> legal_actions_mask =
-      state.LegalActionsMask(state.CurrentPlayer());
+  std::vector<int> legal_actions_mask = state.LegalActionsMask(state.CurrentPlayer());
   int expected_length = state.IsChanceNode() ? game.MaxChanceOutcomes() : game.NumDistinctActions();
   SPIEL_CHECK_EQ(legal_actions_mask.size(), expected_length);
   for (Action action : legal_actions) {
@@ -297,7 +296,7 @@ void RandomSimulation(std::mt19937* rng, const Game& game, bool undo,
     }
 
     if (state->IsChanceNode()) {
-      LegalActionsMaskTest(game, *state, state->LegalActions());
+      LegalActionsMaskTest(game, *state, state->LegalActions(kChancePlayerId));
       // Chance node; sample one according to underlying distribution
       std::vector<std::pair<Action, double>> outcomes = state->ChanceOutcomes();
       Action action = open_spiel::SampleAction(outcomes, *rng).first;
@@ -325,7 +324,6 @@ void RandomSimulation(std::mt19937* rng, const Game& game, bool undo,
       // Sample an action for each player
       for (auto p = Player{0}; p < game.NumPlayers(); p++) {
         std::vector<Action> actions = state->LegalActions(p);
-        LegalActionsMaskTest(game, *state, actions);
         std::uniform_int_distribution<int> dis(0, actions.size() - 1);
         Action action = actions[dis(*rng)];
         joint_action.push_back(action);


### PR DESCRIPTION
- Add an extra field of `max_chance_outcomes_` in `State`
- Keep the length of `LegalActionsMask` and `LegalActions` equal for chance nodes. (fix #283 )

In the meanwhile, I find that the return of `LegalActions` of the game `pig` with chance node is between `[1, MaxChanceOutcomes]` instead of `[0, MaxChanceOutcomes-1]`, which breaks the test.

https://github.com/deepmind/open_spiel/blob/8c8e0863380acaf93fe0b00780196d9117eaac66/open_spiel/games/pig.cc#L240

I'm not sure it is intentional or not. So not fixed yet. @lanctot  Any idea?