### PR TITLE
Add get_all_histories

### DIFF
--- a/open_spiel/algorithms/CMakeLists.txt
+++ b/open_spiel/algorithms/CMakeLists.txt
@@ -25,6 +25,8 @@ add_library (algorithms OBJECT
   expected_returns.h
   external_sampling_mccfr.cc
   external_sampling_mccfr.h
+  get_all_histories.cc
+  get_all_histories.h
   get_all_states.cc
   get_all_states.h
   get_legal_actions_map.cc
@@ -89,6 +91,10 @@ add_test(evaluate_bots_test evaluate_bots_test)
 add_executable(external_sampling_mccfr_test external_sampling_mccfr_test.cc
     $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})
 add_test(external_sampling_mccfr_test external_sampling_mccfr_test)
+
+add_executable(get_all_histories_test get_all_histories_test.cc
+    $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})
+add_test(get_all_histories_test get_all_histories_test)
 
 add_executable(get_all_states_test get_all_states_test.cc
     $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})

--- a/open_spiel/algorithms/get_all_histories.cc
+++ b/open_spiel/algorithms/get_all_histories.cc
@@ -1,0 +1,76 @@
+// Copyright 2020 DeepMind Technologies Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "open_spiel/algorithms/get_all_histories.h"
+
+namespace open_spiel {
+namespace algorithms {
+namespace {
+
+// Walk a subgame and return all histories contained in the subgames. This does
+// a recursive tree walk, therefore all valid sequences must have finite number
+// of actions.
+// Requires State::Clone() to be implemented.
+// Use with extreme caution!
+// Currently not implemented for simultaneous games.
+void GetSubgameHistories(State* state,
+                         std::vector<std::unique_ptr<State>>* all_histories,
+                         int depth_limit, int depth, bool include_terminals,
+                         bool include_chance_states) {
+  if (state->IsTerminal()) {
+    if (include_terminals) {
+      // Include, then terminate recursion.
+      all_histories->push_back(state->Clone());
+    }
+    return;
+  }
+
+  if (depth_limit >= 0 && depth > depth_limit) {
+    return;
+  }
+
+  if (!state->IsChanceNode() || include_chance_states) {
+    all_histories->push_back(state->Clone());
+  }
+
+  for (auto action : state->LegalActions()) {
+    auto next_state = state->Clone();
+    next_state->ApplyAction(action);
+    GetSubgameHistories(next_state.get(), all_histories, depth_limit, depth + 1,
+                        include_terminals, include_chance_states);
+  }
+}
+
+}  // namespace
+
+std::vector<std::unique_ptr<State>> GetAllHistories(
+    const Game& game, int depth_limit, bool include_terminals,
+    bool include_chance_states) {
+  // Get the root state.
+  std::unique_ptr<State> state = game.NewInitialState();
+  std::vector<std::unique_ptr<State>> all_histories;
+
+  // Then, do a recursive tree walk to fill up the vector.
+  GetSubgameHistories(state.get(), &all_histories, depth_limit, 0,
+                      include_terminals, include_chance_states);
+
+  if (all_histories.empty()) {
+    SpielFatalError("GetSubgameHistories returned 0 histories!");
+  }
+
+  return all_histories;
+}
+
+}  // namespace algorithms
+}  // namespace open_spiel

--- a/open_spiel/algorithms/get_all_histories.h
+++ b/open_spiel/algorithms/get_all_histories.h
@@ -1,0 +1,46 @@
+// Copyright 2020 DeepMind Technologies Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OPEN_SPIEL_ALGORITHMS_GET_ALL_HISTORIES_H_
+#define OPEN_SPIEL_ALGORITHMS_GET_ALL_HISTORIES_H_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "open_spiel/spiel.h"
+
+namespace open_spiel {
+namespace algorithms {
+
+// Returns a vector of states corresponding to unique histories in the game.
+//
+// For small games only!
+//
+// Use this implementation with caution as it does a recursive tree
+// walk of the game and could easily fill up memory for larger games or games
+// with long horizons.
+//
+// Currently only works for sequential games.
+//
+// Note: negative depth limit means no limit, 0 means only root, etc..
+
+std::vector<std::unique_ptr<State>> GetAllHistories(
+    const Game& game, int depth_limit, bool include_terminals,
+    bool include_chance_states);
+
+}  // namespace algorithms
+}  // namespace open_spiel
+
+#endif  // OPEN_SPIEL_ALGORITHMS_GET_ALL_HISTORIES_H_

--- a/open_spiel/algorithms/get_all_histories_test.cc
+++ b/open_spiel/algorithms/get_all_histories_test.cc
@@ -1,0 +1,38 @@
+// Copyright 2020 DeepMind Technologies Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "open_spiel/algorithms/get_all_histories.h"
+
+#include "open_spiel/games/tic_tac_toe.h"
+#include "open_spiel/spiel_utils.h"
+
+namespace algorithms = open_spiel::algorithms;
+namespace ttt = open_spiel::tic_tac_toe;
+
+// Orwant, et al. Mastering Algorithms with Perl. 0'Reilly, 1999, p. 183.
+inline constexpr int kTTTNumTotalHistories = 549946;
+inline constexpr int kTTTNumPartialHistories = 294778;
+
+int main(int argc, char **argv) {
+  std::shared_ptr<const open_spiel::Game> game =
+      open_spiel::LoadGame("tic_tac_toe");
+  auto histories = algorithms::GetAllHistories(*game, -1,
+                                               /*include_terminals=*/true,
+                                               /*include_chance_states=*/true);
+  SPIEL_CHECK_EQ(histories.size(), kTTTNumTotalHistories);
+  histories = algorithms::GetAllHistories(*game, -1,
+                                          /*include_terminals=*/false,
+                                          /*include_chance_states=*/true);
+  SPIEL_CHECK_EQ(histories.size(), kTTTNumPartialHistories);
+}

--- a/open_spiel/examples/count_all_states.cc
+++ b/open_spiel/examples/count_all_states.cc
@@ -16,7 +16,7 @@
 
 #include "open_spiel/abseil-cpp/absl/container/flat_hash_set.h"
 #include "open_spiel/abseil-cpp/absl/strings/str_format.h"
-#include "open_spiel/algorithms/get_all_states.h"
+#include "open_spiel/algorithms/get_all_histories.h"
 #include "open_spiel/canonical_game_strings.h"
 #include "open_spiel/spiel.h"
 #include "open_spiel/spiel_utils.h"
@@ -31,15 +31,15 @@ int main(int argc, char** argv) {
         open_spiel::TurnBasedGoofspielGameString(6)}) {
     std::shared_ptr<const open_spiel::Game> game =
         open_spiel::LoadGame(std::string(game_name));
-    std::map<std::string, std::unique_ptr<open_spiel::State>> all_states =
-        open_spiel::algorithms::GetAllStates(*game, /*depth_limit=*/-1,
-                                             /*include_terminals=*/true,
-                                             /*include_chance_states=*/true);
+    std::vector<std::unique_ptr<open_spiel::State>> all_histories =
+        open_spiel::algorithms::GetAllHistories(*game, /*depth_limit=*/-1,
+                                                /*include_terminals=*/true,
+                                                /*include_chance_states=*/true);
     absl::flat_hash_set<std::string> all_infostates;
-    const int num_histories = all_states.size();
+    const int num_histories = all_histories.size();
     int num_terminal_states = 0;
     int num_chance_nodes = 0;
-    for (const auto& [_, state] : all_states) {
+    for (const auto& state : all_histories) {
       if (state->CurrentPlayer() > 0) {
         all_infostates.insert(state->InformationStateString());
       }


### PR DESCRIPTION
Addresses Issue #401. As requested, `GetAllHistories()` returns a `std::vector<std::unique_ptr<State>>`.

> Use State::FullHistory to check for equality, rather than State::ToString

Is there any reason we need to actually perform this check for equality or will a DFS suffice? I couldn’t come up with a scenario in which there’s a difference so I implemented it as a straightforward DFS. Wanted to check though because there’s been some discussion around this issue and I could well have missed something.

I gave `GetAllHistories()` its own file. Seemed like the right way to go but if there’s a preference for including it in the `get_all_states` file as a separate function I’m happy to do that.

And if there’s anything else I can do for this PR just let me know :)
