### PR TITLE
Python: new_initial_state from string.

### DIFF
--- a/open_spiel/games/chess.h
+++ b/open_spiel/games/chess.h
@@ -227,7 +227,8 @@ class ChessGame : public Game {
   int NumDistinctActions() const override {
     return chess::NumDistinctActions();
   }
-  std::unique_ptr<State> NewInitialState(const std::string& fen) const {
+  std::unique_ptr<State> NewInitialState(
+        const std::string& fen) const override {
     return std::unique_ptr<State>(new ChessState(shared_from_this(), fen));
   }
   std::unique_ptr<State> NewInitialState() const override {

--- a/open_spiel/games/clobber.h
+++ b/open_spiel/games/clobber.h
@@ -132,7 +132,7 @@ class ClobberGame : public Game {
   explicit ClobberGame(const GameParameters& params);
   int NumDistinctActions() const override;
   std::unique_ptr<State> NewInitialState(
-      const std::string& board_string) const {
+      const std::string& board_string) const override {
     return std::unique_ptr<State>(
         new ClobberState(shared_from_this(), rows_, columns_, board_string));
   }

--- a/open_spiel/julia/wrapper/spieljl.cc
+++ b/open_spiel/julia/wrapper/spieljl.cc
@@ -369,7 +369,14 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod) {
 
   mod.add_type<open_spiel::Game>("Game")
       .method("num_distinct_actions", &open_spiel::Game::NumDistinctActions)
-      .method("new_initial_state", &open_spiel::Game::NewInitialState)
+      .method("new_initial_state",
+              [](open_spiel::Game& g) {
+                return g.NewInitialState();
+              })
+      .method("new_initial_state",
+              [](open_spiel::Game& g, const std::string& s) {
+                return g.NewInitialState(s);
+              })
       .method("max_chance_outcomes", &open_spiel::Game::MaxChanceOutcomes)
       .method("get_parameters", &open_spiel::Game::GetParameters)
       .method("num_players", &open_spiel::Game::NumPlayers)

--- a/open_spiel/python/pybind11/pyspiel.cc
+++ b/open_spiel/python/pybind11/pyspiel.cc
@@ -272,11 +272,10 @@ PYBIND11_MODULE(pyspiel, m) {
   py::class_<Game, std::shared_ptr<Game>> game(m, "Game");
   game.def("num_distinct_actions", &Game::NumDistinctActions)
       .def("new_initial_state",
-           (std::unique_ptr<State>(Game::*)() const) &
-           Game::NewInitialState)
+           py::overload_cast<>(&Game::NewInitialState, py::const_))
       .def("new_initial_state",
-           (std::unique_ptr<State>(Game::*)(const std::string &) const) &
-           Game::NewInitialState)
+           py::overload_cast<const std::string&>(
+               &Game::NewInitialState, py::const_))
       .def("max_chance_outcomes", &Game::MaxChanceOutcomes)
       .def("get_parameters", &Game::GetParameters)
       .def("num_players", &Game::NumPlayers)

--- a/open_spiel/python/pybind11/pyspiel.cc
+++ b/open_spiel/python/pybind11/pyspiel.cc
@@ -271,7 +271,12 @@ PYBIND11_MODULE(pyspiel, m) {
 
   py::class_<Game, std::shared_ptr<Game>> game(m, "Game");
   game.def("num_distinct_actions", &Game::NumDistinctActions)
-      .def("new_initial_state", &Game::NewInitialState)
+      .def("new_initial_state",
+           (std::unique_ptr<State>(Game::*)() const) &
+           Game::NewInitialState)
+      .def("new_initial_state",
+           (std::unique_ptr<State>(Game::*)(const std::string &) const) &
+           Game::NewInitialState)
       .def("max_chance_outcomes", &Game::MaxChanceOutcomes)
       .def("get_parameters", &Game::GetParameters)
       .def("num_players", &Game::NumPlayers)

--- a/open_spiel/spiel.h
+++ b/open_spiel/spiel.h
@@ -762,6 +762,10 @@ class Game : public std::enable_shared_from_this<Game> {
 
   // Returns a newly allocated initial state.
   virtual std::unique_ptr<State> NewInitialState() const = 0;
+  virtual std::unique_ptr<State> NewInitialState(
+      const std::string& str) const {
+    SpielFatalError("NewInitialState from string is not implemented.");
+  }
 
   // Maximum number of chance outcomes for each chance node.
   virtual int MaxChanceOutcomes() const { return 0; }


### PR DESCRIPTION
A way to initialize a state from a string that describes an initial state in Python.

In Chess and Clobber, this was already implemented so that one could create a new state from a FEN string in chess, or a string describing the board in Clobber, but this was only available in C++. This was done through either the overloaded state constructors (`ChessState(std::shared_ptr<const Game>, const std::string&)`, `ClobberState(std::shared_ptr<const Game>, int, int, const std::string&)`) or the overloaded `NewInitialState` methods in the game classes of `ChessGame` and `ClobberGame`.

This feature was not available in Python. These changes allow for python scripts to call the game's `new_initial_state(initial_state_string: str) -> pyspiel.State` method on a game object to create a custom initial state (as long as `std::unique_ptr<State> NewInitialState(const std::string& str) const override` was implemented in the game's Game class). For example:

```python
import pyspiel
game = pyspiel.load_game("clobber(rows=5,columns=6)")
state = game.new_initial_state("1..xoox..xx..oxoxox....xoooox..")
print(state)
print(state.current_player())
```
Prints:
```
5..xoox
4..xx..
3oxoxox
2....xo
1ooox..
 abcdef

1
```

I didn't think this was the same as serialization/deserialization as the strings representing the board in this case...
1. May represent a board position that is impossible to achieve from the canonical initial state, and
2. Do not contain all information about the board/state (e.g. no threefold repetition information in the FEN string, no row/column information in the Clobber string).

But let me know if this should be done in a different way!