### PR TITLE
Use GetAllHistories in count_all_states example

### DIFF
--- a/open_spiel/examples/count_all_states.cc
+++ b/open_spiel/examples/count_all_states.cc
@@ -16,7 +16,7 @@
 
 #include "open_spiel/abseil-cpp/absl/container/flat_hash_set.h"
 #include "open_spiel/abseil-cpp/absl/strings/str_format.h"
-#include "open_spiel/algorithms/get_all_states.h"
+#include "open_spiel/algorithms/get_all_histories.h"
 #include "open_spiel/canonical_game_strings.h"
 #include "open_spiel/spiel.h"
 #include "open_spiel/spiel_utils.h"
@@ -25,37 +25,46 @@
 // Counts all states and prints them to the console.
 int main(int argc, char** argv) {
   for (std::string_view game_name :
-       {std::string("kuhn_poker"), std::string("leduc_poker"),
-        std::string("liars_dice"), open_spiel::TurnBasedGoofspielGameString(4),
+       {std::string("tic_tac_toe"), std::string("kuhn_poker"),
+        std::string("leduc_poker"), std::string("liars_dice"),
+        open_spiel::TurnBasedGoofspielGameString(4),
         open_spiel::TurnBasedGoofspielGameString(5),
         open_spiel::TurnBasedGoofspielGameString(6)}) {
     std::shared_ptr<const open_spiel::Game> game =
         open_spiel::LoadGame(std::string(game_name));
-    std::map<std::string, std::unique_ptr<open_spiel::State>> all_states =
-        open_spiel::algorithms::GetAllStates(*game, /*depth_limit=*/-1,
-                                             /*include_terminals=*/true,
-                                             /*include_chance_states=*/true);
-    absl::flat_hash_set<std::string> all_infostates;
-    const int num_histories = all_states.size();
-    int num_terminal_states = 0;
+    std::vector<std::unique_ptr<open_spiel::State>> all_histories =
+        open_spiel::algorithms::GetAllHistories(*game, /*depth_limit=*/-1,
+                                                /*include_terminals=*/true,
+                                                /*include_chance_states=*/true);
+    absl::flat_hash_set<std::string> nonterminal_states;
+    absl::flat_hash_set<std::string> terminal_states;
+    const int num_histories = all_histories.size();
+    int num_terminal_histories = 0;
     int num_chance_nodes = 0;
-    // TODO: Fix counting of information states for some games after having a
-    // GetAllHistories. Right now the counting of information states will not
-    // be correct for perfect information games. See this issue for details:
-    // https://github.com/deepmind/open_spiel/issues/401
-    for (const auto& [_, state] : all_states) {
+    for (const auto& state : all_histories) {
       if (state->CurrentPlayer() >= 0) {
-        all_infostates.insert(state->InformationStateString());
+        if (game->GetType().information ==
+            open_spiel::GameType::Information::kPerfectInformation) {
+          nonterminal_states.insert(state->ToString());
+        } else {
+          nonterminal_states.insert(state->InformationStateString());
+        }
       }
-      if (state->IsTerminal()) ++num_terminal_states;
+      if (state->IsTerminal()) {
+         ++num_terminal_histories;
+         terminal_states.insert(state->ToString());
+      }
       if (state->IsChanceNode()) ++num_chance_nodes;
     }
-    const int num_infostates = all_infostates.size();
+    const int num_nonterminal_states = nonterminal_states.size();
+    const int num_terminal_states = terminal_states.size();
     std::cout << absl::StreamFormat(
-                     "Game: %s, num_histories: %i, num_terminals: %i, "
-                     "num_chance: %i, num_infostates: %i",
-                     game_name, num_histories, num_terminal_states,
-                     num_chance_nodes, num_infostates)
+                     "Game: %s, num_histories: %i, num_terminal_histories: %i, "
+                     "num_chance_nodes: %i, num_nonterminal_states: %i, "
+                     "num_terminal_states: %i",
+                     game_name, num_histories, num_terminal_histories,
+                     num_chance_nodes, num_nonterminal_states,
+                     num_terminal_states)
               << std::endl;
   }
 }


### PR DESCRIPTION
Updates count_all_states example to use GetAllHistories.

@lanctot this should address the issues raised in your last comment in https://github.com/deepmind/open_spiel/pull/402. 

It handles both perfect and imperfect information games. Tic tac toe is now included, and we get the correct number of total states: 4520 nonterminal + 958 terminal = 5478 total. The outputs for the other games agree with the current version of the file.

```
Game: tic_tac_toe, num_histories: 549946, num_terminal_histories: 255168, num_chance_nodes: 0, num_nonterminal_states: 4520, num_terminal_states: 958
Game: kuhn_poker, num_histories: 58, num_terminal_histories: 30, num_chance_nodes: 4, num_nonterminal_states: 12, num_terminal_states: 30
Game: leduc_poker, num_histories: 9457, num_terminal_histories: 5520, num_chance_nodes: 157, num_nonterminal_states: 936, num_terminal_states: 5520
Game: liars_dice, num_histories: 294883, num_terminal_histories: 147420, num_chance_nodes: 7, num_nonterminal_states: 24576, num_terminal_states: 147420
Game: turn_based_simultaneous_game(game=goofspiel(imp_info=true,num_cards=4,players=2,points_order=descending,returns_type=win_loss)), num_histories: 1077, num_terminal_histories: 576, num_chance_nodes: 0, num_nonterminal_states: 162, num_terminal_states: 576
Game: turn_based_simultaneous_game(game=goofspiel(imp_info=true,num_cards=5,players=2,points_order=descending,returns_type=win_loss)), num_histories: 26931, num_terminal_histories: 14400, num_chance_nodes: 0, num_nonterminal_states: 2124, num_terminal_states: 14400
Game: turn_based_simultaneous_game(game=goofspiel(imp_info=true,num_cards=6,players=2,points_order=descending,returns_type=win_loss)), num_histories: 969523, num_terminal_histories: 518400, num_chance_nodes: 0, num_nonterminal_states: 34482, num_terminal_states: 518400
```