### PR TITLE
Fix MCCFR average policy python bindings

### DIFF
--- a/open_spiel/algorithms/external_sampling_mccfr.h
+++ b/open_spiel/algorithms/external_sampling_mccfr.h
@@ -90,8 +90,8 @@ class ExternalSamplingMCCFRSolver {
   // Computes the average policy, containing the policy for all players.
   // The returned policy instance should only be used during the lifetime of
   // the CFRSolver object.
-  std::unique_ptr<Policy> AveragePolicy() const {
-    return std::unique_ptr<Policy>(
+  std::shared_ptr<Policy> AveragePolicy() const {
+    return std::shared_ptr<Policy>(
         new CFRAveragePolicy(info_states_, default_policy_));
   }
 

--- a/open_spiel/algorithms/external_sampling_mccfr_test.cc
+++ b/open_spiel/algorithms/external_sampling_mccfr_test.cc
@@ -37,7 +37,7 @@ void MCCFR_2PGameTest(const std::string& game_name, std::mt19937* rng,
   for (int i = 0; i < iterations; i++) {
     solver.RunIteration(rng);
   }
-  const std::unique_ptr<Policy> average_policy = solver.AveragePolicy();
+  const std::shared_ptr<Policy> average_policy = solver.AveragePolicy();
   double nash_conv = NashConv(*game, *average_policy, true);
   std::cout << "Game: " << game_name << ", iters = " << iterations
             << ", NashConv: " << nash_conv << std::endl;
@@ -50,7 +50,7 @@ void MCCFR_KuhnPoker3PTest(std::mt19937* rng) {
   for (int i = 0; i < 100; i++) {
     solver.RunIteration(rng);
   }
-  const std::unique_ptr<Policy> average_policy = solver.AveragePolicy();
+  const std::shared_ptr<Policy> average_policy = solver.AveragePolicy();
   std::cout << "Kuhn 3P (standard averaging) NashConv = "
             << NashConv(*game, *average_policy, true) << std::endl;
 

--- a/open_spiel/algorithms/outcome_sampling_mccfr.h
+++ b/open_spiel/algorithms/outcome_sampling_mccfr.h
@@ -71,8 +71,8 @@ class OutcomeSamplingMCCFRSolver {
   // Computes the average policy, containing the policy for all players.
   // The returned policy instance should only be used during the lifetime of
   // the CFRSolver object.
-  std::unique_ptr<Policy> AveragePolicy() const {
-    return std::unique_ptr<Policy>(
+  std::shared_ptr<Policy> AveragePolicy() const {
+    return std::shared_ptr<Policy>(
         new CFRAveragePolicy(info_states_, default_policy_));
   }
 

--- a/open_spiel/algorithms/outcome_sampling_mccfr_test.cc
+++ b/open_spiel/algorithms/outcome_sampling_mccfr_test.cc
@@ -37,7 +37,7 @@ void MCCFR_2PGameTest(const std::string& game_name, std::mt19937* rng,
   for (int i = 0; i < iterations; i++) {
     solver.RunIteration(rng);
   }
-  const std::unique_ptr<Policy> average_policy = solver.AveragePolicy();
+  const std::shared_ptr<Policy> average_policy = solver.AveragePolicy();
   double nash_conv = NashConv(*game, *average_policy, true);
   std::cout << "Game: " << game_name << ", iters = " << iterations
             << ", NashConv: " << nash_conv << std::endl;


### PR DESCRIPTION
Since `Policy` objects are managed by shared pointers in python (changed [here](https://github.com/deepmind/open_spiel/commit/d9fd68b7f5f1cfa77ef028d33fd89c48f40b7af5),) MCCFR calls to `average_policy` are causing seg faults (e.g. by running [this script](https://github.com/deepmind/open_spiel/blob/master/open_spiel/python/examples/mccfr_cpp_example.py)). This PR fixes that by also using shared pointers for MCCFR solvers.