### PR TITLE
Expose game-specific APIs -- add a basic skeleton.

### DIFF
--- a/open_spiel/python/CMakeLists.txt
+++ b/open_spiel/python/CMakeLists.txt
@@ -13,6 +13,8 @@ set(PYTHON_BINDINGS ${PYTHON_BINDINGS}
   pybind11/algorithms_trajectories.h
   pybind11/bots.cc
   pybind11/bots.h
+  pybind11/games.h
+  pybind11/games.cc
   pybind11/games_bridge.cc
   pybind11/games_bridge.h
   pybind11/games_negotiation.cc

--- a/open_spiel/python/pybind11/games.cc
+++ b/open_spiel/python/pybind11/games.cc
@@ -1,0 +1,70 @@
+// Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "open_spiel/python/pybind11/games.h"
+
+#include "open_spiel/games/kuhn_poker.h"
+#include "open_spiel/games/chess.h"
+
+#include "pybind11/include/pybind11/operators.h"
+#include "pybind11/include/pybind11/pybind11.h"
+#include "pybind11/include/pybind11/stl.h"
+
+namespace open_spiel {
+namespace py = ::pybind11;
+
+void init_pyspiel_game_specific_api(py::module& m) {
+  {
+    using namespace chess;
+    py::module mm = m.def_submodule("chess");
+    py::class_<ChessState, State> chess_state(mm, "ChessState");
+    chess_state
+        .def("board",
+             (const StandardChessBoard& (State::*)() const) &ChessState::Board);
+    py::class_<StandardChessBoard> standard_board(mm, "StandardChessBoard");
+    standard_board.def("at", &StandardChessBoard::at);
+    standard_board.def("to_fen", &StandardChessBoard::ToFEN);
+
+    py::class_<Piece> piece(mm, "Piece");
+    piece.def_readonly("color", &Piece::color)
+         .def_readonly("type", &Piece::type);
+
+    py::enum_<PieceType>(m, "PieceType")
+        .value("EMPTY", PieceType::kEmpty)
+        .value("KING", PieceType::kKing)
+        .value("QUEEN", PieceType::kQueen)
+        .value("ROOK", PieceType::kRook)
+        .value("BISHOP", PieceType::kBishop)
+        .value("KNIGHT", PieceType::kKnight)
+        .value("PAWN", PieceType::kPawn);
+
+    py::enum_<Color>(m, "Color")
+        .value("BLACK", Color::kBlack)
+        .value("WHITE", Color::kWhite)
+        .value("EMPTY", Color::kEmpty);
+
+    py::class_<Square> square(mm, "Square");
+    square.def(py::init<int, int>())
+          .def_readonly("x", &Square::x)
+          .def_readonly("y", &Square::y);
+  }
+
+  {
+    using namespace kuhn_poker;
+    py::module mm = m.def_submodule("kuhn_poker");
+    py::class_<KuhnState, State> kuhn_state(mm, "KuhnState");
+    kuhn_state.def("card_dealt", &KuhnState::CardDealt);
+  }
+}
+}  // namespace open_spiel

--- a/open_spiel/python/pybind11/games.h
+++ b/open_spiel/python/pybind11/games.h
@@ -1,0 +1,25 @@
+// Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OPEN_SPIEL_PYTHON_PYBIND11_GAMES_H_
+#define OPEN_SPIEL_PYTHON_PYBIND11_GAMES_H_
+
+#include "pybind11/include/pybind11/pybind11.h"
+
+// Initialize game-specific APIs.
+namespace open_spiel {
+void init_pyspiel_game_specific_api(::pybind11::module &m);
+}
+
+#endif  // OPEN_SPIEL_PYTHON_PYBIND11_GAMES_H_

--- a/open_spiel/python/pybind11/pyspiel.cc
+++ b/open_spiel/python/pybind11/pyspiel.cc
@@ -29,6 +29,7 @@
 #include "open_spiel/observer.h"
 #include "open_spiel/python/pybind11/algorithms_trajectories.h"
 #include "open_spiel/python/pybind11/bots.h"
+#include "open_spiel/python/pybind11/games.h"
 #include "open_spiel/python/pybind11/game_transforms.h"
 #include "open_spiel/python/pybind11/games_bridge.h"
 #include "open_spiel/python/pybind11/games_negotiation.h"
@@ -557,6 +558,7 @@ PYBIND11_MODULE(pyspiel, m) {
       [](const std::string& string) { throw SpielException(string); });
 
   // Register other bits of the API.
+  init_pyspiel_game_specific_api(m);      // Expose game-specific methods.
   init_pyspiel_bots(m);                   // Bots and bot-related algorithms.
   init_pyspiel_observation_histories(m);  // Histories related to observations.
   init_pyspiel_policy(m);           // Policies and policy-related algorithms.


### PR DESCRIPTION
This PR adds exporting game specific details so that we can query them in Python. This is useful for example for creating game-specific bots or UIs. This is a work-in-progress, I just wanted to know what you think about doing this in general. 

The code in this PR already allows for game specific rendering of the current state for Chess:

![image](https://user-images.githubusercontent.com/1756494/94350684-e74ba000-000d-11eb-9373-d899d59d04c8.png)
