### PR TITLE
Force a point when serializing a double game param

### DIFF
--- a/open_spiel/game_parameters.cc
+++ b/open_spiel/game_parameters.cc
@@ -58,18 +58,18 @@ std::string GameParameter::ToString() const {
     case Type::kInt:
       return absl::StrCat(int_value());
     case Type::kDouble: {
-      // XXX(maintainers): We make sure to include a '.0' for doubles that hold
-      //      integer values to avoid deserializing them as integers (see
-      //      implementation in `GameParameterFromString`).
+      // XXX: We make sure to include a '.0' for doubles that hold
+      //     integer values to avoid deserializing them as integers (see
+      //     implementation in `GameParameterFromString`).
       //
-      //      See also: #382.
+      //     See also: #382.
       //
       //
       // We cannot use StrCat as that would default to exponential notation
       // sometimes. For example, the default format of 10^-9 is the string
       // "1e-9". For that reason, we use std::stringstream here.
       //
-      // FIXME(maintainers): Avoid hardcoding the number of digits after the
+      // TODO: Avoid hardcoding the number of digits after the
       //     point if possible?
       std::stringstream ss;
       ss << std::fixed << std::setprecision(10) << double_value();

--- a/open_spiel/game_parameters.cc
+++ b/open_spiel/game_parameters.cc
@@ -14,8 +14,10 @@
 
 #include "open_spiel/game_parameters.h"
 
+#include <iomanip>
 #include <list>
 #include <map>
+#include <sstream>
 #include <string>
 #include <utility>
 
@@ -55,8 +57,24 @@ std::string GameParameter::ToString() const {
   switch (type_) {
     case Type::kInt:
       return absl::StrCat(int_value());
-    case Type::kDouble:
-      return absl::StrCat(double_value());
+    case Type::kDouble: {
+      // XXX(maintainers): We make sure to include a '.0' for doubles that hold
+      //      integer values to avoid deserializing them as integers (see
+      //      implementation in `GameParameterFromString`).
+      //
+      //      See also: #382.
+      //
+      //
+      // We cannot use StrCat as that would default to exponential notation
+      // sometimes. For example, the default format of 10^-9 is the string
+      // "1e-9". For that reason, we use std::stringstream here.
+      //
+      // FIXME(maintainers): Avoid hardcoding the number of digits after the
+      //     point if possible?
+      std::stringstream ss;
+      ss << std::fixed << std::setprecision(10) << double_value();
+      return ss.str();
+    }
     case Type::kString:
       return string_value();
     case Type::kBool:

--- a/open_spiel/game_parameters.h
+++ b/open_spiel/game_parameters.h
@@ -56,18 +56,20 @@ class GameParameter {
         string_value_(value),
         type_(Type::kString) {}
 
-  // NOTE: This is not subsumed by the previous method, even if value can be
-  //       converted to a std::string, because the [C++ standard][iso] requires
-  //       that the *standard conversion sequence* (see §13.3.3.1.1)
+  // Allows construction of a `GameParameter` from a string literal.
+  //
+  // NOTE: This method is not subsumed by the previous method, even if value can
+  //       be converted to a std::string, because the [C++ standard][iso]
+  //       requires that the *standard conversion sequence* (see §13.3.3.1.1)
   //         `(const char[]) -> const char* -> bool`
   //       take precedence over the *user-defined conversion sequence*
   //         `(const char[]) -> const char* -> std::string`
   //       defined in the standard library.
   //
-  // So, without the next method, `GameParameter("1")` would be registered as
-  // a bool game parameter instead of a string one.
+  //       So, without the next method, `GameParameter("1")` would be registered
+  //       as a bool game parameter instead of a string one.
   //
-  // Closes #380.
+  //       Closes: #380.
   //
   // [iso]: http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2011/n3242.pdf
   explicit GameParameter(const char* value, bool is_mandatory = false)

--- a/open_spiel/game_parameters.h
+++ b/open_spiel/game_parameters.h
@@ -34,6 +34,7 @@ class GameParameter;
 
 using GameParameters = std::map<std::string, GameParameter>;
 std::string GameParametersToString(const GameParameters& game_params);
+GameParameter GameParameterFromString(const std::string& game_string);
 GameParameters GameParametersFromString(const std::string& game_string);
 
 class GameParameter {

--- a/open_spiel/game_parameters.h
+++ b/open_spiel/game_parameters.h
@@ -56,6 +56,25 @@ class GameParameter {
         string_value_(value),
         type_(Type::kString) {}
 
+  // NOTE: This is not subsumed by the previous method, even if value can be
+  //       converted to a std::string, because the [C++ standard][iso] requires
+  //       that the *standard conversion sequence* (see §13.3.3.1.1)
+  //         `(const char[]) -> const char* -> bool`
+  //       take precedence over the *user-defined conversion sequence*
+  //         `(const char[]) -> const char* -> std::string`
+  //       defined in the standard library.
+  //
+  // So, without the next method, `GameParameter("1")` would be registered as
+  // a bool game parameter instead of a string one.
+  //
+  // Closes #380.
+  //
+  // [iso]: http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2011/n3242.pdf
+  explicit GameParameter(const char* value, bool is_mandatory = false)
+      : is_mandatory_(is_mandatory),
+        string_value_(value),
+        type_(Type::kString) {}
+
   explicit GameParameter(bool value, bool is_mandatory = false)
       : is_mandatory_(is_mandatory), bool_value_(value), type_(Type::kBool) {}
 

--- a/open_spiel/integration_tests/playthroughs/cursor_go(board_size=5,max_cursor_moves=7).txt
+++ b/open_spiel/integration_tests/playthroughs/cursor_go(board_size=5,max_cursor_moves=7).txt
@@ -19,7 +19,7 @@ GameType.utility = Utility.ZERO_SUM
 NumDistinctActions() = 6
 PolicyTensorShape() = [6]
 MaxChanceOutcomes() = 0
-GetParameters() = {board_size=5,handicap=0,komi=7.5,max_cursor_moves=7}
+GetParameters() = {board_size=5,handicap=0,komi=7.5000000000,max_cursor_moves=7}
 NumPlayers() = 2
 MinUtility() = -1.0
 MaxUtility() = 1.0

--- a/open_spiel/integration_tests/playthroughs/deep_sea.txt
+++ b/open_spiel/integration_tests/playthroughs/deep_sea.txt
@@ -19,7 +19,7 @@ GameType.utility = Utility.GENERAL_SUM
 NumDistinctActions() = 2
 PolicyTensorShape() = [2]
 MaxChanceOutcomes() = 2
-GetParameters() = {randomize_actions=True,seed=42,size=5,unscaled_move_cost=0.01}
+GetParameters() = {randomize_actions=True,seed=42,size=5,unscaled_move_cost=0.0100000000}
 NumPlayers() = 1
 MinUtility() = -0.01
 MaxUtility() = 0.99

--- a/open_spiel/integration_tests/playthroughs/go.txt
+++ b/open_spiel/integration_tests/playthroughs/go.txt
@@ -19,7 +19,7 @@ GameType.utility = Utility.ZERO_SUM
 NumDistinctActions() = 50
 PolicyTensorShape() = [50]
 MaxChanceOutcomes() = 0
-GetParameters() = {board_size=7,handicap=0,komi=4.5,max_game_length=98}
+GetParameters() = {board_size=7,handicap=0,komi=4.5000000000,max_game_length=98}
 NumPlayers() = 2
 MinUtility() = -1.0
 MaxUtility() = 1.0
@@ -28,7 +28,7 @@ ObservationTensorShape() = [4, 7, 7]
 ObservationTensorLayout() = TensorLayout.CHW
 ObservationTensorSize() = 196
 MaxGameLength() = 98
-ToString() = "go(board_size=7,komi=4.5)"
+ToString() = "go(board_size=7,komi=4.5000000000)"
 
 # State 0
 # GoState(komi=4.5, to_play=B, history.size()=0)

--- a/open_spiel/tests/spiel_test.cc
+++ b/open_spiel/tests/spiel_test.cc
@@ -29,7 +29,7 @@
 #include "open_spiel/spiel_utils.h"
 #include "open_spiel/tests/basic_tests.h"
 
-// XXX(maintainers): If this is useful enough, consider moving to the header
+// XXX: If this is useful enough, consider moving to the header
 //     where all the other SPIEL_CHECK_* macros are defined.
 #define SPIEL_CHECK_THROWS(expr, exception)     \
   try {                                         \
@@ -268,7 +268,7 @@ void GameParametersTest() {
 
   // Parsing from string
   //
-  // XXX(maintainers): Game parameter parsing from string is a bit quirky at the
+  // XXX: Game parameter parsing from string is a bit quirky at the
   //     moment. For example, the strings "+" or "-" make the parser
   //     throw since the parses eagerly tries to parse those as integers and
   //     passes them to std::stoi.

--- a/open_spiel/tests/spiel_test.cc
+++ b/open_spiel/tests/spiel_test.cc
@@ -241,6 +241,13 @@ void LeducPokerDeserializeTest() {
 }
 
 void GameParametersTest() {
+  // Basic types
+  SPIEL_CHECK_TRUE(GameParameter(1).has_int_value());
+  SPIEL_CHECK_TRUE(GameParameter(1.0).has_double_value());
+  SPIEL_CHECK_TRUE(GameParameter(true).has_bool_value());
+  SPIEL_CHECK_TRUE(GameParameter(std::string("1")).has_string_value());
+  SPIEL_CHECK_TRUE(GameParameter("1").has_string_value());  // See issue #380.
+
   // Bare name
   auto params = GameParametersFromString("game_one");
   SPIEL_CHECK_EQ(params.size(), 1);


### PR DESCRIPTION
This is just a bandaid solution to address some quirks in the way
game parameters are serialized and parsed.

See: #382
Unblocks: #376 

I have added some tests to make sure the parser's behavior does not
change accidentally.

Should I rebase onto #381 once it lands?