### PR TITLE
Add Bot API. Register basic bots.

### DIFF
--- a/open_spiel/python/pybind11/bots.cc
+++ b/open_spiel/python/pybind11/bots.cc
@@ -167,6 +167,29 @@ void init_pyspiel_bots(py::module& m) {
       .def("get_policy", &Bot::GetPolicy)
       .def("step_with_policy", &Bot::StepWithPolicy);
 
+  m.def("load_bot",
+        py::overload_cast<const std::string&>(&open_spiel::LoadBot),
+        "Returns a new bot object for the specified bot name using default "
+        "parameters");
+  m.def("load_bot",
+        py::overload_cast<const std::string&, const GameParameters&>(
+            &open_spiel::LoadBot),
+        "Returns a new bot object for the specified bot name using given "
+        "parameters");
+  m.def("is_bot_registered", &IsBotRegistered,
+        "Checks if a bot under the given name is registered.");
+  m.def("registered_bots", &RegisteredBots,
+        "Returns a list of registered bot names.");
+  m.def("bots_that_can_play_game",
+        py::overload_cast<const Game&>(&open_spiel::BotsThatCanPlayGame),
+        "Returns a list of bot names that can play specified game, "
+        "while using default parameters for the bots.");
+  m.def("bots_that_can_play_game",
+        py::overload_cast<const Game&, const GameParameters&>(
+            &open_spiel::BotsThatCanPlayGame),
+        "Returns a list of bot names that can play specified game, "
+        "while using the provided parameters.");
+
   py::class_<algorithms::Evaluator,
              std::shared_ptr<algorithms::Evaluator>> mcts_evaluator(
                  m, "Evaluator");

--- a/open_spiel/python/pybind11/bots.cc
+++ b/open_spiel/python/pybind11/bots.cc
@@ -188,14 +188,7 @@ void init_pyspiel_bots(py::module& m) {
   m.def("bots_that_can_play_game",
         py::overload_cast<const Game&, Player>(&open_spiel::BotsThatCanPlayGame),
          py::arg("game"), py::arg("player"),
-        "Returns a list of bot names that can play specified game, "
-        "while using default parameters for the bots.");
-  m.def("bots_that_can_play_game",
-        py::overload_cast<const Game&, Player, const GameParameters&>(
-            &open_spiel::BotsThatCanPlayGame),
-        py::arg("game"), py::arg("player"), py::arg("params"),
-        "Returns a list of bot names that can play specified game, "
-        "while using the provided parameters.");
+        "Returns a list of bot names that can play specified game for the given player.");
 
   py::class_<algorithms::Evaluator,
              std::shared_ptr<algorithms::Evaluator>> mcts_evaluator(

--- a/open_spiel/python/pybind11/bots.cc
+++ b/open_spiel/python/pybind11/bots.cc
@@ -168,12 +168,17 @@ void init_pyspiel_bots(py::module& m) {
       .def("step_with_policy", &Bot::StepWithPolicy);
 
   m.def("load_bot",
-        py::overload_cast<const std::string&>(&open_spiel::LoadBot),
+        py::overload_cast<
+            const std::string&, const std::shared_ptr<const Game>&, Player>(
+                &open_spiel::LoadBot),
+        py::arg("bot_name"), py::arg("game"), py::arg("player"),
         "Returns a new bot object for the specified bot name using default "
         "parameters");
   m.def("load_bot",
-        py::overload_cast<const std::string&, const GameParameters&>(
-            &open_spiel::LoadBot),
+        py::overload_cast<
+            const std::string&, const std::shared_ptr<const Game>&, Player,
+            const GameParameters&>(&open_spiel::LoadBot),
+        py::arg("bot_name"), py::arg("game"), py::arg("player"), py::arg("params"),
         "Returns a new bot object for the specified bot name using given "
         "parameters");
   m.def("is_bot_registered", &IsBotRegistered,
@@ -181,12 +186,14 @@ void init_pyspiel_bots(py::module& m) {
   m.def("registered_bots", &RegisteredBots,
         "Returns a list of registered bot names.");
   m.def("bots_that_can_play_game",
-        py::overload_cast<const Game&>(&open_spiel::BotsThatCanPlayGame),
+        py::overload_cast<const Game&, Player>(&open_spiel::BotsThatCanPlayGame),
+         py::arg("game"), py::arg("player"),
         "Returns a list of bot names that can play specified game, "
         "while using default parameters for the bots.");
   m.def("bots_that_can_play_game",
-        py::overload_cast<const Game&, const GameParameters&>(
+        py::overload_cast<const Game&, Player, const GameParameters&>(
             &open_spiel::BotsThatCanPlayGame),
+        py::arg("game"), py::arg("player"), py::arg("params"),
         "Returns a list of bot names that can play specified game, "
         "while using the provided parameters.");
 

--- a/open_spiel/python/pybind11/bots.cc
+++ b/open_spiel/python/pybind11/bots.cc
@@ -188,7 +188,13 @@ void init_pyspiel_bots(py::module& m) {
   m.def("bots_that_can_play_game",
         py::overload_cast<const Game&, Player>(&open_spiel::BotsThatCanPlayGame),
          py::arg("game"), py::arg("player"),
-        "Returns a list of bot names that can play specified game for the given player.");
+        "Returns a list of bot names that can play specified game for the "
+        "given player.");
+  m.def("bots_that_can_play_game",
+        py::overload_cast<const Game&>(&open_spiel::BotsThatCanPlayGame),
+        py::arg("game"),
+        "Returns a list of bot names that can play specified game for any "
+        "player.");
 
   py::class_<algorithms::Evaluator,
              std::shared_ptr<algorithms::Evaluator>> mcts_evaluator(

--- a/open_spiel/python/tests/bot_test.py
+++ b/open_spiel/python/tests/bot_test.py
@@ -25,7 +25,12 @@ import numpy as np
 from open_spiel.python.bots import uniform_random
 import pyspiel
 
-SPIEL_BOTS_LIST = pyspiel.registered_bots()
+# Specify bot names in alphabetical order, to make it easier to read.
+SPIEL_BOTS_LIST = [
+  "fixed_action_preference",
+  "uniform_random",
+]
+
 
 class BotTest(absltest.TestCase):
 
@@ -43,31 +48,20 @@ class BotTest(absltest.TestCase):
     np.testing.assert_allclose(average_results, [0.125, -0.125], atol=0.1)
 
   def test_registered_bots(self):
-    # Specify bot names in alphabetical order, to make the test easier to read.
-    expected = set([
-      "fixed_action_preference",
-      "uniform_random",
-    ])
-    expected = sorted(list(expected))
-    self.assertCountEqual(SPIEL_BOTS_LIST, expected)
+    self.assertEqual(sorted(pyspiel.registered_bots()), sorted(SPIEL_BOTS_LIST))
 
   def test_can_play_game(self):
     game = pyspiel.load_game("kuhn_poker")
-    self.assertTrue("uniform_random" in pyspiel.bots_that_can_play_game(game))
-
-  def test_bots_can_be_constructed_with_default_params(self):
-    for bot_name in SPIEL_BOTS_LIST:
-      pyspiel.load_bot(bot_name)
+    self.assertTrue("uniform_random" in
+                    pyspiel.bots_that_can_play_game(game, 0))
 
   def test_passing_params(self):
     game = pyspiel.load_game("tic_tac_toe")
     bots = [
-      pyspiel.load_bot("fixed_action_preference",
-                       {"player": pyspiel.GameParameter(0),
-                        "actions": pyspiel.GameParameter("0:1:2")}),
-      pyspiel.load_bot("fixed_action_preference",
-                       {"player": pyspiel.GameParameter(1),
-                        "actions": pyspiel.GameParameter("3:4")}),
+      pyspiel.load_bot("fixed_action_preference", game, player=0,
+                       params={"actions": pyspiel.GameParameter("0:1:2")}),
+      pyspiel.load_bot("fixed_action_preference", game, player=1,
+                       params={"actions": pyspiel.GameParameter("3:4")}),
     ]
     result = pyspiel.evaluate_bots(game.new_initial_state(), bots, seed=0)
     self.assertEqual(result, [1, -1])  # Player 0 wins.

--- a/open_spiel/python/tests/bot_test.py
+++ b/open_spiel/python/tests/bot_test.py
@@ -52,8 +52,7 @@ class BotTest(absltest.TestCase):
 
   def test_can_play_game(self):
     game = pyspiel.load_game("kuhn_poker")
-    self.assertTrue("uniform_random" in
-                    pyspiel.bots_that_can_play_game(game, 0))
+    self.assertTrue("uniform_random" in pyspiel.bots_that_can_play_game(game))
 
   def test_passing_params(self):
     game = pyspiel.load_game("tic_tac_toe")

--- a/open_spiel/python/tests/bot_test.py
+++ b/open_spiel/python/tests/bot_test.py
@@ -25,6 +25,7 @@ import numpy as np
 from open_spiel.python.bots import uniform_random
 import pyspiel
 
+SPIEL_BOTS_LIST = pyspiel.registered_bots()
 
 class BotTest(absltest.TestCase):
 
@@ -40,6 +41,36 @@ class BotTest(absltest.TestCase):
     ])
     average_results = np.mean(results, axis=0)
     np.testing.assert_allclose(average_results, [0.125, -0.125], atol=0.1)
+
+  def test_registered_bots(self):
+    # Specify bot names in alphabetical order, to make the test easier to read.
+    expected = set([
+      "fixed_action_preference",
+      "uniform_random",
+    ])
+    expected = sorted(list(expected))
+    self.assertCountEqual(SPIEL_BOTS_LIST, expected)
+
+  def test_can_play_game(self):
+    game = pyspiel.load_game("kuhn_poker")
+    self.assertTrue("uniform_random" in pyspiel.bots_that_can_play_game(game))
+
+  def test_bots_can_be_constructed_with_default_params(self):
+    for bot_name in SPIEL_BOTS_LIST:
+      pyspiel.load_bot(bot_name)
+
+  def test_passing_params(self):
+    game = pyspiel.load_game("tic_tac_toe")
+    bots = [
+      pyspiel.load_bot("fixed_action_preference",
+                       {"player": pyspiel.GameParameter(0),
+                        "actions": pyspiel.GameParameter("0:1:2")}),
+      pyspiel.load_bot("fixed_action_preference",
+                       {"player": pyspiel.GameParameter(1),
+                        "actions": pyspiel.GameParameter("3:4")}),
+    ]
+    result = pyspiel.evaluate_bots(game.new_initial_state(), bots, seed=0)
+    self.assertEqual(result, [1, -1])  # Player 0 wins.
 
 
 if __name__ == "__main__":

--- a/open_spiel/spiel_bots.cc
+++ b/open_spiel/spiel_bots.cc
@@ -171,8 +171,7 @@ std::unique_ptr<Bot> MakeUniformRandomBot(Player player_id, int seed) {
 namespace {
 class UniformRandomBotFactory : public BotFactory {
  public:
-  bool CanPlayGame(const Game& game, Player player_id,
-                   const GameParameters& bot_params) const override {
+  bool CanPlayGame(const Game& game, Player player_id) const override {
     return true;
   }
   std::unique_ptr<Bot> Create(
@@ -215,8 +214,7 @@ std::vector<Action> ActionsFromStr(const absl::string_view& str,
 
 class FixedActionPreferenceFactory : public BotFactory {
  public:
-  bool CanPlayGame(const Game& game, Player player_id,
-                   const GameParameters& bot_params) const override {
+  bool CanPlayGame(const Game& game, Player player_id) const override {
     return true;
   }
   std::unique_ptr<Bot> Create(
@@ -257,10 +255,10 @@ std::unique_ptr<Bot> BotRegisterer::CreateByName(
   }
 }
 std::vector<std::string> BotRegisterer::CanPlayGame(
-    const Game& game, Player player_id, const GameParameters& params) {
+    const Game& game, Player player_id) {
   std::vector<std::string> bot_names;
   for (const auto& key_val : factories()) {
-    if (key_val.second->CanPlayGame(game, player_id, params)) {
+    if (key_val.second->CanPlayGame(game, player_id)) {
       bot_names.push_back(key_val.first);
     }
   }
@@ -301,11 +299,7 @@ std::unique_ptr<Bot> LoadBot(const std::string& bot_name,
 }
 std::vector<std::string> BotsThatCanPlayGame(const Game& game,
                                              Player player_id) {
-  return BotRegisterer::CanPlayGame(game, player_id, {});
-}
-std::vector<std::string> BotsThatCanPlayGame(const Game& game, Player player_id,
-                                             const GameParameters& params) {
-  return BotRegisterer::CanPlayGame(game, player_id, params);
+  return BotRegisterer::CanPlayGame(game, player_id);
 }
 
 }  // namespace open_spiel

--- a/open_spiel/spiel_bots.cc
+++ b/open_spiel/spiel_bots.cc
@@ -254,7 +254,7 @@ std::unique_ptr<Bot> BotRegisterer::CreateByName(
     return factory->Create(std::move(game), player_id, params);
   }
 }
-std::vector<std::string> BotRegisterer::CanPlayGame(
+std::vector<std::string> BotRegisterer::BotsThatCanPlayGame(
     const Game& game, Player player_id) {
   std::vector<std::string> bot_names;
   for (const auto& key_val : factories()) {
@@ -264,7 +264,7 @@ std::vector<std::string> BotRegisterer::CanPlayGame(
   }
   return bot_names;
 }
-std::vector<std::string> BotRegisterer::CanPlayGame(const Game& game) {
+std::vector<std::string> BotRegisterer::BotsThatCanPlayGame(const Game& game) {
   std::vector<std::string> bot_names;
   for (const auto& key_val : factories()) {
     bool can_play_for_all = true;
@@ -313,10 +313,10 @@ std::unique_ptr<Bot> LoadBot(const std::string& bot_name,
 }
 std::vector<std::string> BotsThatCanPlayGame(const Game& game,
                                              Player player_id) {
-  return BotRegisterer::CanPlayGame(game, player_id);
+  return BotRegisterer::BotsThatCanPlayGame(game, player_id);
 }
 std::vector<std::string> BotsThatCanPlayGame(const Game& game) {
-  return BotRegisterer::CanPlayGame(game);
+  return BotRegisterer::BotsThatCanPlayGame(game);
 }
 
 }  // namespace open_spiel

--- a/open_spiel/spiel_bots.cc
+++ b/open_spiel/spiel_bots.cc
@@ -264,6 +264,20 @@ std::vector<std::string> BotRegisterer::CanPlayGame(
   }
   return bot_names;
 }
+std::vector<std::string> BotRegisterer::CanPlayGame(const Game& game) {
+  std::vector<std::string> bot_names;
+  for (const auto& key_val : factories()) {
+    bool can_play_for_all = true;
+    for (int player_id = 0; player_id < game.NumPlayers(); ++player_id) {
+      if (!key_val.second->CanPlayGame(game, player_id)) {
+        can_play_for_all = false;
+        break;
+      }
+    }
+    if (can_play_for_all) bot_names.push_back(key_val.first);
+  }
+  return bot_names;
+}
 void BotRegisterer::RegisterBot(const std::string& bot_name,
                                 std::unique_ptr<BotFactory> creator) {
   factories()[bot_name] = std::move(creator);
@@ -300,6 +314,9 @@ std::unique_ptr<Bot> LoadBot(const std::string& bot_name,
 std::vector<std::string> BotsThatCanPlayGame(const Game& game,
                                              Player player_id) {
   return BotRegisterer::CanPlayGame(game, player_id);
+}
+std::vector<std::string> BotsThatCanPlayGame(const Game& game) {
+  return BotRegisterer::CanPlayGame(game);
 }
 
 }  // namespace open_spiel

--- a/open_spiel/spiel_bots.h
+++ b/open_spiel/spiel_bots.h
@@ -187,6 +187,7 @@ class BotRegisterer {
       Player player_id, const GameParameters& params);
   static std::vector<std::string> CanPlayGame(
       const Game& game, Player player_id);
+  static std::vector<std::string> CanPlayGame(const Game& game);
 
   static std::vector<std::string> RegisteredBots();
   static bool IsBotRegistered(const std::string& bot_name);
@@ -210,9 +211,14 @@ bool IsBotRegistered(const std::string& bot_name);
 // Returns a list of registered bots' short names.
 std::vector<std::string> RegisteredBots();
 
-// Returns a list of registered bots' short names that can play specified game.
+// Returns a list of registered bots' short names that can play specified game
+// for a given player.
 std::vector<std::string> BotsThatCanPlayGame(const Game& game,
                                              Player player_id);
+
+// Returns a list of registered bots' short names that can play specified game
+// for any player.
+std::vector<std::string> BotsThatCanPlayGame(const Game& game);
 
 // Returns a new bot object from the specified string, which is the short
 // name plus optional parameters, e.g. "fixed_action_preference(action_list=0;1;2;3)"

--- a/open_spiel/spiel_bots.h
+++ b/open_spiel/spiel_bots.h
@@ -146,8 +146,7 @@ class Bot {
 class BotFactory {
  public:
   // Asks the bot whether it can play the game as the given player.
-  virtual bool CanPlayGame(const Game& game, Player player_id,
-                           const GameParameters& bot_params) const = 0;
+  virtual bool CanPlayGame(const Game& game, Player player_id) const = 0;
 
   // Creates an instance of the bot for a given game and a player
   // for which it should play.
@@ -187,7 +186,7 @@ class BotRegisterer {
       const std::string& bot_name, std::shared_ptr<const Game> game,
       Player player_id, const GameParameters& params);
   static std::vector<std::string> CanPlayGame(
-      const Game& game, Player player_id, const GameParameters& params);
+      const Game& game, Player player_id);
 
   static std::vector<std::string> RegisteredBots();
   static bool IsBotRegistered(const std::string& bot_name);
@@ -212,8 +211,6 @@ bool IsBotRegistered(const std::string& bot_name);
 std::vector<std::string> RegisteredBots();
 
 // Returns a list of registered bots' short names that can play specified game.
-std::vector<std::string> BotsThatCanPlayGame(const Game& game, Player player_id,
-                                             const GameParameters& params);
 std::vector<std::string> BotsThatCanPlayGame(const Game& game,
                                              Player player_id);
 

--- a/open_spiel/spiel_bots.h
+++ b/open_spiel/spiel_bots.h
@@ -185,9 +185,9 @@ class BotRegisterer {
   static std::unique_ptr<Bot> CreateByName(
       const std::string& bot_name, std::shared_ptr<const Game> game,
       Player player_id, const GameParameters& params);
-  static std::vector<std::string> CanPlayGame(
+  static std::vector<std::string> BotsThatCanPlayGame(
       const Game& game, Player player_id);
-  static std::vector<std::string> CanPlayGame(const Game& game);
+  static std::vector<std::string> BotsThatCanPlayGame(const Game& game);
 
   static std::vector<std::string> RegisteredBots();
   static bool IsBotRegistered(const std::string& bot_name);


### PR DESCRIPTION
Adds #373

There is a number of other bots in the library (for example MCTS), but they are more complicated to construct from default params, so I left out their registration at the moment.

I reused the `GameParameter` from games for bots. As pointed out in #335 , it's not a great name, and I think we should rename it to something like `Parameter` or `TypedParameter`, and alias it back for backwards compatibility.