### PR TITLE
InformationStateTensor() fixes in catch and deep_sea

### DIFF
--- a/open_spiel/games/catch.cc
+++ b/open_spiel/games/catch.cc
@@ -35,8 +35,8 @@ const GameType kGameType{/*short_name=*/"catch",
                          GameType::RewardModel::kTerminal,
                          /*max_num_players=*/1,
                          /*min_num_players=*/1,
-                         /*provides_information_state_string=*/true,
-                         /*provides_information_state_tensor=*/true,
+                         /*provides_information_state_string=*/false,
+                         /*provides_information_state_tensor=*/false,
                          /*provides_observation_string=*/true,
                          /*provides_observation_tensor=*/true,
                          /*parameter_specification=*/
@@ -147,12 +147,6 @@ std::vector<double> CatchState::Returns() const {
   }
 }
 
-std::string CatchState::InformationStateString(Player player) const {
-  SPIEL_CHECK_GE(player, 0);
-  SPIEL_CHECK_LT(player, num_players_);
-  return HistoryString();
-}
-
 std::string CatchState::ObservationString(Player player) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
@@ -168,23 +162,6 @@ void CatchState::ObservationTensor(Player player,
   if (initialized_) {
     view[{ball_row_, ball_col_}] = 1.0;
     view[{num_rows_ - 1, paddle_col_}] = 1.0;
-  }
-}
-
-void CatchState::InformationStateTensor(Player player,
-                                        std::vector<double>* values) const {
-  SPIEL_CHECK_GE(player, 0);
-  SPIEL_CHECK_LT(player, num_players_);
-
-  values->resize(num_columns_ + kNumActions * num_rows_);
-  std::fill(values->begin(), values->end(), 0.);
-  if (initialized_) {
-    (*values)[ball_col_] = 1;
-    int offset = history_.size() - ball_row_ - 1;
-    for (int i = 0; i < ball_row_; i++) {
-      (*values)[num_columns_ + i * kNumActions + history_[offset + i].action] =
-          1;
-    }
   }
 }
 

--- a/open_spiel/games/catch.h
+++ b/open_spiel/games/catch.h
@@ -69,12 +69,9 @@ class CatchState : public State {
   std::string ToString() const override;
   bool IsTerminal() const override;
   std::vector<double> Returns() const override;
-  std::string InformationStateString(Player player) const override;
   std::string ObservationString(Player player) const override;
   void ObservationTensor(Player player,
                          std::vector<double>* values) const override;
-  void InformationStateTensor(Player player,
-                              std::vector<double>* values) const override;
   std::unique_ptr<State> Clone() const override;
   void UndoAction(Player player, Action move) override;
   std::vector<Action> LegalActions() const override;
@@ -105,9 +102,6 @@ class CatchGame : public Game {
   }
   std::vector<int> ObservationTensorShape() const override {
     return {num_rows_, num_columns_};
-  }
-  std::vector<int> InformationStateTensorShape() const override {
-    return {num_columns_ + kNumActions * num_rows_};
   }
 
   int NumDistinctActions() const override { return kNumActions; }

--- a/open_spiel/games/deep_sea.cc
+++ b/open_spiel/games/deep_sea.cc
@@ -39,10 +39,10 @@ const GameType kGameType{
     GameType::RewardModel::kRewards,
     /*max_num_players=*/1,
     /*min_num_players=*/1,
-    /*provides_information_state=*/true,
-    /*provides_information_state_as_normalized_vector=*/false,
-    /*provides_observation=*/true,
-    /*provides_observation_as_normalized_vector=*/true,
+    /*provides_information_state_string=*/false,
+    /*provides_information_state_tensor=*/false,
+    /*provides_observation_string=*/true,
+    /*provides_observation_tensor=*/true,
     /*parameter_specification=*/
     {
         {"size", GameParameter(kDefaultSize)},
@@ -124,20 +124,6 @@ std::vector<double> DeepSeaState::Returns() const {
   return {reward_sum};
 }
 
-std::string DeepSeaState::InformationStateString(Player player) const {
-  SPIEL_CHECK_GE(player, 0);
-  SPIEL_CHECK_LT(player, num_players_);
-
-  SPIEL_CHECK_EQ(history_.size(), player_row_);
-  SPIEL_CHECK_EQ(direction_history_.size(), player_row_);
-  std::string str;
-  for (int i = 0; i < player_row_; i++) {
-    absl::StrAppend(&str, history_[i].action ? "R" : "L", "->",
-                    direction_history_[i] ? "R" : "L", "\n");
-  }
-  return str;
-}
-
 std::string DeepSeaState::ObservationString(Player player) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
@@ -156,19 +142,6 @@ void DeepSeaState::ObservationTensor(Player player,
   values->resize(size_ * size_);
   if (player_row_ < size_ && player_col_ < size_)
     (*values)[player_row_ * size_ + player_col_] = 1.0;
-}
-
-void DeepSeaState::InformationStateTensor(Player player,
-                                          std::vector<double>* values) const {
-  SPIEL_CHECK_GE(player, 0);
-  SPIEL_CHECK_LT(player, num_players_);
-
-  values->resize(2 * size_);
-  std::fill(values->begin(), values->end(), -1);
-  for (int i = 0; i < player_row_; i++) {
-    (*values)[2 * i] = history_[i].action;
-    (*values)[2 * i + 1] = direction_history_[i];
-  }
 }
 
 std::unique_ptr<State> DeepSeaState::Clone() const {

--- a/open_spiel/games/deep_sea.h
+++ b/open_spiel/games/deep_sea.h
@@ -65,12 +65,9 @@ class DeepSeaState : public State {
   bool IsTerminal() const override;
   std::vector<double> Rewards() const override;
   std::vector<double> Returns() const override;
-  std::string InformationStateString(Player player) const override;
   std::string ObservationString(Player player) const override;
   void ObservationTensor(Player player,
                          std::vector<double>* values) const override;
-  void InformationStateTensor(Player player,
-                              std::vector<double>* values) const override;
   std::unique_ptr<State> Clone() const override;
   void UndoAction(Player player, Action move) override;
   std::vector<Action> LegalActions() const override;
@@ -104,9 +101,6 @@ class DeepSeaGame : public Game {
   }
   std::vector<int> ObservationTensorShape() const override {
     return {size_, size_};
-  }
-  std::vector<int> InformationStateTensorShape() const override {
-    return {2 * size_};
   }
 
   int NumDistinctActions() const override { return kNumActions; }

--- a/open_spiel/integration_tests/api_test.py
+++ b/open_spiel/integration_tests/api_test.py
@@ -39,9 +39,7 @@ _GAMES_NOT_UNDER_TEST = [
 # The list of game instances to test on the full tree as tuples
 # (name to display, string to pass to load_game).
 _GAMES_FULL_TREE_TRAVERSAL_TESTS = [
-    ("catch", "catch(rows=6,columns=3)"),
     ("cliff_walking", "cliff_walking(horizon=7)"),
-    ("deep_sea", "deep_sea(size=3)"),
     ("kuhn_poker", "kuhn_poker"),
     ("leduc_poker", "leduc_poker"),
     ("iigoofspiel4", "turn_based_simultaneous_game(game=goofspiel("
@@ -64,9 +62,7 @@ _GAMES_FULL_TREE_TRAVERSAL_TESTS_NAMES = [
 
 TOTAL_NUM_STATES = {
     # This maps the game name to (chance, playable, terminal)
-    "catch": (1, 363, 729),
     "cliff_walking": (0, 2119, 6358),
-    "deep_sea": (0, 7, 8),
     "kuhn_poker": (4, 24, 30),
     "leduc_poker": (157, 3780, 5520),
     "liars_dice": (7, 147456, 147420),
@@ -81,9 +77,7 @@ TOTAL_NUM_STATES = {
 # This is kept to ensure non-regression, but we would like to remove that
 # when we can interpret what are these numbers.
 PERFECT_RECALL_NUM_STATES = {
-    "catch": 363,
     "cliff_walking": 2119,
-    "deep_sea": 7,
     "kuhn_poker": 12,
     "leduc_poker": 936,
     "liars_dice": 24576,

--- a/open_spiel/integration_tests/playthroughs/catch.txt
+++ b/open_spiel/integration_tests/playthroughs/catch.txt
@@ -7,8 +7,8 @@ GameType.long_name = "Catch"
 GameType.max_num_players = 1
 GameType.min_num_players = 1
 GameType.parameter_specification = ["columns", "rows"]
-GameType.provides_information_state_string = True
-GameType.provides_information_state_tensor = True
+GameType.provides_information_state_string = False
+GameType.provides_information_state_tensor = False
 GameType.provides_observation_string = True
 GameType.provides_observation_tensor = True
 GameType.provides_factored_observation_string = False
@@ -24,9 +24,6 @@ NumPlayers() = 1
 MinUtility() = -1.0
 MaxUtility() = 1.0
 UtilitySum() = None
-InformationStateTensorShape() = [35]
-InformationStateTensorLayout() = TensorLayout.CHW
-InformationStateTensorSize() = 35
 ObservationTensorShape() = [10, 5]
 ObservationTensorLayout() = TensorLayout.CHW
 ObservationTensorSize() = 50
@@ -50,8 +47,6 @@ HistoryString() = ""
 IsChanceNode() = True
 IsSimultaneousNode() = False
 CurrentPlayer() = -1
-InformationStateString(0) = ""
-InformationStateTensor(0): ◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯
 ObservationString(0) = ".....\n.....\n.....\n.....\n.....\n.....\n.....\n.....\n.....\n.....\n"
 ObservationTensor(0): ◯◯◯◯◯
                       ◯◯◯◯◯
@@ -87,8 +82,6 @@ HistoryString() = "1"
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = 0
-InformationStateString(0) = "1"
-InformationStateTensor(0): ◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯
 ObservationString(0) = ".o...\n.....\n.....\n.....\n.....\n.....\n.....\n.....\n.....\n..x..\n"
 ObservationTensor(0): ◯◉◯◯◯
                       ◯◯◯◯◯
@@ -125,8 +118,6 @@ HistoryString() = "1 1"
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = 0
-InformationStateString(0) = "1 1"
-InformationStateTensor(0): ◯◉◯◯◯◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯
 ObservationString(0) = ".....\n.o...\n.....\n.....\n.....\n.....\n.....\n.....\n.....\n..x..\n"
 ObservationTensor(0): ◯◯◯◯◯
                       ◯◉◯◯◯
@@ -163,8 +154,6 @@ HistoryString() = "1 1 0"
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = 0
-InformationStateString(0) = "1 1 0"
-InformationStateTensor(0): ◯◉◯◯◯◯◉◯◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯
 ObservationString(0) = ".....\n.....\n.o...\n.....\n.....\n.....\n.....\n.....\n.....\n.x...\n"
 ObservationTensor(0): ◯◯◯◯◯
                       ◯◯◯◯◯
@@ -201,8 +190,6 @@ HistoryString() = "1 1 0 0"
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = 0
-InformationStateString(0) = "1 1 0 0"
-InformationStateTensor(0): ◯◉◯◯◯◯◉◯◯◉◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯
 ObservationString(0) = ".....\n.....\n.....\n.o...\n.....\n.....\n.....\n.....\n.....\nx....\n"
 ObservationTensor(0): ◯◯◯◯◯
                       ◯◯◯◯◯
@@ -239,8 +226,6 @@ HistoryString() = "1 1 0 0 1"
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = 0
-InformationStateString(0) = "1 1 0 0 1"
-InformationStateTensor(0): ◯◉◯◯◯◯◉◯◯◉◯◉◯◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯
 ObservationString(0) = ".....\n.....\n.....\n.....\n.o...\n.....\n.....\n.....\n.....\nx....\n"
 ObservationTensor(0): ◯◯◯◯◯
                       ◯◯◯◯◯
@@ -277,8 +262,6 @@ HistoryString() = "1 1 0 0 1 1"
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = 0
-InformationStateString(0) = "1 1 0 0 1 1"
-InformationStateTensor(0): ◯◉◯◯◯◯◉◯◯◉◯◉◯◯◉◯◯◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯
 ObservationString(0) = ".....\n.....\n.....\n.....\n.....\n.o...\n.....\n.....\n.....\nx....\n"
 ObservationTensor(0): ◯◯◯◯◯
                       ◯◯◯◯◯
@@ -315,8 +298,6 @@ HistoryString() = "1 1 0 0 1 1 0"
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = 0
-InformationStateString(0) = "1 1 0 0 1 1 0"
-InformationStateTensor(0): ◯◉◯◯◯◯◉◯◯◉◯◉◯◯◉◯◯◯◉◯◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯
 ObservationString(0) = ".....\n.....\n.....\n.....\n.....\n.....\n.o...\n.....\n.....\nx....\n"
 ObservationTensor(0): ◯◯◯◯◯
                       ◯◯◯◯◯
@@ -353,8 +334,6 @@ HistoryString() = "1 1 0 0 1 1 0 0"
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = 0
-InformationStateString(0) = "1 1 0 0 1 1 0 0"
-InformationStateTensor(0): ◯◉◯◯◯◯◉◯◯◉◯◉◯◯◉◯◯◯◉◯◯◉◯◉◯◯◯◯◯◯◯◯◯◯◯
 ObservationString(0) = ".....\n.....\n.....\n.....\n.....\n.....\n.....\n.o...\n.....\nx....\n"
 ObservationTensor(0): ◯◯◯◯◯
                       ◯◯◯◯◯
@@ -391,8 +370,6 @@ HistoryString() = "1 1 0 0 1 1 0 0 2"
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = 0
-InformationStateString(0) = "1 1 0 0 1 1 0 0 2"
-InformationStateTensor(0): ◯◉◯◯◯◯◉◯◯◉◯◉◯◯◉◯◯◯◉◯◯◉◯◉◯◯◉◯◯◯◯◯◯◯◯
 ObservationString(0) = ".....\n.....\n.....\n.....\n.....\n.....\n.....\n.....\n.o...\n.x...\n"
 ObservationTensor(0): ◯◯◯◯◯
                       ◯◯◯◯◯
@@ -429,8 +406,6 @@ HistoryString() = "1 1 0 0 1 1 0 0 2 1"
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = -4
-InformationStateString(0) = "1 1 0 0 1 1 0 0 2 1"
-InformationStateTensor(0): ◯◉◯◯◯◯◉◯◯◉◯◉◯◯◉◯◯◯◉◯◯◉◯◉◯◯◉◯◯◯◯◉◯◯◯
 ObservationString(0) = ".....\n.....\n.....\n.....\n.....\n.....\n.....\n.....\n.....\n.x...\n"
 ObservationTensor(0): ◯◯◯◯◯
                       ◯◯◯◯◯

--- a/open_spiel/integration_tests/playthroughs/deep_sea.txt
+++ b/open_spiel/integration_tests/playthroughs/deep_sea.txt
@@ -7,7 +7,7 @@ GameType.long_name = "DeepSea"
 GameType.max_num_players = 1
 GameType.min_num_players = 1
 GameType.parameter_specification = ["randomize_actions", "seed", "size", "unscaled_move_cost"]
-GameType.provides_information_state_string = True
+GameType.provides_information_state_string = False
 GameType.provides_information_state_tensor = False
 GameType.provides_observation_string = True
 GameType.provides_observation_tensor = True
@@ -43,7 +43,6 @@ HistoryString() = ""
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = 0
-InformationStateString(0) = ""
 ObservationString(0) = "x........................"
 ObservationTensor(0): ◉◯◯◯◯
                       ◯◯◯◯◯
@@ -71,7 +70,6 @@ HistoryString() = "0"
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = 0
-InformationStateString(0) = "L->L\n"
 ObservationString(0) = ".....x..................."
 ObservationTensor(0): ◯◯◯◯◯
                       ◉◯◯◯◯
@@ -99,7 +97,6 @@ HistoryString() = "0 1"
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = 0
-InformationStateString(0) = "L->L\nR->R\n"
 ObservationString(0) = "...........x............."
 ObservationTensor(0): ◯◯◯◯◯
                       ◯◯◯◯◯
@@ -127,7 +124,6 @@ HistoryString() = "0 1 0"
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = 0
-InformationStateString(0) = "L->L\nR->R\nL->L\n"
 ObservationString(0) = "...............x........."
 ObservationTensor(0): ◯◯◯◯◯
                       ◯◯◯◯◯
@@ -155,7 +151,6 @@ HistoryString() = "0 1 0 1"
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = 0
-InformationStateString(0) = "L->L\nR->R\nL->L\nR->R\n"
 ObservationString(0) = ".....................x..."
 ObservationTensor(0): ◯◯◯◯◯
                       ◯◯◯◯◯
@@ -183,7 +178,6 @@ HistoryString() = "0 1 0 1 0"
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = -4
-InformationStateString(0) = "L->L\nR->R\nL->L\nR->R\nL->R\n"
 ObservationString(0) = "........................."
 ObservationTensor(0): ◯◯◯◯◯
                       ◯◯◯◯◯

--- a/open_spiel/python/environments/catch.py
+++ b/open_spiel/python/environments/catch.py
@@ -150,9 +150,9 @@ class Environment(object):
         step_type=step_type)
 
   def _get_observation(self):
-    board = np.zeros((2, self._height, self._width), dtype=np.float32)
-    board[0, self._ball_pos.y, self._ball_pos.x] = 1.0
-    board[1, self._paddle_pos.y, self._paddle_pos.x] = 1.0
+    board = np.zeros((self._height, self._width), dtype=np.float32)
+    board[self._ball_pos.y, self._ball_pos.x] = 1.0
+    board[self._paddle_pos.y, self._paddle_pos.x] = 1.0
     return board.flatten()
 
   def observation_spec(self):
@@ -164,7 +164,7 @@ class Environment(object):
       A specification dict describing the observation fields and shapes.
     """
     return dict(
-        info_state=tuple([2 * self._height * self._width]),
+        info_state=tuple([self._height * self._width]),
         legal_actions=(self._num_actions,),
         current_player=(),
     )


### PR DESCRIPTION
`InformationStateTensor()` in `catch.cc` contained a bug. The offset was off by one, so in place of the player's first action, it recorded the chance action that determined the column of the ball. As per @lanctot's suggestion, this submission removes the function entirely.

The `GameType` in `deep_sea.cc` read `/*provides_information_state_as_normalized_vector=*/false,` when in fact it did provide the function `InformationStateTensor()`. This submission fixes the outdated `as_normalized_vector` description, and removes information states from deep_sea.

In addition, the observation tensor in catch.py has been slightly modified to agree with the observation tensor in catch.cc.