### PR TITLE
Small usability improvements for Swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 // Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
@@ -20,6 +20,7 @@ import PackageDescription
 
 let package = Package(
   name: "OpenSpiel",
+  platforms: [.macOS(.v10_13)],
   products: [
     .library(
       name: "OpenSpiel",
@@ -35,7 +36,7 @@ let package = Package(
       targets: ["TexasHoldemBenchmark"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/google/swift-benchmark.git", .branch("master")),
+    .package(name: "Benchmark", url: "https://github.com/google/swift-benchmark.git", .branch("master")),
   ],
   targets: [
     .target(

--- a/swift/Sources/OpenSpiel/Spiel.swift
+++ b/swift/Sources/OpenSpiel/Spiel.swift
@@ -312,6 +312,25 @@ public struct GameInfo {
   /// Which type of information state representations are supported?
   public let providesInformationStateString: Bool
   public let providesInformationStateTensor: Bool
+    
+  /// Creates`GameInfo` struct from a full list of static game properties.
+  public init(shortName: String, longName: String, dynamics: GameInfo.Dynamics,
+              chanceMode: GameInfo.ChanceMode, information: GameInfo.Information,
+              utility: GameInfo.Utility, rewardModel: GameInfo.RewardModel,
+              maxPlayers: Int, minPlayers: Int, providesInformationStateString: Bool,
+              providesInformationStateTensor: Bool) {
+    self.shortName = shortName
+    self.longName = longName
+    self.dynamics = dynamics
+    self.chanceMode = chanceMode
+    self.information = information
+    self.utility = utility
+    self.rewardModel = rewardModel
+    self.maxPlayers = maxPlayers
+    self.minPlayers = minPlayers
+    self.providesInformationStateString = providesInformationStateString
+    self.providesInformationStateTensor = providesInformationStateTensor
+  }
 }
 
 /// Used to sample a policy. Can also sample from chance outcomes.


### PR DESCRIPTION
Hello @elkhrt,

To follow up on our discussion in #375 here's a PR that "fixes a few potholes" when using OpenSpiel in Swift.

- [x] 1. [`GameInfo`](https://github.com/deepmind/open_spiel/blob/91da643188fcacd7a57bf5a64ee392d6c919dcfc/swift/Sources/OpenSpiel/Spiel.swift#L242) struct doesn't have a public member-wise intializer.

- [x] 2. Building with latest [S4TF](https://github.com/tensorflow/swift/blob/master/Installation.md)  toolchain 0.11 fails. Fixing this requires upgrading `Package.swift` manifest to Swift 5.

- [ ] 3. I'll submit the games from [_Sutton & Barto '18_](http://incompleteideas.net/book/the-book-2nd.html) book in separate PRs. I'd like to test them first by working through the exercises.

Please, let me know what do you think and if the commits need improvements.

Thanks!

  Vojta
