### PR TITLE
Add a specific bounds check.

### DIFF
--- a/open_spiel/observer.cc
+++ b/open_spiel/observer.cc
@@ -27,6 +27,7 @@ namespace open_spiel {
 DimensionedSpan ContiguousAllocator::Get(
     absl::string_view name, const absl::InlinedVector<int, 4>& shape) {
   const int size = absl::c_accumulate(shape, 1, std::multiplies<int>());
+  SPIEL_DCHECK_LE(offset_, data_.size());
   auto piece = data_.subspan(offset_, size);
   offset_ += size;
   return DimensionedSpan(piece, shape);


### PR DESCRIPTION
I spent bunch of time on this one -- subspan throws an exception which is translated into IndexError in Python without a stacktrace, making it difficult to locate the source of problem. By duplicating this boundary check it is easier to track down future bugs.