### PR TITLE
Fix Oh Hell InfoStateTest buffer overflow.

### DIFF
--- a/docs/games.md
+++ b/docs/games.md
@@ -38,7 +38,7 @@ Status                                       | Game
 <font color="orange"><b>~</b></font>         | [Markov Soccer](#markov-soccer)
 ![](_static/green_circ10.png "green circle") | [Matching Pennies (Three-player)](#matching-pennies-three-player)
 ![](_static/green_circ10.png "green circle") | [Negotiation](#negotiation)
-<font color="red"><b>X</b></font>            | [Oh Hell](#oh-hell)
+<font color="orange"><b>X</b></font>         | [Oh Hell](#oh-hell)
 ![](_static/green_circ10.png "green circle") | [Oshi-Zumo](#oshi-zumo)
 ![](_static/green_circ10.png "green circle") | [Oware](#oware)
 ![](_static/green_circ10.png "green circle") | [Pentago](#pentago)

--- a/open_spiel/games/oh_hell.h
+++ b/open_spiel/games/oh_hell.h
@@ -38,9 +38,6 @@
 // for every trick won and an additional 10 points if they won the exact number
 // bid.
 //
-// There are known problems with this game; there seem to be nondeterministic
-// failures in the basic tests, so they have been disabled until we can fix
-// them. See https://github.com/deepmind/open_spiel/issues/412 for details.
 
 #include <memory>
 #include <string>

--- a/open_spiel/games/oh_hell_test.cc
+++ b/open_spiel/games/oh_hell_test.cc
@@ -60,7 +60,7 @@ std::string InformationStateTensorToString(Player player,
   int num_tricks;
   Player dealer;
   int trump;
-  std::vector<bool> hand(max_num_tricks);
+  std::vector<int> hand(deck_props.NumCards());
   std::vector<int> bids(num_players);
   std::vector<int> tricks_won(num_players);
   std::vector<Trick> tricks(max_num_tricks);
@@ -94,7 +94,7 @@ std::string InformationStateTensorToString(Player player,
   ptr += deck_props.NumCards();
   // Current hand
   for (int i = 0; i < deck_props.NumCards(); ++i) {
-    if (ptr[i] == 1) hand[i] = true;
+    if (ptr[i] == 1) hand[i] = 1;
   }
   ptr += deck_props.NumCards();
   // bids
@@ -246,12 +246,7 @@ void InformationStateTensorTest(int num_games = 10) {
 }  // namespace open_spiel
 
 int main(int argc, char** argv) {
-  /*
-  There are nondeterministic errors with this test that sometimes fail on
-  Travis marking the build as failing on github. Disabling them until we find
-  the cause and fix. See https://github.com/deepmind/open_spiel/issues/412
   open_spiel::oh_hell::BasicGameTests();
   open_spiel::oh_hell::GameConfigSimTest();
   open_spiel::oh_hell::InformationStateTensorTest();
-  */
 }


### PR DESCRIPTION
Fixes https://github.com/deepmind/open_spiel/issues/412

Overflow was caused by a vector too small to collect the one-hot encoded hand from the infostate tensor. The memory beyond the allocated space was being written to later in the function, resulting in additional cards showing up in the hand.

I was unable to reproduce the issue locally, so I did some additional testing by force pushing the branch with no changes 6 times so that CI would run (not sure if there is a better way). The oh_hell_test passed in all configurations every time, but there was a failure where one of the other tests failed to finish in one of the builds:
https://travis-ci.org/github/deepmind/open_spiel/builds/737581699
