### PR TITLE
Add a number of methods for traversing Action-Observation / Public-Observation histories.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ ENV/
 
  # Build products
 build/
+build*/
 cmake-build-*/
 dist/
 pyspiel.egg-info/

--- a/open_spiel/CMakeLists.txt
+++ b/open_spiel/CMakeLists.txt
@@ -194,6 +194,7 @@ include_directories(..)
 
 add_subdirectory (algorithms)
 add_subdirectory (examples)
+add_subdirectory (fog)
 add_subdirectory (games)
 add_subdirectory (game_transforms)
 add_subdirectory (tests)

--- a/open_spiel/fog/CMakeLists.txt
+++ b/open_spiel/fog/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(observation_history_test
+  observation_history_test.cc ${OPEN_SPIEL_OBJECTS})
+add_test(observation_history_test observation_history_test)

--- a/open_spiel/fog/observation_history.cc
+++ b/open_spiel/fog/observation_history.cc
@@ -17,6 +17,10 @@
 
 namespace open_spiel {
 
+// -----------------------------------------------------------------------------
+// ActionOrObs
+// -----------------------------------------------------------------------------
+
 bool ActionOrObs::operator==(const ActionOrObs& other) const {
   if (tag != other.tag) return false;
   if (tag == Either::kAction) return action == other.action;
@@ -36,8 +40,12 @@ std::string ActionOrObs::ToString() const {
   return "";  // This will never return.
 }
 
+// -----------------------------------------------------------------------------
+// ActionObservationHistory
+// -----------------------------------------------------------------------------
+
 ActionObservationHistory::ActionObservationHistory(
-    Player player, const State& target) : player_(player) {
+    Player player, const State& target) : player_(player), elapsed_time_(0) {
   SPIEL_CHECK_GE(player_, 0);
   SPIEL_CHECK_LT(player_, target.NumPlayers());
   SPIEL_CHECK_TRUE(target.GetGame()->GetType().provides_observation_string);
@@ -46,7 +54,7 @@ ActionObservationHistory::ActionObservationHistory(
 
   std::unique_ptr<State> state = target.GetGame()->NewInitialState();
   for (int i = 0; i < history.size(); i++) {
-    const auto& [history_player, action] = history[i];
+    const auto&[history_player, action] = history[i];
     push_back(state->ObservationString(player));
     if (state->CurrentPlayer() == player) {
       push_back(action);
@@ -61,28 +69,146 @@ ActionObservationHistory::ActionObservationHistory(const State& target)
 
 ActionObservationHistory::ActionObservationHistory(
     Player player, std::vector<ActionOrObs> history)
-    : history_(std::move(history)), player_(player) {
+    : player_(player), elapsed_time_(0), history_(std::move(history)) {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_FALSE(history_.empty());  // There is always an obs for root node.
   SPIEL_CHECK_TRUE(history_[0].IsObservation());
-  for (int i = 1; i < history.size(); i++)
-    // Implication  history[i].IsAction() => history[i-1].IsObservation()
-    SPIEL_CHECK_TRUE(!history[i].IsAction() || history[i-1].IsObservation());
+
+  for (int i = 1; i < history_.size(); i++) {
+    if (history_[i].IsObservation()) elapsed_time_++;
+    SPIEL_CHECK_IMPLY(history_[i].IsAction(), history_[i - 1].IsObservation());
+  }
 }
 
-bool ActionObservationHistory::IsPrefix(
+const std::string& ActionObservationHistory::ObservationAt(int time) const {
+  SPIEL_CHECK_GE(time, 0);
+  SPIEL_CHECK_LE(time, elapsed_time_);
+  // We don't know how many actions happened before the requested time,
+  // so we need to traverse the vector.
+  int t = 0;
+  for (const ActionOrObs& aoo : history_) {
+    if (!aoo.IsObservation()) continue;
+    if (t == time) return aoo.Observation();
+    ++t;
+  }
+
+  // Some time inconsistency?
+  SpielFatalError("This should never happen");
+  return "";
+}
+
+Action ActionObservationHistory::ActionAt(int time) const {
+  SPIEL_CHECK_GE(time, 0);
+  SPIEL_CHECK_LE(time, elapsed_time_);
+  // We don't know how many actions happened before the requested time,
+  // so we need to traverse the vector.
+  int t = 0;
+  for (const ActionOrObs& aoo : history_) {
+    // Player was not acting at requested time.
+    if (t > time) return kInvalidAction;
+
+    if (t == time && aoo.IsAction()) return aoo.Action();
+    if (aoo.IsObservation()) ++t;
+  }
+
+  // Some time inconsistency?
+  SpielFatalError("This should never happen");
+  return 0;
+}
+
+bool ActionObservationHistory::CorrespondsTo(
+    Player pl, const State& state) const {
+  if (ClockTime() != state.MoveNumber()) return false;
+  bool equal = CheckStateCorrespondenceInSimulation(pl, state, ClockTime());
+  SPIEL_CHECK_IMPLY(equal, IsPrefixOf(pl, state));
+  SPIEL_CHECK_IMPLY(equal, IsExtensionOf(pl, state));
+  return equal;
+}
+
+bool ActionObservationHistory::CorrespondsTo(
     const ActionObservationHistory& other) const {
+  bool equal = player_ == other.player_ && history_ == other.history_;
+  SPIEL_CHECK_IMPLY(equal, elapsed_time_ == other.elapsed_time_);
+  SPIEL_CHECK_IMPLY(equal, IsPrefixOf(other));
+  SPIEL_CHECK_IMPLY(equal, IsExtensionOf(other));
+  return equal;
+}
+
+bool ActionObservationHistory::IsPrefixOf(
+    const ActionObservationHistory& other) const {
+  if (player_ != other.player_) return false;
+
+  if (CorrespondsToInitialState()) return true;
+  if (other.CorrespondsToInitialState()) return false;
+
   const auto& a = history_;
   const auto& b = other.history_;
-  if (a.empty()) return true;
-  if (b.empty()) return false;  // True only if a is empty, handled before.
   if (a.size() > b.size()) return false;
   if (a.size() == b.size()) return a == b;
   return std::equal(a.begin(), a.end(), b.begin());
 }
 
-std::string ActionObservationHistory::ToString() const {
-  return absl::StrJoin(history_, ", ", absl::StreamFormatter());
+bool ActionObservationHistory::IsPrefixOf(
+    Player pl, const State& state) const {
+  const std::shared_ptr<const Game> game = state.GetGame();
+  SPIEL_CHECK_TRUE(game->GetType().provides_observation_string);
+
+  if (CorrespondsToInitialState()) return true;
+  // Cannot be prefix if state is earlier.
+  if (ClockTime() > state.MoveNumber()) return false;
+
+  return CheckStateCorrespondenceInSimulation(pl, state, ClockTime());
+}
+
+bool ActionObservationHistory::IsExtensionOf(
+    const ActionObservationHistory& other) const {
+  return other.IsPrefixOf(*this);
+}
+
+bool ActionObservationHistory::IsExtensionOf(
+    Player pl, const State& state) const {
+  const std::shared_ptr<const Game> game = state.GetGame();
+  SPIEL_CHECK_TRUE(game->GetType().provides_observation_string);
+
+  if (state.IsInitialState()) return true;
+  // Cannot be extension if state is later.
+  if (state.MoveNumber() > ClockTime()) return false;
+
+  // Check the latest observation is identical -- most observations
+  // will differ only in the last items.
+  if (state.ObservationString(pl) != ObservationAt(state.MoveNumber()))
+    return false;
+
+  return CheckStateCorrespondenceInSimulation(pl, state, state.MoveNumber());
+}
+
+bool ActionObservationHistory::CheckStateCorrespondenceInSimulation(
+    Player pl, const State& state, int until_time) const {
+  const std::vector<State::PlayerAction>& state_history = state.FullHistory();
+  std::unique_ptr<State> simulation = state.GetGame()->NewInitialState();
+
+  int i = 0;  // The index for state_history access.
+  int j = 1;  // The index for history_ access.
+  while (simulation->MoveNumber() < until_time) {
+    SPIEL_CHECK_LT(i, state_history.size());
+    SPIEL_CHECK_LT(j, history_.size());
+    SPIEL_CHECK_FALSE(simulation->IsTerminal());
+
+    if (simulation->CurrentPlayer() == pl) {
+      if (!history_[j].IsAction()) return false;
+      if (history_[j].Action() != state_history[i].action) return false;
+      j++;
+    }
+
+    simulation->ApplyAction(state_history[i].action);
+    i++;
+
+    if (!history_[j].IsObservation()) return false;
+    if (history_[j].Observation() != simulation->ObservationString(pl))
+      return false;
+    j++;
+  }
+  return true;
 }
 
 void ActionObservationHistory::push_back(const ActionOrObs& aoo) {
@@ -97,19 +223,18 @@ void ActionObservationHistory::push_back(const ActionOrObs& aoo) {
       (history_.empty()) || (aoo.IsAction() && history_.back().IsObservation());
   SPIEL_CHECK_TRUE(aoo.IsObservation() || not_two_consecutive_actions);
 
+  // Increment time for non-initial observations.
+  if (!history_.empty() && aoo.IsObservation()) ++elapsed_time_;
   history_.push_back(aoo);
 }
 
-bool PublicObservationHistory::IsPrefix(
-    const PublicObservationHistory& other) const {
-  const auto& a = history_;
-  const auto& b = other.history_;
-  if (a.empty()) return true;
-  if (b.empty()) return false;  // True only if a is empty, handled before.
-  if (a.size() > b.size()) return false;
-  if (a.size() == b.size()) return a == b;
-  return std::equal(a.begin(), a.end(), b.begin());
+std::string ActionObservationHistory::ToString() const {
+  return absl::StrJoin(history_, ", ", absl::StreamFormatter());
 }
+
+// -----------------------------------------------------------------------------
+// PublicObservationHistory
+// -----------------------------------------------------------------------------
 
 PublicObservationHistory::PublicObservationHistory(const State& target) {
   SPIEL_CHECK_TRUE(
@@ -119,7 +244,7 @@ PublicObservationHistory::PublicObservationHistory(const State& target) {
   std::unique_ptr<State> state = target.GetGame()->NewInitialState();
   // Use FullHistory even though we don't need the player -- prevent
   // doing a copy.
-  for (const auto& [player, action] : target.FullHistory()) {
+  for (const auto&[player, action] : target.FullHistory()) {
     history_.push_back(state->PublicObservationString());
     state->ApplyAction(action);
   }
@@ -132,9 +257,108 @@ PublicObservationHistory::PublicObservationHistory(
   SPIEL_CHECK_EQ(history_.at(0), kStartOfGamePublicObservation);
 }
 
+int PublicObservationHistory::ClockTime() const {
+  SPIEL_CHECK_FALSE(history_.empty());
+  SPIEL_CHECK_EQ(history_.at(0), kStartOfGamePublicObservation);
+  return history_.size() - 1;
+}
+
+const std::string& PublicObservationHistory::ObservationAt(int time) const {
+  return history_.at(time);
+}
+
+bool PublicObservationHistory::CorrespondsTo(
+    const PublicObservationHistory& other) const {
+  return history_ == other.history_;
+}
+
+bool PublicObservationHistory::CorrespondsTo(const State& state) const {
+  if (ClockTime() != state.MoveNumber()) return false;
+  bool equal = CheckStateCorrespondenceInSimulation(state, ClockTime());
+  SPIEL_CHECK_IMPLY(equal, IsPrefixOf(state));
+  SPIEL_CHECK_IMPLY(equal, IsExtensionOf(state));
+  return equal;
+}
+
+bool PublicObservationHistory::IsPrefixOf(
+    const PublicObservationHistory& other) const {
+  if (CorrespondsToInitialState()) return true;
+  if (other.CorrespondsToInitialState()) return false;
+
+  const auto& a = history_;
+  const auto& b = other.history_;
+  if (a.size() > b.size()) return false;
+  if (a.size() == b.size()) return a == b;
+  return std::equal(a.begin(), a.end(), b.begin());
+}
+
+bool PublicObservationHistory::IsPrefixOf(const State& state) const {
+  const std::shared_ptr<const Game> game = state.GetGame();
+  SPIEL_CHECK_TRUE(game->GetType().provides_factored_observation_string);
+
+  if (CorrespondsToInitialState()) return true;
+  // Cannot be prefix if state is earlier.
+  if (state.MoveNumber() < ClockTime()) return false;
+
+  return CheckStateCorrespondenceInSimulation(state, ClockTime());
+}
+
+bool PublicObservationHistory::IsExtensionOf(
+    const PublicObservationHistory& other) const {
+  return other.IsPrefixOf(*this);
+}
+
+bool PublicObservationHistory::IsExtensionOf(const State& state) const {
+  const std::shared_ptr<const Game> game = state.GetGame();
+  SPIEL_CHECK_TRUE(game->GetType().provides_factored_observation_string);
+
+  if (state.MoveNumber() > ClockTime()) return false;
+
+  // Check the latest observation is identical -- most observations
+  // will differ only in the last items.
+  if (state.PublicObservationString() != ObservationAt(state.MoveNumber()))
+    return false;
+
+  return CheckStateCorrespondenceInSimulation(state, state.MoveNumber());
+}
+
 std::string PublicObservationHistory::ToString() const {
   return absl::StrJoin(history_, ", ");
 }
+
+void PublicObservationHistory::push_back(const std::string& observation) {
+  SPIEL_CHECK_IMPLY(
+      history_.empty(), observation == kStartOfGamePublicObservation);
+  SPIEL_CHECK_NE(observation, kInvalidPublicObservation);
+  history_.push_back(observation);
+}
+
+bool PublicObservationHistory::CheckStateCorrespondenceInSimulation(
+    const State& state, int until_time) const {
+  const std::vector<State::PlayerAction>& state_history = state.FullHistory();
+  std::unique_ptr<State> simulation = state.GetGame()->NewInitialState();
+  SPIEL_CHECK_EQ(simulation->PublicObservationString(),
+                 kStartOfGamePublicObservation);
+
+  int i = 0;  // The index for state_history access.
+  int j = 1;  // The index for history_ access.
+  while (simulation->MoveNumber() < until_time) {
+    SPIEL_CHECK_LT(i, state_history.size());
+    SPIEL_CHECK_LT(j, history_.size());
+    SPIEL_CHECK_FALSE(simulation->IsTerminal());
+
+    simulation->ApplyAction(state_history[i].action);
+    i++;
+
+    if (history_.at(j) != simulation->PublicObservationString()) return false;
+    j++;
+  }
+  return true;
+}
+
+// -----------------------------------------------------------------------------
+// Streaming.
+// -----------------------------------------------------------------------------
 
 std::ostream& operator<<(std::ostream& os, const ActionOrObs& aoo) {
   return os << aoo.ToString();

--- a/open_spiel/fog/observation_history_test.cc
+++ b/open_spiel/fog/observation_history_test.cc
@@ -1,0 +1,92 @@
+// Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "open_spiel/spiel.h"
+#include "open_spiel/spiel_utils.h"
+#include "open_spiel/fog/observation_history.h"
+
+namespace open_spiel {
+namespace {
+
+// This is a similar test to the one done in Python:
+// python/tests/observation_history_test.py
+void CheckKuhnPokerObservationHistory() {
+  using AO = ActionOrObs;
+  using AOH = ActionObservationHistory;
+  using POH = PublicObservationHistory;
+
+  std::shared_ptr<const Game> game = LoadGame("kuhn_poker");
+
+  std::unique_ptr<State> s = game->NewInitialState();
+  SPIEL_CHECK_TRUE(s->IsChanceNode());
+  SPIEL_CHECK_EQ(POH(* s), POH({kStartOfGamePublicObservation}));
+  SPIEL_CHECK_EQ(AOH(0, *s), AOH(0, {AO("")}));
+  SPIEL_CHECK_EQ(AOH(1, *s), AOH(1, {AO("")}));
+
+  s->ApplyAction(2);
+  SPIEL_CHECK_TRUE(s->IsChanceNode());
+  SPIEL_CHECK_EQ(POH(* s), POH({kStartOfGamePublicObservation,
+                                "Deal to player 0"}));
+  SPIEL_CHECK_EQ(AOH(0, *s), AOH(0, {AO(""), AO("211")}));
+  SPIEL_CHECK_EQ(AOH(1, *s), AOH(1, {AO(""), AO("")}));
+
+  s->ApplyAction(1);
+  SPIEL_CHECK_TRUE(s->IsPlayerNode());
+  SPIEL_CHECK_EQ(POH(* s), POH({kStartOfGamePublicObservation,
+                                "Deal to player 0",
+                                "Deal to player 1"}));
+  SPIEL_CHECK_EQ(AOH(0, *s), AOH(0, {AO(""), AO("211"), AO("211")}));
+  SPIEL_CHECK_EQ(AOH(1, *s), AOH(1, {AO(""), AO(""), AO("111")}));
+
+  s->ApplyAction(0);
+  SPIEL_CHECK_TRUE(s->IsPlayerNode());
+  SPIEL_CHECK_EQ(POH(* s), POH({kStartOfGamePublicObservation,
+                                "Deal to player 0",
+                                "Deal to player 1",
+                                "Pass"}));
+  SPIEL_CHECK_EQ(AOH(0, *s), AOH(0, {AO(""), AO("211"), AO("211"), AO(0),
+                                     AO("211")}));
+  SPIEL_CHECK_EQ(AOH(1, *s), AOH(1, {AO(""), AO(""), AO("111"),
+                                     AO("111")}));
+
+  s->ApplyAction(1);
+  SPIEL_CHECK_TRUE(s->IsPlayerNode());
+  SPIEL_CHECK_EQ(POH(* s), POH({kStartOfGamePublicObservation,
+                                "Deal to player 0",
+                                "Deal to player 1",
+                                "Pass", "Bet"}));
+  SPIEL_CHECK_EQ(AOH(0, *s), AOH(0, {AO(""), AO("211"), AO("211"), AO(0),
+                                     AO("211"), AO("212")}));
+  SPIEL_CHECK_EQ(AOH(1, *s), AOH(1, {AO(""), AO(""), AO("111"), AO("111"),
+                                     AO(1), AO("112")}));
+
+  s->ApplyAction(1);
+  SPIEL_CHECK_TRUE(s->IsTerminal());
+  SPIEL_CHECK_EQ(POH(* s), POH({kStartOfGamePublicObservation,
+                                "Deal to player 0",
+                                "Deal to player 1",
+                                "Pass", "Bet", "Bet"}));
+  SPIEL_CHECK_EQ(AOH(0, *s), AOH(0, {AO(""), AO("211"), AO("211"), AO(0),
+                                     AO("211"), AO("212"), AO(1), AO("222")}));
+  SPIEL_CHECK_EQ(AOH(1, *s), AOH(1, {AO(""), AO(""), AO("111"), AO("111"),
+                                     AO(1), AO("112"), AO("122")}));
+}
+
+}  // namespace
+}  // namespace open_spiel
+
+
+int main(int argc, char** argv) {
+  open_spiel::CheckKuhnPokerObservationHistory();
+}

--- a/open_spiel/python/tests/observation_history_test.py
+++ b/open_spiel/python/tests/observation_history_test.py
@@ -32,100 +32,196 @@ from absl.testing import absltest
 import pyspiel
 
 
-class ObservationHistoryTest(absltest.TestCase):
+def state_from_sequence(game, action_sequence):
+  state = game.new_initial_state()
+  for action in action_sequence:
+    state.apply_action(action)
+  return state
 
+
+class ObservationHistoryTest(absltest.TestCase):
   def test_kuhn_rollout(self):
     game = pyspiel.load_game("kuhn_poker")
+
+    # Test on this specific sequence.
+    action_sequence = [2, 1, 0, 1, 1]
+
+    root_state = game.new_initial_state()
+    terminal = state_from_sequence(game, action_sequence)
+    self.assertTrue(terminal.is_terminal())
+
+    # Check prefixes, extensions and correspondences of both
+    # public-observation histories / action-observation histories
+    # while rolling out.
+    seq_idx = 0
+
+    def advance_and_test(state):
+      nonlocal seq_idx
+      action = action_sequence[seq_idx]
+
+      parent_state = state.clone()
+      state.apply_action(action)
+
+      # Both PublicObservationHistory and ActionObservationHistory need to pass
+      # the same correspondence / prefix / extension tests, for both
+      # construction from state (and player for AOH) or just passing state (and
+      # player) without history construction. So this tests them together.
+      # These are passed as constructors (lefts) and targets (rights).
+      constructors_with_targets = [
+        # (p)layer, (s)tate
+        (lambda p, s: pyspiel.ActionObservationHistory(p, s), [
+          lambda p, s: [pyspiel.ActionObservationHistory(p, s)],
+          lambda p, s: [p, s]
+        ]),
+        # Since PublicObservationHistory does not need a player, it is ignored.
+        (lambda _, s: pyspiel.PublicObservationHistory(s), [
+          lambda _, s: [pyspiel.PublicObservationHistory(s)],
+          lambda _, s: [s]
+        ])
+      ]
+
+      for (left, rights) in constructors_with_targets:
+        for right in rights:
+          for player in range(2):
+            # Shortcuts for conciseness: the most important things
+            # relevant for the tests have long names.
+            # In other words, when reading the code just skip over
+            # the short vars to gain understanding.
+            l, r, p = left, right, player
+
+            self.assertTrue(l(p, state).corresponds_to(*r(p, state)))
+            self.assertFalse(l(p, parent_state).corresponds_to(*r(p, state)))
+            if state.is_terminal():
+              self.assertTrue(l(p, terminal).corresponds_to(*r(p, state)))
+            else:
+              self.assertFalse(l(p, terminal).corresponds_to(*r(p, state)))
+            if state.is_initial_state():
+              self.assertTrue(l(p, root_state).corresponds_to(*r(p, state)))
+            else:
+              self.assertFalse(l(p, root_state).corresponds_to(*r(p, state)))
+
+            self.assertTrue(l(p, parent_state).is_prefix_of(*r(p, state)))
+            self.assertFalse(l(p, state).is_prefix_of(*r(p, parent_state)))
+            self.assertTrue(l(p, root_state).is_prefix_of(*r(p, state)))
+            if state.is_terminal():
+              self.assertTrue(l(p, terminal).is_prefix_of(*r(p, state)))
+            else:
+              self.assertFalse(l(p, terminal).is_prefix_of(*r(p, state)))
+
+            self.assertFalse(l(p, parent_state).is_extension_of(*r(p, state)))
+            self.assertTrue(l(p, state).is_extension_of(*r(p, parent_state)))
+            self.assertTrue(l(p, terminal).is_extension_of(*r(p, state)))
+            if state.is_initial_state():
+              self.assertTrue(l(p, root_state).is_extension_of(*r(p, state)))
+            else:
+              self.assertFalse(l(p, root_state).is_extension_of(*r(p, state)))
+
+      seq_idx += 1
+      return state
 
     state = game.new_initial_state()
     self.assertTrue(state.is_chance_node())
     self.assertEqual(
         pyspiel.PublicObservationHistory(state),
         pyspiel.PublicObservationHistory([
-            pyspiel.PublicObservation.START_GAME]))
+          pyspiel.PublicObservation.START_GAME]))
     self.assertEqual(
         pyspiel.ActionObservationHistory(0, state),
-        pyspiel.ActionObservationHistory(0, [""]))
+        pyspiel.ActionObservationHistory(0, [
+          pyspiel.PrivateObservation.NOTHING]))
     self.assertEqual(
         pyspiel.ActionObservationHistory(1, state),
-        pyspiel.ActionObservationHistory(1, [""]))
+        pyspiel.ActionObservationHistory(1, [
+          pyspiel.PrivateObservation.NOTHING]))
 
-    state.apply_action(2)
+    advance_and_test(state)
     self.assertTrue(state.is_chance_node())
     self.assertEqual(
         pyspiel.PublicObservationHistory(state),
         pyspiel.PublicObservationHistory([
-            pyspiel.PublicObservation.START_GAME, "Deal to player 0"]))
+          pyspiel.PublicObservation.START_GAME, "Deal to player 0"]))
     self.assertEqual(
         pyspiel.ActionObservationHistory(0, state),
-        pyspiel.ActionObservationHistory(0, ["", "211"]))
+        pyspiel.ActionObservationHistory(0, [
+          pyspiel.PrivateObservation.NOTHING, "211"]))
     self.assertEqual(
         pyspiel.ActionObservationHistory(1, state),
-        pyspiel.ActionObservationHistory(1, ["", ""]))
+        pyspiel.ActionObservationHistory(1, [
+          pyspiel.PrivateObservation.NOTHING,
+          pyspiel.PrivateObservation.NOTHING]))
 
-    state.apply_action(1)
+    advance_and_test(state)
     self.assertTrue(state.is_player_node())
     self.assertEqual(
         pyspiel.PublicObservationHistory(state),
         pyspiel.PublicObservationHistory([
-            pyspiel.PublicObservation.START_GAME, "Deal to player 0",
-            "Deal to player 1"
+          pyspiel.PublicObservation.START_GAME, "Deal to player 0",
+          "Deal to player 1"
         ]))
     self.assertEqual(
         pyspiel.ActionObservationHistory(0, state),
-        pyspiel.ActionObservationHistory(0, ["", "211", "211"]))
+        pyspiel.ActionObservationHistory(0, [
+          pyspiel.PrivateObservation.NOTHING, "211", "211"]))
     self.assertEqual(
         pyspiel.ActionObservationHistory(1, state),
-        pyspiel.ActionObservationHistory(1, ["", "", "111"]))
+        pyspiel.ActionObservationHistory(1, [
+          pyspiel.PrivateObservation.NOTHING,
+          pyspiel.PrivateObservation.NOTHING, "111"]))
 
-    state.apply_action(0)
+    advance_and_test(state)
     self.assertTrue(state.is_player_node())
     self.assertEqual(
         pyspiel.PublicObservationHistory(state),
         pyspiel.PublicObservationHistory([
-            pyspiel.PublicObservation.START_GAME, "Deal to player 0",
-            "Deal to player 1", "Pass"
+          pyspiel.PublicObservation.START_GAME, "Deal to player 0",
+          "Deal to player 1", "Pass"
         ]))
     self.assertEqual(
         pyspiel.ActionObservationHistory(0, state),
-        pyspiel.ActionObservationHistory(0, ["", "211", "211", 0, "211"]))
+        pyspiel.ActionObservationHistory(0, [
+          pyspiel.PrivateObservation.NOTHING, "211", "211", 0, "211"]))
     self.assertEqual(
         pyspiel.ActionObservationHistory(1, state),
-        pyspiel.ActionObservationHistory(1, ["", "", "111", "111"]))
+        pyspiel.ActionObservationHistory(1, [
+          pyspiel.PrivateObservation.NOTHING,
+          pyspiel.PrivateObservation.NOTHING, "111", "111"]))
 
-    state.apply_action(1)
+    advance_and_test(state)
     self.assertTrue(state.is_player_node())
     self.assertEqual(
         pyspiel.PublicObservationHistory(state),
         pyspiel.PublicObservationHistory([
-            pyspiel.PublicObservation.START_GAME, "Deal to player 0",
-            "Deal to player 1", "Pass", "Bet"
+          pyspiel.PublicObservation.START_GAME, "Deal to player 0",
+          "Deal to player 1", "Pass", "Bet"
         ]))
     self.assertEqual(
         pyspiel.ActionObservationHistory(0, state),
-        pyspiel.ActionObservationHistory(
-            0, ["", "211", "211", 0, "211", "212"]))
+        pyspiel.ActionObservationHistory(0, [
+          pyspiel.PrivateObservation.NOTHING, "211", "211", 0, "211", "212"]))
     self.assertEqual(
         pyspiel.ActionObservationHistory(1, state),
-        pyspiel.ActionObservationHistory(
-            1, ["", "", "111", "111", 1, "112"]))
+        pyspiel.ActionObservationHistory(1, [
+          pyspiel.PrivateObservation.NOTHING,
+          pyspiel.PrivateObservation.NOTHING, "111", "111", 1, "112"]))
 
-    state.apply_action(1)
+    advance_and_test(state)
     self.assertTrue(state.is_terminal())
     self.assertEqual(
         pyspiel.PublicObservationHistory(state),
         pyspiel.PublicObservationHistory([
-            pyspiel.PublicObservation.START_GAME, "Deal to player 0",
-            "Deal to player 1", "Pass", "Bet", "Bet"
+          pyspiel.PublicObservation.START_GAME, "Deal to player 0",
+          "Deal to player 1", "Pass", "Bet", "Bet"
         ]))
     self.assertEqual(
         pyspiel.ActionObservationHistory(0, state),
-        pyspiel.ActionObservationHistory(
-            0, ["", "211", "211", 0, "211", "212", 1, "222"]))
+        pyspiel.ActionObservationHistory(0, [
+          pyspiel.PrivateObservation.NOTHING,
+          "211", "211", 0, "211", "212", 1, "222"]))
     self.assertEqual(
         pyspiel.ActionObservationHistory(1, state),
-        pyspiel.ActionObservationHistory(
-            1, ["", "", "111", "111", 1, "112", "122"]))
+        pyspiel.ActionObservationHistory(1, [
+          pyspiel.PrivateObservation.NOTHING,
+          pyspiel.PrivateObservation.NOTHING, "111", "111", 1, "112", "122"]))
 
 
 if __name__ == "__main__":

--- a/open_spiel/spiel.h
+++ b/open_spiel/spiel.h
@@ -348,8 +348,15 @@ class State {
   // including chance) and the `State` objects.
   std::string HistoryString() const { return absl::StrJoin(History(), " "); }
 
+  // Return how many moves have been done so far in the game.
+  // When players make simultaneous moves, this counts only as a one move.
+  // Chance transitions count also as one move.
+  // Note that game transformations are not required to preserve the move
+  // number in the transformed game.
+  int MoveNumber() const;
+
   // Is this a first state in the game, i.e. the initial state (root node)?
-  bool IsInitialState() const { return History().empty(); }
+  bool IsInitialState() const { return history_.empty(); }
 
   // For imperfect information games. Returns an identifier for the current
   // information state for the specified player.
@@ -487,7 +494,7 @@ class State {
 
   // The public / private observations factorize observations into their
   // (mostly) non-overlapping public and private parts (they overlap only for
-  // the start of the game and time). See also <open_spiel/fog_constants.h>
+  // the start of the game and time). See also fog/ directory for details.
   //
   // The public observations correspond to information that all the players know
   // that all the players know, like upward-facing cards on a table.
@@ -496,14 +503,15 @@ class State {
   // All games have non-empty public observations. The minimum public
   // information is time: we assume that all the players can perceive absolute
   // time (we do not consider any relativistic effects). The implemented games
-  // must be 1-timeable (see [1] for details), a property that is trivially
-  // satisfied with all human-played board games, so you don't have to typically
-  // worry about this. (You'd have to knock players out / consider Einstein's
-  // time-relativistic effects to make non-timeable games.).
+  // must be 1-timeable, a property that is trivially satisfied with all
+  // human-played board games, so you typically don't have to worry about this.
+  // (You'd have to knock players out / consider Einstein's time-relativistic
+  // effects to make non-timeable games.).
   //
   // The public observations are used to create a list of observations:
-  // a public observation history. If you return any non-empty public
-  // observation, you implicitly encode time as well within this sequence.
+  // a public observation history. Because of the list structure, when you
+  // return any non-empty public observation, you implicitly encode time as well
+  // within this sequence.
   //
   // Public observations are not required to be "common knowledge" observations.
   // Example: In imperfect-info version of card game Goofspiel, players make
@@ -517,21 +525,18 @@ class State {
   // it is in general expensive to compute. Returning public observation "draw"
   // is sufficient.
   //
-  // In the initial state this function must return kStartOfGameObservation.
-  // If there is no public observation available except time, the implementation
-  // should return kClockTickObservation.
-  // Note that empty strings for observations are forbidden.
-  //
-  // See the Factored-Observation Game (FOG) paper for more details.
-  // [1] https://arxiv.org/abs/1906.11110
-
+  // In the initial state this function must return
+  // kStartOfGamePublicObservation. If there is no public observation available
+  // except time, the implementation must return kClockTickObservation. Note
+  // that empty strings for observations are forbidden - they correspond
+  // to kInvalidPublicObservation.
   virtual std::string PublicObservationString() const {
     SpielFatalError("PublicObservationString is not implemented.");
   }
 
   // The public / private observations factorize observations into their
   // (mostly) non-overlapping public and private parts (they overlap only for
-  // the start of the game and time). See also <open_spiel/fog_constants.h>
+  // the start of the game and time). See also fog/ directory for details.
   //
   // The private observations correspond to the part of the observation that
   // is not public. In Poker, this would be the cards the player holds in his
@@ -547,24 +552,16 @@ class State {
   // it the same as if the player just placed his cards on the table for
   // everyone to see.
   //
-  // In the initial state this function must return kStartOfGameObservation.
   // If there is no private observation available, the implementation should
-  // return kClockTickObservation. These two types of observations are shared
-  // with the public observations. This is done for technical reasons discussed
-  // in <open_spiel/fog_constants.h>
-  //
-  // Perfect information games have no private observations: implementations
-  // should just return a start of game and clock ticking. Imperfect-information
-  // games should return a different string string at least once in the game
-  // (otherwise they would be considered perfect-info games).
-  // Note that empty strings for observations are forbidden.
+  // return kNothingPrivateObservation. Perfect information games have no
+  // private observations and should return only this constant.
+  // Imperfect-information games should return a different string string
+  // at least once in the game (otherwise they would be considered perfect-info
+  // games).
   //
   // Implementations should start with (and it's tested in api_test.py):
   //   SPIEL_CHECK_GE(player, 0);
   //   SPIEL_CHECK_LT(player, num_players_);
-  //
-  // See the Factored-Observation Game (FOG) paper for more details.
-  // [1] https://arxiv.org/abs/1906.11110
   virtual std::string PrivateObservationString(Player player) const {
     SpielFatalError("PrivateObservationString is not implemented.");
   }

--- a/open_spiel/spiel_utils.h
+++ b/open_spiel/spiel_utils.h
@@ -39,7 +39,7 @@
 #include "open_spiel/abseil-cpp/absl/time/time.h"
 #include "open_spiel/abseil-cpp/absl/types/optional.h"
 
-// Code that is not part of the API, but is widely useful in implementations
+// Code that is not part of the API, but is widely useful in implementations.
 
 namespace open_spiel {
 
@@ -48,6 +48,20 @@ namespace open_spiel {
 // lookup here since that requires putting these overloads into std::, which is
 // not allowed (only template specializations on std:: template classes may be
 // added to std::, and this is not one of them).
+
+// Make sure that arbitrary structures can be printed out.
+// (Fix for GCC, as it cannot process structures out of order.
+// Otherwise it produces several pages of templating errors.)
+template <typename T>
+std::ostream& operator<<(std::ostream& stream, const std::unique_ptr<T>& v);
+template <typename T, typename U>
+std::ostream& operator<<(std::ostream& stream, const std::pair<T, U>& v);
+template <typename T>
+std::ostream& operator<<(std::ostream& stream, const std::vector<T>& v);
+template <typename T, std::size_t N>
+std::ostream& operator<<(std::ostream& stream, const std::array<T, N>& v);
+
+// Actual template implementations.
 template <typename T>
 std::ostream& operator<<(std::ostream& stream, const std::vector<T>& v) {
   stream << "[";
@@ -197,6 +211,8 @@ bool Near(T a, T b, T epsilon) {
 #define SPIEL_CHECK_LT(x, y) SPIEL_CHECK_OP(x, <, y)
 #define SPIEL_CHECK_EQ(x, y) SPIEL_CHECK_OP(x, ==, y)
 #define SPIEL_CHECK_NE(x, y) SPIEL_CHECK_OP(x, !=, y)
+// check an implication:  x => y  |=|  !x || y
+#define SPIEL_CHECK_IMPLY(x, y) SPIEL_CHECK_OP(!(x), ||, y)
 #define SPIEL_CHECK_PROB(x) \
   SPIEL_CHECK_GE(x, 0);     \
   SPIEL_CHECK_LE(x, 1);     \


### PR DESCRIPTION
Add a number of methods for traversing Action-Observation / Public-Observation histories.

These are useful for targeted traversal of imp. info games:
- IsPrefixOf
- IsExtensionOf
- CorrespondsTo

And these are useful for finding equivalences between imp. info structures and perfect info world tree:
- ClockTime
- MoveNumber