### PR TITLE
Implemented the save and restore methods in the DQN agent

### DIFF
--- a/open_spiel/python/algorithms/dqn.py
+++ b/open_spiel/python/algorithms/dqn.py
@@ -19,7 +19,9 @@ from __future__ import division
 from __future__ import print_function
 
 import collections
+import os
 import random
+from absl import logging
 import numpy as np
 import tensorflow.compat.v1 as tf
 
@@ -198,6 +200,11 @@ class DQN(rl_agent.AbstractAgent):
     action_indices = tf.stack(
         [tf.range(tf.shape(self._q_values)[0]), self._action_ph], axis=-1)
     predictions = tf.gather_nd(self._q_values, action_indices)
+
+    self._savers = [
+        ("q_network", tf.train.Saver(self._q_network.variables)),
+        ("target_q_network", tf.train.Saver(self._target_q_network.variables))
+    ]
 
     if loss_str == "mse":
       loss_class = tf.losses.mean_squared_error
@@ -382,6 +389,54 @@ class DQN(rl_agent.AbstractAgent):
             self._legal_actions_mask_ph: legal_actions_mask,
         })
     return loss
+
+  def _full_checkpoint_name(self, checkpoint_dir, name):
+    checkpoint_filename = "_".join([name, "pid" + str(self.player_id)])
+    return os.path.join(checkpoint_dir, checkpoint_filename)
+
+  def _latest_checkpoint_filename(self, name):
+    checkpoint_filename = "_".join([name, "pid" + str(self.player_id)])
+    return checkpoint_filename + "_latest"
+
+  def save(self, checkpoint_dir):
+    """Saves the q network and the target q-network.
+
+    Note that this does not save the experience replay buffers and should
+    only be used to restore the agent's policy, not resume training.
+
+    Args:
+      checkpoint_dir: directory where checkpoints will be saved.
+    """
+    for name, saver in self._savers:
+      path = saver.save(
+          self._session,
+          self._full_checkpoint_name(checkpoint_dir, name),
+          latest_filename=self._latest_checkpoint_filename(name))
+      logging.info("Saved to path: %s", path)
+
+  def has_checkpoint(self, checkpoint_dir):
+    for name, _ in self._savers:
+      if tf.train.latest_checkpoint(
+          self._full_checkpoint_name(checkpoint_dir, name),
+          os.path.join(checkpoint_dir,
+                       self._latest_checkpoint_filename(name))) is None:
+        return False
+    return True
+
+  def restore(self, checkpoint_dir):
+    """Restores the q network and the target q-network.
+
+    Note that this does not restore the experience replay buffers and should
+    only be used to restore the agent's policy, not resume training.
+
+    Args:
+      checkpoint_dir: directory from which checkpoints will be restored.
+    """
+    for name, saver in self._savers:
+      full_checkpoint_dir = self._full_checkpoint_name(checkpoint_dir, name)
+      logging.info("Restoring checkpoint: %s", full_checkpoint_dir)
+      saver.restore(self._session, full_checkpoint_dir)
+
 
   @property
   def q_values(self):

--- a/open_spiel/python/algorithms/nfsp.py
+++ b/open_spiel/python/algorithms/nfsp.py
@@ -315,7 +315,7 @@ class NFSP(rl_agent.AbstractAgent):
     """
     for name, saver in self._savers:
       full_checkpoint_dir = self._full_checkpoint_name(checkpoint_dir, name)
-      logging.info("Restoring checkpoint: %s", (full_checkpoint_dir))
+      logging.info("Restoring checkpoint: %s", full_checkpoint_dir)
       saver.restore(self._session, full_checkpoint_dir)
 
 

--- a/open_spiel/python/algorithms/policy_gradient.py
+++ b/open_spiel/python/algorithms/policy_gradient.py
@@ -372,7 +372,7 @@ class PolicyGradient(rl_agent.AbstractAgent):
   def restore(self, checkpoint_dir):
     for name, saver in self._savers:
       full_checkpoint_dir = self._full_checkpoint_name(checkpoint_dir, name)
-      logging.info("Restoring checkpoint: %s", (full_checkpoint_dir))
+      logging.info("Restoring checkpoint: %s", full_checkpoint_dir)
       saver.restore(self._session, full_checkpoint_dir)
 
   @property

--- a/open_spiel/python/examples/breakthrough_dqn.py
+++ b/open_spiel/python/examples/breakthrough_dqn.py
@@ -32,7 +32,10 @@ FLAGS = flags.FLAGS
 
 # Training parameters
 flags.DEFINE_string("checkpoint_dir", "/tmp/dqn_test",
-                    "Directory to save/load the agent.")
+                    "Directory to save/load the agent models.")
+flags.DEFINE_integer(
+    "save_every", int(1e4),
+    "Episode frequency at which the DQN agent models are saved.")
 flags.DEFINE_integer("num_train_episodes", int(1e6),
                      "Number of training episodes.")
 flags.DEFINE_integer(
@@ -103,14 +106,15 @@ def main(_):
             replay_buffer_capacity=FLAGS.replay_buffer_capacity,
             batch_size=FLAGS.batch_size) for idx in range(num_players)
     ]
-    saver = tf.train.Saver()
     sess.run(tf.global_variables_initializer())
 
     for ep in range(FLAGS.num_train_episodes):
       if (ep + 1) % FLAGS.eval_every == 0:
         r_mean = eval_against_random_bots(env, agents, random_agents, 1000)
         logging.info("[%s] Mean episode rewards %s", ep + 1, r_mean)
-        saver.save(sess, FLAGS.checkpoint_dir, ep)
+      if (ep + 1) % FLAGS.save_every == 0:
+        for agent in agents:
+            agent.save(FLAGS.checkpoint_dir)
 
       time_step = env.reset()
       while not time_step.last():


### PR DESCRIPTION
I implemented the feature of saving and loading models for the DQN agent, taking from nfsp and policy gradient versions. I also adapted the example in `breakthrough.py`, allowing to save the agent models rather than the entire session.