### PR TITLE
Add InformActions bot function for simultaneous move games

### DIFF
--- a/open_spiel/python/pybind11/bots.cc
+++ b/open_spiel/python/pybind11/bots.cc
@@ -103,6 +103,16 @@ class PyBot : public Bot {
         player_id,
         action);
   }
+  void InformActions(const State& state,
+                     const std::vector<Action>& actions) override {
+    PYBIND11_OVERLOAD_NAME(
+        void,  // Return type (must be a simple token for macro parser)
+        Bot,   // Parent class
+        "inform_actions",  // Name of function in Python
+        InformActions,     // Name of function in C++
+        state,             // Arguments
+        actions);
+  }
 
   void RestartAt(const State& state) override {
     PYBIND11_OVERLOAD_NAME(
@@ -152,6 +162,7 @@ void init_pyspiel_bots(py::module& m) {
       .def("provides_force_action", &Bot::ProvidesForceAction)
       .def("force_action", &Bot::ForceAction)
       .def("inform_action", &Bot::InformAction)
+      .def("inform_actions", &Bot::InformActions)
       .def("provides_policy", &Bot::ProvidesPolicy)
       .def("get_policy", &Bot::GetPolicy)
       .def("step_with_policy", &Bot::StepWithPolicy);

--- a/open_spiel/spiel_bots.h
+++ b/open_spiel/spiel_bots.h
@@ -85,7 +85,10 @@ class Bot {
   // stateful, the default implementation is a no-op.
   virtual void InformAction(const State& state, Player player_id,
                             Action action) {}
-  // TODO(author7): Add an InformActions for simultaneous move games.
+  // In simultaneous move games the bot receives a vector containing the
+  // actions taken by all players in the given state.
+  virtual void InformActions(const State& state,
+                             const std::vector<Action>& actions) {}
 
   // Restarts the bot to its initial state, ready to start a new trajectory.
   virtual void Restart() {}


### PR DESCRIPTION
This use case came up when implementing a bot. Noticed there was already a todo in the code so thought it worthy of a pull request.