### PR TITLE
Adds a suggested-alpha function

### DIFF
--- a/open_spiel/python/egt/alpharank.py
+++ b/open_spiel/python/egt/alpharank.py
@@ -792,11 +792,11 @@ def compute(payoff_tables,
 
   return rhos, rho_m, pi, num_profiles, num_strats_per_population
 
-def suggest_alpha(payoff_tables):
+def suggest_alpha(payoff_tables, tol=.1):
   """Suggests an alpha for use in alpha-rank. 
 
   The suggested alpha is approximately the smallest possible alpha such that 
-  the ranking has 'settled out'. It is calculated as 2/min_gap_between_payoffs. 
+  the ranking has 'settled out'. It is calculated as -ln(tol)/min_gap_between_payoffs. 
 
   Args:
     payoff_tables: List of game payoff tables, one for each agent identity. Each
@@ -806,8 +806,10 @@ def suggest_alpha(payoff_tables):
   Returns:
     A suggested alpha.
   """ 
+  payoffs_are_hpt_format = utils.check_payoffs_are_hpt(payoff_tables)
+
   num_strats_per_population =\
-    utils.get_num_strats_per_population(payoff_tables, False)
+    utils.get_num_strats_per_population(payoff_tables, payoffs_are_hpt_format)
   num_profiles = utils.get_num_profiles(num_strats_per_population)
 
   gap = np.inf
@@ -820,12 +822,12 @@ def suggest_alpha(payoff_tables):
 
     for index_population_that_changed, col_profile in next_profile_gen:
       payoff_table_k = payoff_tables[index_population_that_changed]
-      f_r = _get_payoff(payoff_table_k, False, col_profile, 
+      f_r = _get_payoff(payoff_table_k, payoffs_are_hpt_format, col_profile, 
                           index_population_that_changed)
-      f_s = _get_payoff(payoff_table_k, False, row_profile, 
+      f_s = _get_payoff(payoff_table_k, payoffs_are_hpt_format, row_profile, 
                           index_population_that_changed)
       if f_r > f_s:
         gap = min(gap, f_r - f_s)
 
-  return 2/gap
+  return -np.log(tol)/gap
 

--- a/open_spiel/python/egt/alpharank.py
+++ b/open_spiel/python/egt/alpharank.py
@@ -798,10 +798,24 @@ def suggest_alpha(payoff_tables, tol=.1):
   The suggested alpha is approximately the smallest possible alpha such that 
   the ranking has 'settled out'. It is calculated as -ln(tol)/min_gap_between_payoffs. 
 
+  The logic behind this settling out is that the fixation probabilities can be 
+  expanded as a series, and the relative size of each term in this series
+  changes with alpha. As alpha gets larger and larger, one of the terms in 
+  this series comes to dominate, and this causes the ranking to settle 
+  down. Just how fast this domination happens is easy to calculate, and this 
+  function uses it to estimate the alpha by which the ranking has settled.
+
+  You can find further discussion at the PR:
+
+  https://github.com/deepmind/open_spiel/pull/403
+
   Args:
     payoff_tables: List of game payoff tables, one for each agent identity. Each
       payoff_table may be either a numpy array, or a _PayoffTableInterface
       object.
+    tol: the desired gap between the first and second terms in the fixation 
+      probability expansion. A smaller tolerance leads to a larger alpha, and 
+      a 'more settled out' ranking.  
   
   Returns:
     A suggested alpha.


### PR DESCRIPTION
This adds a function to the alpha-rank module that'll suggest an alpha large enough for the ranking to have 'settled out'. 

The logic behind this is that the transition probabilities can be expanded as a power series, as per Eqn 8 [in the paper](https://arxiv.org/pdf/1903.01373.pdf):

<img src="https://user-images.githubusercontent.com/662606/95656038-6c04e680-0b03-11eb-88b7-53c698014776.png" height=75>

When alpha is sufficiently large, then the first or the last term will dominate. That happens roughly when

<img src="https://user-images.githubusercontent.com/662606/95656243-e7b36300-0b04-11eb-9d0c-fe2332264086.png" height=35>

This is when the first term is e^2 (approx 10x) larger than the second term. 

Empirically, it seems like this dominating-term effect is what gets the ranking to settle down, and I've started to use it as a 'default alpha'. As an exemplar, here's the sweep from Kuhn poker

```python
payoff_tables = alpharank_example.get_kuhn_poker_data(num_players=2)
alpharank.sweep_pi_vs_alpha(payoff_tables, visualize=True)
```
![image](https://user-images.githubusercontent.com/662606/95656439-56dd8700-0b06-11eb-8f8a-9003d5ff0156.png)

for which `alpharank.suggest_alpha(payoff_tables)` gives 10^2. 