### PR TITLE
Add tests for consistency of observations.

### DIFF
--- a/open_spiel/games/coordinated_mp.cc
+++ b/open_spiel/games/coordinated_mp.cc
@@ -135,13 +135,16 @@ std::string PenniesState::InformationStateString(Player player) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
 
-  std::string str = "";
+  std::string str = std::to_string(MoveNumber());
+
   if (player == Player(0)) {
     if (actionA_ == kHeads) str.push_back('H');
     if (actionA_ == kTails) str.push_back('T');
   }
+
   if (infoset_ == kTop) str.push_back('T');
   if (infoset_ == kBottom) str.push_back('B');
+
   if (player == Player(1)) {
     if (actionB_ == kHeads) str.push_back('H');
     if (actionB_ == kTails) str.push_back('T');

--- a/open_spiel/python/algorithms/sample_some_states.py
+++ b/open_spiel/python/algorithms/sample_some_states.py
@@ -1,0 +1,96 @@
+# Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Example algorithm to sample some states from a game."""
+
+import time
+import random
+
+
+def sample_some_states(game,
+    max_rollouts=100,
+    time_limit=1,
+    depth_limit=-1,
+    include_terminals=True,
+    include_chance_states=True,
+    to_string=lambda s: s.history_str()):
+  """Samples some states in the game, indexed by their string representation.
+
+  This can be run for large games, in contrast to `get_all_states`. It is useful
+  for tests that need to check a predicate only on a subset of the game, since
+  generating the whole game is infeasible. This function either makes specified
+  number of rollouts or terminates after specified time limit.
+
+  Currently only works for sequential games.
+
+  Arguments:
+    game: The game to analyze, as returned by `load_game`.
+    max_rollouts: The maximum number of rollouts to make. Negative means no
+      limit.
+    time_limit: Time limit in seconds. Negative means no limit.
+    depth_limit: How deeply to analyze the game tree. Negative means no limit, 0
+      means root-only, etc.
+    include_terminals: If True, include terminal states.
+    include_chance_states: If True, include chance node states.
+    to_string: The serialization function. We expect this to be
+      `lambda s: s.history_str()` as this enforces perfect recall, but for
+        historical reasons, using `str` is also supported, but the goal is to
+        remove this argument.
+
+  Returns:
+    A `dict` with `to_string(state)` keys and `pyspiel.State` values containing
+    all states encountered traversing the game tree up to the specified depth.
+  """
+  if max_rollouts <= 0 and time_limit <= 0:
+    raise ValueError("Both max_rollouts={} and time_limit={} are smaller "
+                     "(or equal) than zero. The function would not return "
+                     "a useful result.")
+  some_states = dict()
+
+  def is_time_out(t):
+    return False if time_limit < 0 else time.time() - t > time_limit
+  def rollouts_exceeded(n):
+    return False if max_rollouts < 0 else n >= max_rollouts
+  def add_state_if_not_present(state):
+    nonlocal some_states
+    state_str = to_string(state)
+    if state_str not in some_states:
+      some_states[state_str] = state.clone()
+
+  start = time.time()
+  num_rollouts = 0
+  state = game.new_initial_state()
+  while not is_time_out(start) and not rollouts_exceeded(num_rollouts):
+    if not state.is_chance_node() or include_chance_states:
+      add_state_if_not_present(state)
+
+    # Do not continue beyond depth limit.
+    if state.move_number() >= depth_limit >= 0:
+      num_rollouts += 1
+      state = game.new_initial_state()
+      continue
+
+    action = random.choice(state.legal_actions(state.current_player()))
+    state.apply_action(action)
+
+    if state.is_terminal():
+      if include_terminals:
+        add_state_if_not_present(state)
+      num_rollouts += 1
+      state = game.new_initial_state()
+
+  if not some_states:
+    raise ValueError("get_some_states sampled 0 states!")
+
+  return some_states

--- a/open_spiel/python/algorithms/sample_some_states_test.py
+++ b/open_spiel/python/algorithms/sample_some_states_test.py
@@ -1,0 +1,54 @@
+# Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for open_spiel.python.algorithms.sample_some_states."""
+
+from absl.testing import absltest
+
+from open_spiel.python.algorithms import sample_some_states
+import pyspiel
+
+
+class SampleSomeStatesTest(absltest.TestCase):
+
+  def test_simple_games_with_one_rollout(self):
+    game = pyspiel.load_game_as_turn_based("matrix_mp")
+    states = sample_some_states.sample_some_states(
+        game, max_rollouts=1)
+    self.assertLen(states, 3)
+
+    states = sample_some_states.sample_some_states(
+        game, max_rollouts=1, include_terminals=False)
+    self.assertLen(states, 2)
+
+    states = sample_some_states.sample_some_states(
+        game, max_rollouts=1, depth_limit=0)
+    self.assertLen(states, 1)
+
+    states = sample_some_states.sample_some_states(
+        game, max_rollouts=1, depth_limit=1)
+    self.assertLen(states, 2)
+
+    game = pyspiel.load_game_as_turn_based("coordinated_mp")
+    states = sample_some_states.sample_some_states(
+        game, max_rollouts=1)
+    self.assertLen(states, 4)
+
+    states = sample_some_states.sample_some_states(
+        game, max_rollouts=1, include_chance_states=False)
+    self.assertLen(states, 3)
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/open_spiel/python/pybind11/pyspiel.cc
+++ b/open_spiel/python/pybind11/pyspiel.cc
@@ -256,6 +256,7 @@ PYBIND11_MODULE(pyspiel, m) {
       .def("__str__", &State::ToString)
       .def("is_terminal", &State::IsTerminal)
       .def("is_initial_state", &State::IsInitialState)
+      .def("move_number", &State::MoveNumber)
       .def("rewards", &State::Rewards)
       .def("returns", &State::Returns)
       .def("player_reward", &State::PlayerReward)


### PR DESCRIPTION
This PR mostly refactors `api_test.py` for partially enforcing OpenSpiel API.

- Sample states when setting up the test class.
- Update existing methods to use these sampled states.
- Add a test for checking partition consistency for specified relations between partitions. These partitions represent observations in the games.

The partition consistency test currently does not test tensor representation and non-sequential games.

The currently failing games are following:
```
first_sealed_auction  information_state_string    Relation.EQUALS            action_observation_history
first_sealed_auction  information_state_string    Relation.SUBSET_OR_EQUALS  move_number
hearts                information_state_string    Relation.SUBSET_OR_EQUALS  move_number
kuhn_poker            information_state_string    Relation.EQUALS            action_observation_history
kuhn_poker            information_state_string    Relation.SUBSET_OR_EQUALS  move_number
kuhn_poker            information_state_string    Relation.SUBSET_OR_EQUALS  public_observation_history
leduc_poker           information_state_string    Relation.EQUALS            action_observation_history
leduc_poker           information_state_string    Relation.SUBSET_OR_EQUALS  move_number
lewis_signaling       information_state_string    Relation.EQUALS            action_observation_history
lewis_signaling       information_state_string    Relation.SUBSET_OR_EQUALS  move_number
liars_dice            information_state_string    Relation.SUBSET_OR_EQUALS  move_number
pentago               information_state_string    Relation.EQUALS            action_observation_history
phantom_ttt           information_state_string    Relation.EQUALS            action_observation_history
tiny_bridge_2p        information_state_string    Relation.EQUALS            action_observation_history
tiny_bridge_2p        information_state_string    Relation.SUBSET_OR_EQUALS  move_number
tiny_bridge_4p        information_state_string    Relation.EQUALS            action_observation_history
tiny_bridge_4p        information_state_string    Relation.SUBSET_OR_EQUALS  move_number
tiny_hanabi           information_state_string    Relation.EQUALS            action_observation_history
tiny_hanabi           information_state_string    Relation.SUBSET_OR_EQUALS  move_number
```

I believe most errors are because of wrong encoding of time (move number) in the games.