### PR TITLE
External sampling mccfr in python

### DIFF
--- a/open_spiel/python/algorithms/external_sampling_mccfr.py
+++ b/open_spiel/python/algorithms/external_sampling_mccfr.py
@@ -60,7 +60,7 @@ class ExternalSamplingSolver(object):
                 "using turn_based_simultaneous_game.")
 
     def iteration(self):
-        """Performs one iteration of outcome sampling.
+        """Performs one iteration of external sampling.
 
         An iteration consists of one episode for each player as the update player.
         """
@@ -140,6 +140,13 @@ class ExternalSamplingSolver(object):
             return positive_regrets / sum_pos_regret
 
     def _full_update_average(self, state, reach_probs):
+        """Performs a full update average.
+
+        Args:
+          state: the open spiel state to run from
+          reach_probs: array containing the probability of reaching the state
+          from the players point of view
+        """
         if state.is_terminal():
             return
         if state.is_chance_node():
@@ -175,11 +182,13 @@ class ExternalSamplingSolver(object):
         """Runs an episode of external sampling.
 
         Args:
-          state: the open spiel state to run from (will be modified in-place).
+          state: the open spiel state to run from
           player: the player to update regrets for
 
         Returns:
           value: is the value of the state in the game
+          obtained as the weighted average of the values
+          of the children
         """
         if state.is_terminal():
             return state.player_return(player)

--- a/open_spiel/python/algorithms/external_sampling_mccfr.py
+++ b/open_spiel/python/algorithms/external_sampling_mccfr.py
@@ -1,0 +1,195 @@
+# Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Python implementation for Monte Carlo Counterfactual Regret Minimization."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import pyspiel
+
+# Indices in the information sets for the regrets and average policy sums.
+_REGRET_INDEX = 0
+_AVG_POLICY_INDEX = 1
+
+
+class ExternalSamplingSolver(object):
+    """
+    An implementation of external sampling MCCFR
+    """
+
+    def __init__(self, game, average_type='k_simple'):
+        self._game = game
+        self._infostates = {}  # infostate keys -> [regrets, avg strat]
+        self._num_players = game.num_players()
+        # How to average the strategy. The 'simple' type does the averaging for
+        # player i + 1 mod num_players on player i's regret update pass; in two players
+        # this corresponds to the standard implementation (updating the average
+        # policy at opponent nodes). In n>2 players, this can be a problem for several
+        # reasons: first, it does not compute the estimate as described by the
+        # (unbiased) stochastically-weighted averaging in chapter 4 of Lanctot 2013
+        # commonly used in MCCFR because the denominator (important sampling
+        # correction) should include all the other sampled players as well so the
+        # sample reach no longer cancels with reach of the player updating their
+        # average policy. Second, if one player assigns zero probability to an action
+        # (leading to a subtree), the average policy of a different player in that
+        # subtree is no longer updated. Hence, the full averaging does not update the
+        # average policy in the regret passes but does a separate pass to update the
+        # average policy. Nevertheless, we set the simple type as the default because
+        # it is faster, seems to work better empirically, and it matches what was done
+        # in Pluribus (Brown and Sandholm. Superhuman AI for multiplayer poker.
+        # Science, 11, 2019).
+        self._average_type = average_type
+
+        assert game.get_type().dynamics == pyspiel.GameType.Dynamics.SEQUENTIAL, (
+                "MCCFR requires sequential games. If you're trying to run it " +
+                "on a simultaneous (or normal-form) game, please first transform it " +
+                "using turn_based_simultaneous_game.")
+
+    def iteration(self):
+        """Performs one iteration of outcome sampling.
+
+        An iteration consists of one episode for each player as the update player.
+        """
+        for player in range(self._num_players):
+            state = self._game.new_initial_state()
+            self._update_regrets(state, player)
+        if self._average_type == 'k_full':
+            raise NotImplementedError
+
+    def _lookup_infostate_info(self, info_state_key, num_legal_actions):
+        """Looks up an information set table for the given key.
+
+        Args:
+          info_state_key: information state key (string identifier).
+          num_legal_actions: number of legal actions at this information state.
+
+        Returns:
+          A list of:
+            - the average regrets as a numpy array of shape [num_legal_actions]
+            - the average strategy as a numpy array of shape [num_legal_actions].
+              The average is weighted using `my_reach`
+        """
+        retrieved_infostate = self._infostates.get(info_state_key, None)
+        if retrieved_infostate is not None:
+            return retrieved_infostate
+
+        # Start with a small amount of regret and total accumulation, to give a
+        # uniform policy: this will get erased fast.
+        self._infostates[info_state_key] = [
+            np.ones(num_legal_actions, dtype=np.float64) / 1000.0,
+            np.ones(num_legal_actions, dtype=np.float64) / 1000.0,
+        ]
+        return self._infostates[info_state_key]
+
+    def _add_regret(self, info_state_key, action_idx, amount):
+        self._infostates[info_state_key][_REGRET_INDEX][action_idx] += amount
+
+    def _add_avstrat(self, info_state_key, action_idx, amount):
+        self._infostates[info_state_key][_AVG_POLICY_INDEX][action_idx] += amount
+
+    def callable_avg_policy(self):
+        """Returns the average joint policy as a callable.
+
+        The callable has a signature of the form string (information
+        state key) -> list of (action, prob).
+        """
+
+        def wrap(state):
+            info_state_key = state.information_state_string(state.current_player())
+            legal_actions = state.legal_actions()
+            infostate_info = self._lookup_infostate_info(info_state_key,
+                                                         len(legal_actions))
+            avstrat = (
+                    infostate_info[_AVG_POLICY_INDEX] /
+                    infostate_info[_AVG_POLICY_INDEX].sum())
+            return [(legal_actions[i], avstrat[i]) for i in range(len(legal_actions))]
+
+        return wrap
+
+    def _regret_matching(self, regrets, num_legal_actions):
+        """Applies regret matching to get a policy.
+
+        Args:
+          regrets: numpy array of regrets for each action.
+          num_legal_actions: number of legal actions at this state.
+
+        Returns:
+          numpy array of the policy indexed by the index of legal action in the
+          list.
+        """
+        positive_regrets = np.maximum(regrets,
+                                      np.zeros(num_legal_actions, dtype=np.float64))
+        sum_pos_regret = positive_regrets.sum()
+        if sum_pos_regret <= 0:
+            return np.ones(num_legal_actions, dtype=np.float64) / num_legal_actions
+        else:
+            return positive_regrets / sum_pos_regret
+
+    def _update_regrets(self, state, player):
+        """Runs an episode of external sampling.
+
+        Args:
+          state: the open spiel state to run from (will be modified in-place).
+          player: the player to update regrets for
+
+        Returns:
+          value: is the value of the state in the game
+        """
+        if state.is_terminal():
+            return state.player_return(player)
+
+        if state.is_chance_node():
+            outcomes, probs = zip(*state.chance_outcomes())
+            outcome = np.random.choice(outcomes, p=probs)
+            return self._update_regrets(state.child(outcome), player)
+
+        cur_player = state.current_player()
+        info_state_key = state.information_state_string(cur_player)
+        legal_actions = state.legal_actions()
+        num_legal_actions = len(legal_actions)
+
+        infostate_info = self._lookup_infostate_info(info_state_key,
+                                                     num_legal_actions)
+        policy = self._regret_matching(infostate_info[_REGRET_INDEX],
+                                       num_legal_actions)
+
+        value = 0
+        child_values = np.zeros(num_legal_actions, dtype=np.float64)
+        if cur_player != player:
+            # Sample at opponent node
+            action_idx = np.random.choice(np.arange(num_legal_actions), p=policy)
+            value = self._update_regrets(state.child(legal_actions[action_idx]),
+                                         player)
+        else:
+            # Walk over all actions at my node
+            for action_idx in range(num_legal_actions):
+                child_values[action_idx] = self._update_regrets(state.child(legal_actions[action_idx]),
+                                                                player)
+                value += policy[action_idx] * child_values[action_idx]
+
+        if cur_player == player:
+            # Update regrets.
+            for action_idx in range(num_legal_actions):
+                self._add_regret(info_state_key, action_idx, child_values[action_idx] - value)
+        # Simple average does averaging on the opponent node. To do this in a game
+        # with more than two players, we only update the player + 1 mod num_players,
+        # which reduces to the standard rule in 2 players.
+        if self._average_type == 'k_simple' and cur_player == (player + 1) % self._num_players:
+            for action_idx in range(num_legal_actions):
+                self._add_avstrat(info_state_key, action_idx, policy[action_idx])
+
+        return value

--- a/open_spiel/python/algorithms/external_sampling_mccfr_test.py
+++ b/open_spiel/python/algorithms/external_sampling_mccfr_test.py
@@ -82,6 +82,32 @@ class OutcomeSamplingMCCFRTest(absltest.TestCase):
         print("Kuhn2P, conv = {}".format(conv))
         self.assertLess(conv, 0.05)
 
+    def test_outcome_sampling_liars_dice_2p_simple(self):
+        np.random.seed(SEED)
+        game = pyspiel.load_game("liars_dice")
+        os_solver = external_sampling_mccfr.ExternalSamplingSolver(game, 'k_simple')
+        for _ in range(100):
+            os_solver.iteration()
+        conv = exploitability.nash_conv(
+            game,
+            policy.tabular_policy_from_callable(game,
+                                                os_solver.callable_avg_policy()))
+        print("Kuhn2P, conv = {}".format(conv))
+        self.assertLess(conv, 1.6)
+
+    def test_outcome_sampling_liars_dice_2p_full(self):
+        np.random.seed(SEED)
+        game = pyspiel.load_game("liars_dice")
+        os_solver = external_sampling_mccfr.ExternalSamplingSolver(game, 'k_full')
+        for _ in range(100):
+            os_solver.iteration()
+        conv = exploitability.nash_conv(
+            game,
+            policy.tabular_policy_from_callable(game,
+                                                os_solver.callable_avg_policy()))
+        print("Kuhn2P, conv = {}".format(conv))
+        self.assertLess(conv, 1.6)
+
     def test_outcome_sampling_kuhn_3p_simple(self):
         np.random.seed(SEED)
         game = pyspiel.load_game("kuhn_poker",

--- a/open_spiel/python/algorithms/external_sampling_mccfr_test.py
+++ b/open_spiel/python/algorithms/external_sampling_mccfr_test.py
@@ -28,9 +28,9 @@ import pyspiel
 SEED = 39823987
 
 
-class OutcomeSamplingMCCFRTest(absltest.TestCase):
+class ExternalSamplingMCCFRTest(absltest.TestCase):
 
-    def test_outcome_sampling_leduc_2p_simple(self):
+    def test_external_sampling_leduc_2p_simple(self):
         np.random.seed(SEED)
         game = pyspiel.load_game("leduc_poker")
         os_solver = external_sampling_mccfr.ExternalSamplingSolver(game, 'k_simple')
@@ -43,7 +43,7 @@ class OutcomeSamplingMCCFRTest(absltest.TestCase):
         print("Leduc2P, conv = {}".format(conv))
         self.assertLess(conv, 2.5)
 
-    def test_outcome_sampling_leduc_2p_full(self):
+    def test_external_sampling_leduc_2p_full(self):
         np.random.seed(SEED)
         game = pyspiel.load_game("leduc_poker")
         os_solver = external_sampling_mccfr.ExternalSamplingSolver(game, 'k_full')
@@ -56,7 +56,7 @@ class OutcomeSamplingMCCFRTest(absltest.TestCase):
         print("Leduc2P, conv = {}".format(conv))
         self.assertLess(conv, 2.5)
 
-    def test_outcome_sampling_kuhn_2p_simple(self):
+    def test_external_sampling_kuhn_2p_simple(self):
         np.random.seed(SEED)
         game = pyspiel.load_game("kuhn_poker")
         os_solver = external_sampling_mccfr.ExternalSamplingSolver(game, 'k_simple')
@@ -69,7 +69,7 @@ class OutcomeSamplingMCCFRTest(absltest.TestCase):
         print("Kuhn2P, conv = {}".format(conv))
         self.assertLess(conv, 0.05)
 
-    def test_outcome_sampling_kuhn_2p_full(self):
+    def test_external_sampling_kuhn_2p_full(self):
         np.random.seed(SEED)
         game = pyspiel.load_game("kuhn_poker")
         os_solver = external_sampling_mccfr.ExternalSamplingSolver(game, 'k_full')
@@ -82,7 +82,7 @@ class OutcomeSamplingMCCFRTest(absltest.TestCase):
         print("Kuhn2P, conv = {}".format(conv))
         self.assertLess(conv, 0.05)
 
-    def test_outcome_sampling_liars_dice_2p_simple(self):
+    def test_external_sampling_liars_dice_2p_simple(self):
         np.random.seed(SEED)
         game = pyspiel.load_game("liars_dice")
         os_solver = external_sampling_mccfr.ExternalSamplingSolver(game, 'k_simple')
@@ -95,7 +95,7 @@ class OutcomeSamplingMCCFRTest(absltest.TestCase):
         print("Kuhn2P, conv = {}".format(conv))
         self.assertLess(conv, 1.6)
 
-    def test_outcome_sampling_liars_dice_2p_full(self):
+    def test_external_sampling_liars_dice_2p_full(self):
         np.random.seed(SEED)
         game = pyspiel.load_game("liars_dice")
         os_solver = external_sampling_mccfr.ExternalSamplingSolver(game, 'k_full')
@@ -108,7 +108,7 @@ class OutcomeSamplingMCCFRTest(absltest.TestCase):
         print("Kuhn2P, conv = {}".format(conv))
         self.assertLess(conv, 1.6)
 
-    def test_outcome_sampling_kuhn_3p_simple(self):
+    def test_external_sampling_kuhn_3p_simple(self):
         np.random.seed(SEED)
         game = pyspiel.load_game("kuhn_poker",
                                  {"players": pyspiel.GameParameter(3)})
@@ -122,7 +122,7 @@ class OutcomeSamplingMCCFRTest(absltest.TestCase):
         print("Kuhn3P, conv = {}".format(conv))
         self.assertLess(conv, 0.1)
 
-    def test_outcome_sampling_kuhn_3p_full(self):
+    def test_external_sampling_kuhn_3p_full(self):
         np.random.seed(SEED)
         game = pyspiel.load_game("kuhn_poker",
                                  {"players": pyspiel.GameParameter(3)})

--- a/open_spiel/python/algorithms/external_sampling_mccfr_test.py
+++ b/open_spiel/python/algorithms/external_sampling_mccfr_test.py
@@ -1,0 +1,115 @@
+# Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for open_spiel.python.algorithms.cfr."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from absl.testing import absltest
+import numpy as np
+from open_spiel.python import policy
+from open_spiel.python.algorithms import exploitability
+from open_spiel.python.algorithms import external_sampling_mccfr
+import pyspiel
+
+SEED = 39823987
+
+
+class OutcomeSamplingMCCFRTest(absltest.TestCase):
+
+    def test_outcome_sampling_leduc_2p_simple(self):
+        np.random.seed(SEED)
+        game = pyspiel.load_game("leduc_poker")
+        os_solver = external_sampling_mccfr.ExternalSamplingSolver(game, 'k_simple')
+        for _ in range(1000):
+            os_solver.iteration()
+        conv = exploitability.nash_conv(
+            game,
+            policy.tabular_policy_from_callable(game,
+                                                os_solver.callable_avg_policy()))
+        print("Leduc2P, conv = {}".format(conv))
+        self.assertLess(conv, 2.5)
+
+    def test_outcome_sampling_leduc_2p_full(self):
+        np.random.seed(SEED)
+        game = pyspiel.load_game("leduc_poker")
+        os_solver = external_sampling_mccfr.ExternalSamplingSolver(game, 'k_full')
+        for _ in range(1000):
+            os_solver.iteration()
+        conv = exploitability.nash_conv(
+            game,
+            policy.tabular_policy_from_callable(game,
+                                                os_solver.callable_avg_policy()))
+        print("Leduc2P, conv = {}".format(conv))
+        self.assertLess(conv, 2.5)
+
+    def test_outcome_sampling_kuhn_2p_simple(self):
+        np.random.seed(SEED)
+        game = pyspiel.load_game("kuhn_poker")
+        os_solver = external_sampling_mccfr.ExternalSamplingSolver(game, 'k_simple')
+        for _ in range(1000):
+            os_solver.iteration()
+        conv = exploitability.nash_conv(
+            game,
+            policy.tabular_policy_from_callable(game,
+                                                os_solver.callable_avg_policy()))
+        print("Kuhn2P, conv = {}".format(conv))
+        self.assertLess(conv, 0.05)
+
+    def test_outcome_sampling_kuhn_2p_full(self):
+        np.random.seed(SEED)
+        game = pyspiel.load_game("kuhn_poker")
+        os_solver = external_sampling_mccfr.ExternalSamplingSolver(game, 'k_full')
+        for _ in range(1000):
+            os_solver.iteration()
+        conv = exploitability.nash_conv(
+            game,
+            policy.tabular_policy_from_callable(game,
+                                                os_solver.callable_avg_policy()))
+        print("Kuhn2P, conv = {}".format(conv))
+        self.assertLess(conv, 0.05)
+
+    def test_outcome_sampling_kuhn_3p_simple(self):
+        np.random.seed(SEED)
+        game = pyspiel.load_game("kuhn_poker",
+                                 {"players": pyspiel.GameParameter(3)})
+        os_solver = external_sampling_mccfr.ExternalSamplingSolver(game, 'k_simple')
+        for _ in range(1000):
+            os_solver.iteration()
+        conv = exploitability.nash_conv(
+            game,
+            policy.tabular_policy_from_callable(game,
+                                                os_solver.callable_avg_policy()))
+        print("Kuhn3P, conv = {}".format(conv))
+        self.assertLess(conv, 0.1)
+
+    def test_outcome_sampling_kuhn_3p_full(self):
+        np.random.seed(SEED)
+        game = pyspiel.load_game("kuhn_poker",
+                                 {"players": pyspiel.GameParameter(3)})
+        os_solver = external_sampling_mccfr.ExternalSamplingSolver(game, 'k_full')
+        for _ in range(1000):
+            os_solver.iteration()
+        conv = exploitability.nash_conv(
+            game,
+            policy.tabular_policy_from_callable(game,
+                                                os_solver.callable_avg_policy()))
+        print("Kuhn3P, conv = {}".format(conv))
+        self.assertLess(conv, 0.1)
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/open_spiel/python/examples/mccfr_example.py
+++ b/open_spiel/python/examples/mccfr_example.py
@@ -24,6 +24,7 @@ from absl import flags
 from open_spiel.python.algorithms import outcome_sampling_mccfr as outcome_mccfr
 from open_spiel.python.algorithms import external_sampling_mccfr as external_mccfr
 from open_spiel.python.algorithms import exploitability
+from open_spiel.python import policy
 import pyspiel
 
 FLAGS = flags.FLAGS
@@ -44,15 +45,16 @@ def main(_):
     game = pyspiel.load_game(FLAGS.game,
                              {"players": pyspiel.GameParameter(FLAGS.players)})
     if FLAGS.sampling == 'external':
-        cfr_solver = external_mccfr.ExternalSamplingSolver(game)
+        cfr_solver = external_mccfr.ExternalSamplingSolver(game, 'k_full')
     else:
         cfr_solver = outcome_mccfr.OutcomeSamplingSolver(game)
     for i in range(FLAGS.iterations):
         cfr_solver.iteration()
         if i % FLAGS.print_freq == 0:
-            # conv = exploitability.exploitability(game, cfr_solver.average_policy())
-            # print("Iteration {} exploitability {}".format(i, conv))
-            print("Iteration {}".format(i))
+            conv = exploitability.nash_conv(game,
+                                            policy.tabular_policy_from_callable(game, cfr_solver.callable_avg_policy()))
+            print("Iteration {} exploitability {}".format(i, conv))
+
 
 if __name__ == "__main__":
     app.run(main)

--- a/open_spiel/python/examples/mccfr_example.py
+++ b/open_spiel/python/examples/mccfr_example.py
@@ -35,7 +35,7 @@ flags.DEFINE_enum(
     ["external", "outcome"],
     "Sampling for the MCCFR solver",
 )
-flags.DEFINE_integer("iterations", 100000, "Number of iterations")
+flags.DEFINE_integer("iterations", 10000, "Number of iterations")
 flags.DEFINE_string("game", "kuhn_poker", "Name of the game")
 flags.DEFINE_integer("players", 2, "Number of players")
 flags.DEFINE_integer("print_freq", 1000, "How often to print the exploitability")
@@ -45,7 +45,7 @@ def main(_):
     game = pyspiel.load_game(FLAGS.game,
                              {"players": pyspiel.GameParameter(FLAGS.players)})
     if FLAGS.sampling == 'external':
-        cfr_solver = external_mccfr.ExternalSamplingSolver(game, 'k_full')
+        cfr_solver = external_mccfr.ExternalSamplingSolver(game, 'k_simple')
     else:
         cfr_solver = outcome_mccfr.OutcomeSamplingSolver(game)
     for i in range(FLAGS.iterations):

--- a/open_spiel/python/examples/mccfr_example.py
+++ b/open_spiel/python/examples/mccfr_example.py
@@ -1,0 +1,58 @@
+# Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Example use of the MCCFR algorithm on Kuhn Poker."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from absl import app
+from absl import flags
+
+from open_spiel.python.algorithms import outcome_sampling_mccfr as outcome_mccfr
+from open_spiel.python.algorithms import external_sampling_mccfr as external_mccfr
+from open_spiel.python.algorithms import exploitability
+import pyspiel
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_enum(
+    "sampling",
+    "external",
+    ["external", "outcome"],
+    "Sampling for the MCCFR solver",
+)
+flags.DEFINE_integer("iterations", 100000, "Number of iterations")
+flags.DEFINE_string("game", "kuhn_poker", "Name of the game")
+flags.DEFINE_integer("players", 2, "Number of players")
+flags.DEFINE_integer("print_freq", 1000, "How often to print the exploitability")
+
+
+def main(_):
+    game = pyspiel.load_game(FLAGS.game,
+                             {"players": pyspiel.GameParameter(FLAGS.players)})
+    if FLAGS.sampling == 'external':
+        cfr_solver = external_mccfr.ExternalSamplingSolver(game)
+    else:
+        cfr_solver = outcome_mccfr.OutcomeSamplingSolver(game)
+    for i in range(FLAGS.iterations):
+        cfr_solver.iteration()
+        if i % FLAGS.print_freq == 0:
+            # conv = exploitability.exploitability(game, cfr_solver.average_policy())
+            # print("Iteration {} exploitability {}".format(i, conv))
+            print("Iteration {}".format(i))
+
+if __name__ == "__main__":
+    app.run(main)


### PR DESCRIPTION
I implemented the external version of MCCFR in Python (`external_sampling_mccfr.py`). I tried to mirror the C++ version (`external_sampling_mccfr.cc`) as much as possible, taking the scheleton from the outcome version in Python (`outcome_sampling_mccfr.py`). Some code is duplicated with respect to it and maybe a super-class should be created.

I also created a module for tests (`external_sampling_mccfr_test.py`) where I taken some of the threshold values from the C++ version. I added the remaining values without any particular logic, but just using small thresholds similar to the known cases.

Finally, I changed the `mccfr_example.py` by allowing to use the new external sampling.

