### PR TITLE
Add better support for simultaneous move games.

### DIFF
--- a/open_spiel/algorithms/cfr.cc
+++ b/open_spiel/algorithms/cfr.cc
@@ -68,12 +68,13 @@ CFRAveragePolicy::CFRAveragePolicy(const CFRInfoStateValuesTable& info_states,
                                    std::shared_ptr<Policy> default_policy)
     : info_states_(info_states), default_policy_(default_policy) {}
 
-ActionsAndProbs CFRAveragePolicy::GetStatePolicy(const State& state) const {
+ActionsAndProbs CFRAveragePolicy::GetStatePolicy(
+    const State& state, Player player) const {
   ActionsAndProbs actions_and_probs;
-  auto entry = info_states_.find(state.InformationStateString());
+  auto entry = info_states_.find(state.InformationStateString(player));
   if (entry == info_states_.end()) {
     if (default_policy_) {
-      return default_policy_->GetStatePolicy(state);
+      return default_policy_->GetStatePolicy(state, player);
     } else {
       return actions_and_probs;
     }
@@ -124,12 +125,13 @@ CFRCurrentPolicy::CFRCurrentPolicy(const CFRInfoStateValuesTable& info_states,
                                    std::shared_ptr<Policy> default_policy)
     : info_states_(info_states), default_policy_(default_policy) {}
 
-ActionsAndProbs CFRCurrentPolicy::GetStatePolicy(const State& state) const {
+ActionsAndProbs CFRCurrentPolicy::GetStatePolicy(
+    const State& state, Player player) const {
   ActionsAndProbs actions_and_probs;
-  auto entry = info_states_.find(state.InformationStateString());
+  auto entry = info_states_.find(state.InformationStateString(player));
   if (entry == info_states_.end()) {
     if (default_policy_) {
-      return default_policy_->GetStatePolicy(state);
+      return default_policy_->GetStatePolicy(state, player);
     } else {
       return actions_and_probs;
     }

--- a/open_spiel/algorithms/cfr.h
+++ b/open_spiel/algorithms/cfr.h
@@ -129,7 +129,11 @@ class CFRAveragePolicy : public Policy {
   // return a uniform policy.
   CFRAveragePolicy(const CFRInfoStateValuesTable& info_states,
                    std::shared_ptr<Policy> default_policy);
-  ActionsAndProbs GetStatePolicy(const State& state) const override;
+  ActionsAndProbs GetStatePolicy(const State& state) const override {
+    return GetStatePolicy(state, state.CurrentPlayer());
+  };
+  ActionsAndProbs GetStatePolicy(const State& state,
+                                 Player player) const override;
   ActionsAndProbs GetStatePolicy(const std::string& info_state) const override;
 
  private:
@@ -149,7 +153,11 @@ class CFRCurrentPolicy : public Policy {
   // to not use a default policy).
   CFRCurrentPolicy(const CFRInfoStateValuesTable& info_states,
                    std::shared_ptr<Policy> default_policy);
-  ActionsAndProbs GetStatePolicy(const State& state) const override;
+  ActionsAndProbs GetStatePolicy(const State& state) const override {
+    return GetStatePolicy(state, state.CurrentPlayer());
+  };
+  ActionsAndProbs GetStatePolicy(const State& state,
+                                 Player player) const override;
   ActionsAndProbs GetStatePolicy(const std::string& info_state) const override;
   TabularPolicy AsTabular() const;
 

--- a/open_spiel/algorithms/corr_dist/afcce.h
+++ b/open_spiel/algorithms/corr_dist/afcce.h
@@ -120,7 +120,10 @@ class AFCCETabularPolicy : public TabularPolicy {
     SpielFatalError("GetStatePolicy(const std::string&) should not be called.");
     return TabularPolicy::GetStatePolicy(info_state);
   }
-
+  ActionsAndProbs GetStatePolicy(const State& state, Player pl) const override {
+    SPIEL_CHECK_EQ(state.CurrentPlayer(), pl);
+    return GetStatePolicy(state);
+  }
   ActionsAndProbs GetStatePolicy(const State& state) const override;
 
  private:

--- a/open_spiel/algorithms/corr_dist/afce.h
+++ b/open_spiel/algorithms/corr_dist/afce.h
@@ -96,7 +96,10 @@ class AFCETabularPolicy : public TabularPolicy {
     SpielFatalError("GetStatePolicy(const std::string&) should not be called.");
     return TabularPolicy::GetStatePolicy(info_state);
   }
-
+  ActionsAndProbs GetStatePolicy(const State& state, Player pl) const override {
+    SPIEL_CHECK_EQ(state.CurrentPlayer(), pl);
+    return GetStatePolicy(state);
+  }
   ActionsAndProbs GetStatePolicy(const State& state) const override;
 
  private:

--- a/open_spiel/algorithms/corr_dist/efcce.h
+++ b/open_spiel/algorithms/corr_dist/efcce.h
@@ -120,7 +120,10 @@ class EFCCETabularPolicy : public TabularPolicy {
     SpielFatalError("GetStatePolicy(const std::string&) should not be called.");
     return TabularPolicy::GetStatePolicy(info_state);
   }
-
+  ActionsAndProbs GetStatePolicy(const State& state, Player pl) const override {
+    SPIEL_CHECK_EQ(state.CurrentPlayer(), pl);
+    return GetStatePolicy(state);
+  }
   ActionsAndProbs GetStatePolicy(const State& state) const override;
 
  private:

--- a/open_spiel/algorithms/corr_dist/efce.h
+++ b/open_spiel/algorithms/corr_dist/efce.h
@@ -118,7 +118,10 @@ class EFCETabularPolicy : public TabularPolicy {
     SpielFatalError("GetStatePolicy(const std::string&) should not be called.");
     return TabularPolicy::GetStatePolicy(info_state);
   }
-
+  ActionsAndProbs GetStatePolicy(const State& state, Player pl) const override {
+    SPIEL_CHECK_EQ(state.CurrentPlayer(), pl);
+    return GetStatePolicy(state);
+  }
   ActionsAndProbs GetStatePolicy(const State& state) const override;
 
  private:

--- a/open_spiel/algorithms/expected_returns.cc
+++ b/open_spiel/algorithms/expected_returns.cc
@@ -216,7 +216,7 @@ std::vector<double> ExpectedReturns(const State& state,
     return ExpectedReturnsImpl(
         state,
         [&policies](Player player, const State& state) {
-          return policies[player]->GetStatePolicy(state);
+          return policies[player]->GetStatePolicy(state, player);
         },
         depth_limit);
   }
@@ -236,7 +236,7 @@ std::vector<double> ExpectedReturns(const State& state,
     return ExpectedReturnsImpl(
         state,
         [&joint_policy](Player player, const State& state) {
-          return joint_policy.GetStatePolicy(state);
+          return joint_policy.GetStatePolicy(state, player);
         },
         depth_limit);
   }

--- a/open_spiel/policy.h
+++ b/open_spiel/policy.h
@@ -257,7 +257,9 @@ std::unique_ptr<TabularPolicy> DeserializeTabularPolicy(
 // tabular version, except that this works for large games.
 class UniformPolicy : public Policy {
  public:
-  ActionsAndProbs GetStatePolicy(const State& state) const override {
+  ActionsAndProbs GetStatePolicy(
+      const State& state, Player player) const override {
+    SPIEL_CHECK_TRUE(state.IsPlayerActing(player));
     return UniformStatePolicy(state);
   }
 


### PR DESCRIPTION
This changes ExpectedReturns to use the policy for the requested player.
Because of this change, it propagates to multiple places that are implementing the Policy class.