### PR TITLE
Write to console which python include dirs are used.

### DIFF
--- a/open_spiel/python/CMakeLists.txt
+++ b/open_spiel/python/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package(Python3 COMPONENTS Interpreter Development)
+message(NOTICE "Python include dirs: ${Python3_INCLUDE_DIRS}")
 include_directories(SYSTEM ${Python3_INCLUDE_DIRS})
 
 if(Python3_VERSION VERSION_LESS "3.6.0")


### PR DESCRIPTION
This was useful for troubleshooting IDE cmake integration. 

While I had virtualenv correctly setup, the IDE used system default python version which was different from the one used in the virtualenv. This lead to weird error messages (segfaults) that were non-trivial to figure out. This message should help debugging future issues if someone has a problem like this too.

The messages were something like this (saving for future reference if someone finds this in github search):

```
> import pyspiel
ImportError: /home/michal/Code/open_spiel/build/python/pyspiel.so: undefined symbol: PyThread_tss_set
```

```
$ ./scripts/regenerate_playthroughs.sh         
./scripts/regenerate_playthroughs.sh: line 21:  9679 Segmentation fault      (core dumped)
```




