### PR TITLE
Make sure that OrTools can be linked to any executable in OpenSpiel.

### DIFF
--- a/open_spiel/CMakeLists.txt
+++ b/open_spiel/CMakeLists.txt
@@ -231,17 +231,6 @@ endif()
 if (BUILD_WITH_GAMUT)
   set(OPEN_SPIEL_OBJECTS ${OPEN_SPIEL_OBJECTS} $<TARGET_OBJECTS:gamut>)
 endif()
-if (BUILD_WITH_ORTOOLS)
-  # set(ORTOOLS_HOME $ENV{HOME}/or-tools)
-  # list(APPEND CMAKE_PREFIX_PATH "${ORTOOLS_HOME}")
-  # find_package(ortools CONFIG REQUIRED)
-  # link_libraries(open_spiel_core ortools::ortools)
-  # set(OPEN_SPIEL_OBJECTS $<TARGET_OBJECTS:open_spiel_ortools> ${OPEN_SPIEL_OBJECTS})
-  # Use the following to link your_target_executable with OR-Tools libraries:
-  # target_link_libraries (your_target_executable ortools::ortools)
-endif()
-
-
 
 # We have the parent of this directory in the include path, so that we can
 # include for example "open_spiel/spiel.h" (assuming this directory is named
@@ -264,6 +253,25 @@ add_subdirectory (utils)
 
 if (BUILD_WITH_JULIA)
   add_subdirectory (julia)
+endif()
+
+if (BUILD_WITH_ORTOOLS)
+  # Compile with OR-Tools headers and link against binary distribution,
+  # downloaded from https://developers.google.com/optimization/install/cpp/linux
+  # and assumed to be in $HOME/or-tools.
+  # The flags were taken from the compilation of linear_programming.cc after
+  # running make test_cc.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_BOP -DUSE_GLOP -DUSE_CBC -DUSE_CLP -DUSE_SCIP")
+  set(ORTOOLS_HOME $ENV{HOME}/or-tools)
+  set(ORTOOLS_INC_DIRS ${ORTOOLS_HOME} ${ORTOOLS_HOME}/include)
+  set(ORTOOLS_LIB_DIRS ${ORTOOLS_HOME}/lib ${ORTOOLS_HOME}/lib64)
+  set(ORTOOLS_LIBS z rt pthread ortools)
+  set_target_properties(open_spiel_core PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  include_directories(${ORTOOLS_INC_DIRS})
+  link_directories(${ORTOOLS_LIB_DIRS})
+  set(OPEN_SPIEL_OBJECTS ${OPEN_SPIEL_OBJECTS} $<TARGET_OBJECTS:open_spiel_ortools>)
+
+  add_subdirectory(algorithms/ortools)
 endif()
 
 # Build a shared library, i.e. libopen_spiel.so. We generally only enable this

--- a/open_spiel/algorithms/CMakeLists.txt
+++ b/open_spiel/algorithms/CMakeLists.txt
@@ -60,9 +60,6 @@ add_library (algorithms OBJECT
 )
 target_include_directories (algorithms PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-if (${BUILD_WITH_ORTOOLS})
-  add_subdirectory (ortools)
-endif()
 
 add_executable(best_response_test best_response_test.cc
         $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})

--- a/open_spiel/algorithms/ortools/CMakeLists.txt
+++ b/open_spiel/algorithms/ortools/CMakeLists.txt
@@ -5,42 +5,13 @@
 #
 # You need to set BUILD_WITH_ORTOOLS to ON to include C++ Linear Programming.
 
-# Binary option: compile with OR-Tools headers and link against binary
-# distribution, downloaded from https://developers.google.com/optimization/install/cpp/linux
-# and assumed to be in $HOME/or-tools. The flags were taken fro the compilation
-# of linear_programming.cc after running make test_cc.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_BOP -DUSE_GLOP -DUSE_CBC -DUSE_CLP -DUSE_SCIP")
-set(ORTOOLS_HOME $ENV{HOME}/or-tools)
-set(ORTOOLS_INC_DIRS ${ORTOOLS_HOME} ${ORTOOLS_HOME}/include)
-set(ORTOOLS_LIB_DIRS ${ORTOOLS_HOME}/lib ${ORTOOLS_HOME}/lib64)
-set(ORTOOLS_LIBS z rt pthread ortools)
 add_library(open_spiel_ortools OBJECT
   lp_solver.cc
   lp_solver.h
-)
-set_target_properties(open_spiel_ortools PROPERTIES POSITION_INDEPENDENT_CODE ON)
-target_include_directories(open_spiel_ortools PUBLIC ${ORTOOLS_INC_DIRS})
-link_directories(open_spiel_ortools ${ORTOOLS_LIB_DIRS})
+  )
 target_link_libraries(open_spiel_ortools ${ORTOOLS_LIBS})
+
 add_executable(lp_solver_test lp_solver_test.cc ${OPEN_SPIEL_OBJECTS}
                $<TARGET_OBJECTS:tests> $<TARGET_OBJECTS:open_spiel_ortools>)
 target_link_libraries(lp_solver_test ${ORTOOLS_LIBS})
 add_test(lp_solver_test lp_solver_test)
-
-# Build OR-Tools from source option: compile with OR-Tools from source. Assumes
-# the source in a subdirectory or-tools (or sym linked). Disable the above to
-# use this. Note that the OR-Tools CMake build is experimental. See CMake build
-# instructions are here:
-# https://github.com/google/or-tools/blob/stable/cmake/README.md
-# set(BUILD_DEPS ON)
-#add_subdirectory(or-tools)
-#add_library(open_spiel_ortools OBJECT
-#  lp_solver.cc
-#  lp_solver.h
-#)
-#target_link_libraries(open_spiel_ortools ortools::ortools)
-#add_executable(lp_solver_test lp_solver_test.cc ${OPEN_SPIEL_OBJECTS}
-#               $<TARGET_OBJECTS:tests> $<TARGET_OBJECTS:open_spiel_ortools>)
-#target_link_libraries(lp_solver_test ortools::ortools)
-#add_test(lp_solver_test lp_solver_test)
-


### PR DESCRIPTION
For a target T, now you can use anywhere
target_link_libraries(T ${ORTOOLS_LIBS})

I dropped the source option, as I was not able to replicate it.