### PR TITLE
Fix the sampled stochastic games test

### DIFF
--- a/open_spiel/python/tests/sampled_stochastic_games_test.py
+++ b/open_spiel/python/tests/sampled_stochastic_games_test.py
@@ -43,16 +43,14 @@ class SampledStochasticGamesTest(parameterized.TestCase):
                              {"rng_seed": pyspiel.GameParameter(0)})
 
     for seed in range(NUM_RUNS):
-      # Mutate game's internal RNG state.
+      # Mutate game's internal RNG state by doing a full playout.
+      test_utils.random_playout(game.new_initial_state(), seed)
       deserialized_game = pickle.loads(pickle.dumps(game))
 
       # Make sure initial states are the same after game deserialization.
       state = test_utils.random_playout(game.new_initial_state(), seed)
       deserialized_state = test_utils.random_playout(
           deserialized_game.new_initial_state(), seed)
-
-      # If game with default parameters doesn't use the RNG
-      # below assertion fails.
       self.assertEqual(str(state), str(deserialized_state))
 
 


### PR DESCRIPTION
I believe the current test was inadequate as the RNG state of sampled stochastic games was not actually advanced before the de/ser cycle (line 47). In order to advance the state, a full playout of a "single game" should be performed. The RNG state needs to be advanced to avoid serializing the initial RNG state value which would be "deserialized" correctly even in cases where deserialization is simply creating an instance with default initial values. cc @finbarrtimbers 