### PR TITLE
Allow constructing game parameters from string literals

### DIFF
--- a/open_spiel/game_parameters.h
+++ b/open_spiel/game_parameters.h
@@ -56,18 +56,20 @@ class GameParameter {
         string_value_(value),
         type_(Type::kString) {}
 
-  // NOTE: This is not subsumed by the previous method, even if value can be
-  //       converted to a std::string, because the [C++ standard][iso] requires
-  //       that the *standard conversion sequence* (see §13.3.3.1.1)
+  // Allows construction of a `GameParameter` from a string literal.
+  //
+  // NOTE: This method is not subsumed by the previous method, even if value can
+  //       be converted to a std::string, because the [C++ standard][iso]
+  //       requires that the *standard conversion sequence* (see §13.3.3.1.1)
   //         `(const char[]) -> const char* -> bool`
   //       take precedence over the *user-defined conversion sequence*
   //         `(const char[]) -> const char* -> std::string`
   //       defined in the standard library.
   //
-  // So, without the next method, `GameParameter("1")` would be registered as
-  // a bool game parameter instead of a string one.
+  //       So, without the next method, `GameParameter("1")` would be registered
+  //       as a bool game parameter instead of a string one.
   //
-  // Closes #380.
+  //       Closes: #380.
   //
   // [iso]: http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2011/n3242.pdf
   explicit GameParameter(const char* value, bool is_mandatory = false)

--- a/open_spiel/game_parameters.h
+++ b/open_spiel/game_parameters.h
@@ -56,6 +56,25 @@ class GameParameter {
         string_value_(value),
         type_(Type::kString) {}
 
+  // NOTE: This is not subsumed by the previous method, even if value can be
+  //       converted to a std::string, because the [C++ standard][iso] requires
+  //       that the *standard conversion sequence* (see §13.3.3.1.1)
+  //         `(const char[]) -> const char* -> bool`
+  //       take precedence over the *user-defined conversion sequence*
+  //         `(const char[]) -> const char* -> std::string`
+  //       defined in the standard library.
+  //
+  // So, without the next method, `GameParameter("1")` would be registered as
+  // a bool game parameter instead of a string one.
+  //
+  // Closes #380.
+  //
+  // [iso]: http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2011/n3242.pdf
+  explicit GameParameter(const char* value, bool is_mandatory = false)
+      : is_mandatory_(is_mandatory),
+        string_value_(value),
+        type_(Type::kString) {}
+
   explicit GameParameter(bool value, bool is_mandatory = false)
       : is_mandatory_(is_mandatory), bool_value_(value), type_(Type::kBool) {}
 

--- a/open_spiel/tests/spiel_test.cc
+++ b/open_spiel/tests/spiel_test.cc
@@ -241,6 +241,13 @@ void LeducPokerDeserializeTest() {
 }
 
 void GameParametersTest() {
+  // Basic types
+  SPIEL_CHECK_TRUE(GameParameter(1).has_int_value());
+  SPIEL_CHECK_TRUE(GameParameter(1.0).has_double_value());
+  SPIEL_CHECK_TRUE(GameParameter(true).has_bool_value());
+  SPIEL_CHECK_TRUE(GameParameter(std::string("1")).has_string_value());
+  SPIEL_CHECK_TRUE(GameParameter("1").has_string_value());  // See issue #380.
+
   // Bare name
   auto params = GameParametersFromString("game_one");
   SPIEL_CHECK_EQ(params.size(), 1);


### PR DESCRIPTION
Closes: #380 

Overloads `GameParameter` so that it accepts string literals directly.

Adjusted:
- [x] Implementation
- [x] Tests