### PR TITLE
DeepCFR tree traversal bug

### DIFF
--- a/open_spiel/python/algorithms/deep_cfr.py
+++ b/open_spiel/python/algorithms/deep_cfr.py
@@ -305,17 +305,19 @@ class DeepCFRSolver(policy.Policy):
       for action in state.legal_actions():
         expected_payoff[action] = self._traverse_game_tree(
             state.child(action), player)
+      cfv = 0
+      for a_ in state.legal_actions():
+        cfv += strategy[a_] * expected_payoff[a_]
       for action in state.legal_actions():
         sampled_regret[action] = expected_payoff[action]
-        for a_ in state.legal_actions():
-          sampled_regret[action] -= strategy[a_] * expected_payoff[a_]
+        sampled_regret[action] -= cfv
       sampled_regret_arr = [0] * self._num_actions
       for action in sampled_regret:
         sampled_regret_arr[action] = sampled_regret[action]
       self._advantage_memories[player].add(
           AdvantageMemory(state.information_state_tensor(), self._iteration,
                           sampled_regret_arr, action))
-      return max(expected_payoff.values())
+      return cfv
     else:
       other_player = state.current_player()
       _, strategy = self._sample_action_from_advantage(state, other_player)


### PR DESCRIPTION
When traversing the game tree, the expected value under the current strategy has to be passed up the tree, not the maximum value of the current runout. This is mentioned in https://arxiv.org/abs/1811.00164, section 4: "When a terminal node is reached, the value is passed back up. In chance and opponent infosets, the value of the sampled action is passed back up unaltered. In traverser infosets, the value passed back up is the weighted average of all action values, where action a’s weight is σ^t(I, a)."

With the same parameters as in https://arxiv.org/abs/1901.07621, this gives a NashConv of about 0.3 after 100 iterations with 1500 traversals each, which is twice as much as shown in the paper. So if they used avg_exploitability = NashConv/2, the code seems comparable, otherwise there might still be some other bugs.

I also have a TF2-implementation that uses the skip-connection and layer norm as described in the paper, as well as applying the legal_action_mask in the network training, which has also been mentioned in [pull request 406](https://github.com/deepmind/open_spiel/pull/406). These changes don't give noticable improvements in leduc though.

I am also not sure what the plan with integrating TF2 implementations is. Should I provide the code, and if yes, how?