### PR TITLE
Add a test for creation of a shared library.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ matrix:
       - BUILD_SHARED_LIB="ON"
       - DEFAULT_OPTIONAL_DEPENDENCY="ON"
       - BUILD_WITH_ORTOOLS="ON"
+      - BUILD_WITH_ORTOOLS_DOWNLOAD_URL="https://github.com/google/or-tools/releases/download/v8.0/or-tools_ubuntu-18.04_v8.0.8283.tar.gz"
 
 script:
   - pwd

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,16 @@ matrix:
       - DEFAULT_OPTIONAL_DEPENDENCY="ON"
       - TRAVIS_USE_NOX=1
 
+  # Build and run tests for building a shared library with linkable
+  # third party dependencies in place.
+  - os: linux
+    dist: bionic # Ubuntu 18.04.2 LTS released on 26 April 2018
+    env:
+      - OS_PYTHON_VERSION=3.6
+      - BUILD_SHARED_LIB="ON"
+      - DEFAULT_OPTIONAL_DEPENDENCY="ON"
+      - BUILD_WITH_ORTOOLS="ON"
+
 script:
   - pwd
   - chmod +x install.sh

--- a/open_spiel/CMakeLists.txt
+++ b/open_spiel/CMakeLists.txt
@@ -238,7 +238,7 @@ if (BUILD_WITH_ORTOOLS)
   # The flags were taken from the compilation of linear_programming.cc after
   # running make test_cc.
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_BOP -DUSE_GLOP -DUSE_CBC -DUSE_CLP -DUSE_SCIP")
-  set(ORTOOLS_HOME $ENV{HOME}/or-tools)
+  set(ORTOOLS_HOME "${CMAKE_CURRENT_SOURCE_DIR}/ortools")
   set(ORTOOLS_INC_DIRS ${ORTOOLS_HOME} ${ORTOOLS_HOME}/include)
   set(ORTOOLS_LIB_DIRS ${ORTOOLS_HOME}/lib ${ORTOOLS_HOME}/lib64)
   set(ORTOOLS_LIBS z rt pthread ortools)

--- a/open_spiel/CMakeLists.txt
+++ b/open_spiel/CMakeLists.txt
@@ -245,7 +245,8 @@ if (BUILD_WITH_ORTOOLS)
   set_target_properties(open_spiel_core PROPERTIES POSITION_INDEPENDENT_CODE ON)
   include_directories(${ORTOOLS_INC_DIRS})
   link_directories(${ORTOOLS_LIB_DIRS})
-  set(OPEN_SPIEL_OBJECTS ${OPEN_SPIEL_OBJECTS} $<TARGET_OBJECTS:open_spiel_ortools>)
+  # Use following to link your_target_executable with OrTools libraries:
+  # target_link_libraries(your_target_executable ${ORTOOLS_LIBS})
 endif()
 
 
@@ -261,7 +262,6 @@ add_subdirectory (examples)
 add_subdirectory (fog)
 add_subdirectory (games)
 add_subdirectory (game_transforms)
-add_subdirectory (tests)
 
 if (BUILD_WITH_PYTHON)
   add_subdirectory (python)
@@ -284,7 +284,11 @@ if(NOT DEFINED ENV{BUILD_SHARED_LIB})
 endif()
 set (BUILD_SHARED_LIB $ENV{BUILD_SHARED_LIB})
 if (BUILD_SHARED_LIB)
-  add_library(open_spiel SHARED ${OPEN_SPIEL_OBJECTS})
+  add_library(open_spiel SHARED ${OPEN_SPIEL_OBJECTS}
+    # Optionally include files that use external dependencies, for example
+    # linear program specification for finding Nash equilibria.
+    $<TARGET_OBJECTS:open_spiel_ortools>
+  )
   target_include_directories(open_spiel PUBLIC
       ${CMAKE_CURRENT_SOURCE_DIR} abseil-cpp)
   target_link_libraries(open_spiel PUBLIC
@@ -295,5 +299,10 @@ if (BUILD_SHARED_LIB)
     absl::str_format
     absl::strings
     absl::time
+    # Optionally link external dependencies, for example OrTools for solving
+    # linear programs.
+    ${ORTOOLS_LIBS}
   )
 endif()
+
+add_subdirectory (tests)

--- a/open_spiel/scripts/global_variables.sh
+++ b/open_spiel/scripts/global_variables.sh
@@ -67,4 +67,7 @@ export BUILD_WITH_GAMUT="${BUILD_WITH_GAMUT:-"OFF"}"
 # Disabled by default as it requires installation of third party software.
 # See algorithms/ortools/CMakeLists.txt for specific instructions.
 export BUILD_WITH_ORTOOLS="${BUILD_WITH_ORTOOLS:-"OFF"}"
-
+# You may want to replace this URL according to your system.
+# Use version 8 at minimum, due to compatibility between absl library versions
+# used in OpenSpiel and in OrTools.
+export BUILD_WITH_ORTOOLS_DOWNLOAD_URL="${BUILD_WITH_ORTOOLS_DOWNLOAD_URL:-"https://github.com/google/or-tools/releases/download/v8.0/or-tools_ubuntu-18.04_v8.0.8283.tar.gz"}"

--- a/open_spiel/scripts/install.sh
+++ b/open_spiel/scripts/install.sh
@@ -155,22 +155,8 @@ fi
 # https://developers.google.com/optimization/install/cpp/
 DIR="open_spiel/ortools"
 if [[ ${BUILD_WITH_ORTOOLS:-"ON"} == "ON" ]] && [[ ! -d ${DIR} ]]; then
-  # You may want to replace this URL according to your system.
-  #
-  # Use version 8 at minimum, due to compatibility between absl library versions
-  # used in OpenSpiel and in OrTools.
-  if [[ "$OSTYPE" == "linux-gnu" ]]; then
-    DOWNLOAD_URL="https://github.com/google/or-tools/releases/download/v8.0/or-tools_ubuntu-18.04_v8.0.8283.tar.gz"
-  elif [[ "$OSTYPE" == "darwin"* ]]; then  # Mac OSX
-    DOWNLOAD_URL="https://github.com/google/or-tools/releases/download/v8.0/or-tools_MacOsX-10.15.7_v8.0.8283.tar.gz"
-  else
-    echo "The OS '$OSTYPE' is not supported (Only Linux and MacOS is). " \
-         "Feel free to contribute the install for a new OS."
-    exit 1
-  fi
-
   DOWNLOAD_FILE="${DOWNLOAD_CACHE_DIR}/ortools.tar.gz"
-  [[ -f "${DOWNLOAD_FILE}" ]] || wget --show-progress -O "${DOWNLOAD_FILE}" "$DOWNLOAD_URL"
+  [[ -f "${DOWNLOAD_FILE}" ]] || wget --show-progress -O "${DOWNLOAD_FILE}" "${BUILD_WITH_ORTOOLS_DOWNLOAD_URL}"
   mkdir "$DIR"
   tar -xzf "${DOWNLOAD_FILE}" --strip 1 -C "$DIR"
 fi

--- a/open_spiel/scripts/install.sh
+++ b/open_spiel/scripts/install.sh
@@ -150,6 +150,23 @@ if [[ ${BUILD_WITH_LIBTORCH:-"ON"} == "ON" ]] && [[ ! -d ${DIR} ]]; then
   unzip "${DOWNLOAD_FILE}" -d "open_spiel/libtorch/"
 fi
 
+# Add OrTools
+# This downloads the precompiled binaries available from the official website.
+# https://developers.google.com/optimization/install/cpp/
+DIR="open_spiel/ortools"
+if [[ ${BUILD_WITH_ORTOOLS:-"ON"} == "ON" ]] && [[ ! -d ${DIR} ]]; then
+  # You may want to replace this URL according to your system.
+  #
+  # Use version 8 at minimum, due to compatibility between absl library versions
+  # used in OpenSpiel and in OrTools.
+  DOWNLOAD_URL="https://github.com/google/or-tools/releases/download/v8.0/or-tools_ubuntu-18.04_v8.0.8283.tar.gz"
+
+  DOWNLOAD_FILE="${DOWNLOAD_CACHE_DIR}/ortools.tar.gz"
+  [[ -f "${DOWNLOAD_FILE}" ]] || wget --show-progress -O "${DOWNLOAD_FILE}" "$DOWNLOAD_URL"
+  mkdir "$DIR"
+  tar -xzvf "${DOWNLOAD_FILE}" --strip 1 -C "$DIR"
+fi
+
 # 2. Install other required system-wide dependencies
 
 # Install Julia if required and not present already.

--- a/open_spiel/scripts/install.sh
+++ b/open_spiel/scripts/install.sh
@@ -159,7 +159,15 @@ if [[ ${BUILD_WITH_ORTOOLS:-"ON"} == "ON" ]] && [[ ! -d ${DIR} ]]; then
   #
   # Use version 8 at minimum, due to compatibility between absl library versions
   # used in OpenSpiel and in OrTools.
-  DOWNLOAD_URL="https://github.com/google/or-tools/releases/download/v8.0/or-tools_ubuntu-18.04_v8.0.8283.tar.gz"
+  if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    DOWNLOAD_URL="https://github.com/google/or-tools/releases/download/v8.0/or-tools_ubuntu-18.04_v8.0.8283.tar.gz"
+  elif [[ "$OSTYPE" == "darwin"* ]]; then  # Mac OSX
+    DOWNLOAD_URL="https://github.com/google/or-tools/releases/download/v8.0/or-tools_MacOsX-10.15.7_v8.0.8283.tar.gz"
+  else
+    echo "The OS '$OSTYPE' is not supported (Only Linux and MacOS is). " \
+         "Feel free to contribute the install for a new OS."
+    exit 1
+  fi
 
   DOWNLOAD_FILE="${DOWNLOAD_CACHE_DIR}/ortools.tar.gz"
   [[ -f "${DOWNLOAD_FILE}" ]] || wget --show-progress -O "${DOWNLOAD_FILE}" "$DOWNLOAD_URL"

--- a/open_spiel/scripts/install.sh
+++ b/open_spiel/scripts/install.sh
@@ -164,7 +164,7 @@ if [[ ${BUILD_WITH_ORTOOLS:-"ON"} == "ON" ]] && [[ ! -d ${DIR} ]]; then
   DOWNLOAD_FILE="${DOWNLOAD_CACHE_DIR}/ortools.tar.gz"
   [[ -f "${DOWNLOAD_FILE}" ]] || wget --show-progress -O "${DOWNLOAD_FILE}" "$DOWNLOAD_URL"
   mkdir "$DIR"
-  tar -xzvf "${DOWNLOAD_FILE}" --strip 1 -C "$DIR"
+  tar -xzf "${DOWNLOAD_FILE}" --strip 1 -C "$DIR"
 fi
 
 # 2. Install other required system-wide dependencies

--- a/open_spiel/tests/CMakeLists.txt
+++ b/open_spiel/tests/CMakeLists.txt
@@ -7,3 +7,10 @@ target_include_directories (tests PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 add_executable(spiel_test spiel_test.cc
                $<TARGET_OBJECTS:tests> ${OPEN_SPIEL_OBJECTS})
 add_test(spiel_test spiel_test)
+
+if (BUILD_SHARED_LIB)
+  add_executable(shared_lib_test shared_lib_test.cc)
+  target_link_libraries(shared_lib_test open_spiel)
+  add_test(shared_lib_test shared_lib_test)
+endif()
+

--- a/open_spiel/tests/shared_lib_test.cc
+++ b/open_spiel/tests/shared_lib_test.cc
@@ -1,0 +1,55 @@
+// Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file tests whether we can build a shared library that contains all
+// the optional dependencies.
+
+#include <iostream>
+
+#include "open_spiel/games/kuhn_poker.h"
+#include "open_spiel/spiel.h"
+#include "open_spiel/spiel_utils.h"
+
+#if BUILD_WITH_ORTOOLS
+#include "open_spiel/algorithms/ortools/lp_solver.h"
+#include "open_spiel/algorithms/matrix_game_utils.h"
+#endif  // BUILD_WITH_ORTOOLS
+
+namespace {
+
+void TestLinkingWithOpenSpielCore() {
+  std::cout << "Running open_spiel_core" << '\n';
+  std::shared_ptr<const open_spiel::Game> game = open_spiel::LoadGame("kuhn_poker");
+  SPIEL_CHECK_EQ(game->GetType().short_name, "kuhn_poker");
+}
+
+#if BUILD_WITH_ORTOOLS
+void TestLinkingWithOpenSpielOrtools() {
+  std::cout << "Running open_spiel_ortools" << '\n';
+  std::shared_ptr<const open_spiel::matrix_game::MatrixGame> game =
+      open_spiel::algorithms::LoadMatrixGame("matrix_rps");
+  open_spiel::algorithms::ortools::ZeroSumGameSolution solution =
+      open_spiel::algorithms::ortools::SolveZeroSumMatrixGame(*game);
+  SPIEL_CHECK_FLOAT_NEAR(solution.values[0], 0., 1e-10);
+}
+#endif  // BUILD_WITH_ORTOOLS
+
+}  // namespace
+
+int main() {
+  TestLinkingWithOpenSpielCore();
+#if BUILD_WITH_ORTOOLS
+  TestLinkingWithOpenSpielOrtools();
+#endif
+}


### PR DESCRIPTION
We can now have a shared library that includes third party dependencies packaged inside of it, so we can use things like sequence-form LPs without researchers worrying about linking with OrTools. 

This is useful for experiments, where you can just provide a singled shared library with all dependencies and copy it for example to a computation cluster.