### PR TITLE
Add infostate trees.

### DIFF
--- a/open_spiel/algorithms/CMakeLists.txt
+++ b/open_spiel/algorithms/CMakeLists.txt
@@ -33,6 +33,8 @@ add_library (algorithms OBJECT
   get_legal_actions_map.h
   history_tree.cc
   history_tree.h
+  infostate_tree.h
+  infostate_tree.cc
   is_mcts.cc
   is_mcts.h
   matrix_game_utils.cc
@@ -111,6 +113,10 @@ add_test(get_legal_actions_map_test get_legal_actions_map_test)
 add_executable(history_tree_test history_tree_test.cc
         $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})
 add_test(history_tree_test history_tree_test)
+
+add_executable(infostate_tree_test   infostate_tree_test.cc
+        $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})
+add_test(infostate_tree_test infostate_tree_test)
 
 add_executable(is_mcts_test is_mcts_test.cc
         $<TARGET_OBJECTS:algorithms> ${OPEN_SPIEL_OBJECTS})

--- a/open_spiel/algorithms/infostate_tree.cc
+++ b/open_spiel/algorithms/infostate_tree.cc
@@ -694,13 +694,12 @@ std::pair<double, SfStrategy> InfostateTree::BestResponse(
     double max_value = init_value;
     SequenceId max_id = current;
     const InfostateNode* node = observation_infostate(current);
-    current = node->start_sequence_id();
-    while (current != node->end_sequence_id()) {
+    for (current = node->start_sequence_id();
+         current != node->end_sequence_id(); current.next()) {
       if (gradient[current] > max_value) {
         max_value = gradient[current];
         max_id = current;
       }
-      current.next();
     }
     if (init_value != max_value) {
       gradient[node->sequence_id()] += max_value;

--- a/open_spiel/algorithms/infostate_tree.cc
+++ b/open_spiel/algorithms/infostate_tree.cc
@@ -499,6 +499,14 @@ std::shared_ptr<InfostateTree> MakeInfostateTree(
 std::shared_ptr<InfostateTree> MakeInfostateTree(
     const std::vector<InfostateNode*>& start_nodes,
     int max_move_ahead_limit) {
+  std::vector<const InfostateNode*> const_nodes(
+      start_nodes.begin(), start_nodes.end());
+  return MakeInfostateTree(const_nodes, max_move_ahead_limit);
+}
+
+std::shared_ptr<InfostateTree> MakeInfostateTree(
+    const std::vector<const InfostateNode*>& start_nodes,
+    int max_move_ahead_limit) {
   SPIEL_CHECK_FALSE(start_nodes.empty());
   const InfostateNode* some_node = start_nodes[0];
   const InfostateTree& originating_tree = some_node->tree();

--- a/open_spiel/algorithms/infostate_tree.cc
+++ b/open_spiel/algorithms/infostate_tree.cc
@@ -1,0 +1,814 @@
+// Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "open_spiel/algorithms/infostate_tree.h"
+
+#include <limits>
+#include <memory>
+#include <string>
+#include <stack>
+#include <utility>
+#include <vector>
+
+#include "open_spiel/action_view.h"
+
+
+namespace open_spiel {
+namespace algorithms {
+
+InfostateNode::InfostateNode(
+    const InfostateTree& tree, InfostateNode* parent, int incoming_index,
+    InfostateNodeType type, const std::string& infostate_string,
+    double terminal_utility,
+    double terminal_ch_reach_prob, size_t depth,
+    std::vector<Action> legal_actions, std::vector<Action> terminal_history)
+    : tree_(tree), parent_(parent),
+      incoming_index_(incoming_index), type_(type),
+      infostate_string_(infostate_string),
+      depth_(depth),
+      terminal_utility_(terminal_utility),
+      terminal_chn_reach_prob_(terminal_ch_reach_prob),
+      legal_actions_(std::move(legal_actions)),
+      terminal_history_(std::move(terminal_history)) {
+
+  // Implications for kTerminalNode
+  SPIEL_DCHECK_TRUE(type_ != kTerminalInfostateNode || parent_);
+  // Implications for kDecisionNode
+  SPIEL_DCHECK_TRUE(type_ != kDecisionInfostateNode || parent_);
+  // Implications for kObservationNode
+  SPIEL_DCHECK_TRUE(
+      !(type_ == kObservationInfostateNode
+            && parent_ && parent_->type() == kDecisionInfostateNode)
+      || (incoming_index_ >= 0
+            && incoming_index_ < parent_->legal_actions().size())
+  );
+}
+
+const std::string& InfostateNode::infostate_string() const {
+  // Avoid working with empty infostate strings.
+  // Use Hasinfostate_string() first to check.
+  SPIEL_DCHECK_TRUE(has_infostate_string());
+  return infostate_string_;
+}
+
+bool InfostateNode::has_infostate_string() const {
+  return infostate_string_ != kFillerInfostate
+      && infostate_string_ != kDummyRootNodeInfostate;
+}
+
+double InfostateNode::terminal_utility() const {
+  SPIEL_CHECK_EQ(type_, kTerminalInfostateNode);
+  return terminal_utility_;
+}
+
+double InfostateNode::terminal_chance_reach_prob() const {
+  SPIEL_CHECK_EQ(type_, kTerminalInfostateNode);
+  return terminal_chn_reach_prob_;
+}
+
+const std::vector<Action>& InfostateNode::legal_actions() const {
+  SPIEL_CHECK_EQ(type_, kDecisionInfostateNode);
+  return legal_actions_;
+}
+
+const std::vector<std::unique_ptr<State>>& InfostateNode::corresponding_states()
+const {
+  return corresponding_states_;
+}
+
+const std::vector<double>& InfostateNode::corresponding_chance_reach_probs()
+const {
+  return corresponding_ch_reaches_;
+}
+
+const SequenceId InfostateNode::sequence_id() const {
+  SPIEL_CHECK_FALSE(sequence_id_.is_undefined());
+  return sequence_id_;
+}
+const SequenceId InfostateNode::start_sequence_id() const {
+  SPIEL_CHECK_FALSE(start_sequence_id_.is_undefined());
+  return start_sequence_id_;
+}
+const SequenceId InfostateNode::end_sequence_id() const {
+  SPIEL_CHECK_FALSE(end_sequence_id_.is_undefined());
+  return end_sequence_id_;
+}
+const DecisionId InfostateNode::decision_id() const {
+  SPIEL_CHECK_EQ(type_, kDecisionInfostateNode);
+  SPIEL_CHECK_FALSE(decision_id_.is_undefined());
+  return decision_id_;
+}
+InfostateNode* InfostateNode::AddChild(std::unique_ptr<InfostateNode> child) {
+  SPIEL_CHECK_EQ(child->parent_, this);
+  children_.push_back(std::move(child));
+  return children_.back().get();
+}
+
+InfostateNode* InfostateNode::GetChild(
+    const std::string& infostate_string) const {
+  for (const std::unique_ptr<InfostateNode>& child : children_) {
+    if (child->infostate_string() == infostate_string) return child.get();
+  }
+  return nullptr;
+}
+
+std::ostream& InfostateNode::operator<<(std::ostream& os) const {
+  if (!parent_) return os << 'x';
+  return os << parent_ << ',' << incoming_index_;
+}
+
+std::string InfostateNode::MakeCertificate() const {
+  if (type_ == kTerminalInfostateNode) return "{}";
+
+  std::vector<std::string> certificates;
+  for (InfostateNode* child : child_iterator()) {
+    certificates.push_back(child->MakeCertificate());
+  }
+  std::sort(certificates.begin(), certificates.end());
+
+  std::string open, close;
+  if (type_ == kDecisionInfostateNode) {
+    open = "[";
+    close = "]";
+  } else if (type_ == kObservationInfostateNode) {
+    open = "(";
+    close = ")";
+  }
+
+  return absl::StrCat(
+      open,
+      absl::StrJoin(certificates.begin(), certificates.end(), ""),
+      close);
+}
+
+void InfostateNode::RebalanceSubtree(int target_depth, int current_depth) {
+  SPIEL_DCHECK_LE(current_depth, target_depth);
+  depth_ = current_depth;
+
+  if (is_leaf_node() && target_depth != current_depth) {
+    // Prepare the chain of dummy observations.
+    depth_ = target_depth;
+    std::unique_ptr<InfostateNode> node = Release();
+    InfostateNode* node_parent = node->parent();
+    int position_in_leaf_parent = node->incoming_index();
+    std::unique_ptr<InfostateNode> chain_head =
+        std::unique_ptr<InfostateNode>(new InfostateNode(
+            /*tree=*/tree_, /*parent=*/nullptr,
+            /*incoming_index=*/position_in_leaf_parent,
+            kObservationInfostateNode,
+            /*infostate_string=*/kFillerInfostate,
+            /*terminal_utility=*/NAN, /*terminal_ch_reach_prob=*/NAN,
+            current_depth, /*legal_actions=*/{}, /*terminal_history=*/{}));
+    InfostateNode* chain_tail = chain_head.get();
+    for (int i = 1; i < target_depth - current_depth; ++i) {
+      chain_tail = chain_tail->AddChild(
+          std::unique_ptr<InfostateNode>(new InfostateNode(
+              /*tree=*/tree_, /*parent=*/chain_tail,
+              /*incoming_index=*/0, kObservationInfostateNode,
+              /*infostate_string=*/kFillerInfostate,
+              /*terminal_utility=*/NAN, /*terminal_ch_reach_prob=*/NAN,
+              current_depth + i, /*legal_actions=*/{},
+              /*terminal_history=*/{})));
+    }
+    chain_tail->children_.push_back(nullptr);
+
+    // First put the node to the chain. If we did it in reverse order,
+    // i.e chain to parent and then node to the chain, the node would
+    // become freed.
+    node->SwapParent(std::move(node), /*target=*/chain_tail, 0);
+    chain_head->SwapParent(std::move(chain_head), /*target=*/node_parent,
+                           position_in_leaf_parent);
+  }
+
+  for (std::unique_ptr<InfostateNode>& child : children_) {
+    child->RebalanceSubtree(target_depth, current_depth + 1);
+  }
+}
+
+std::unique_ptr<InfostateNode> InfostateNode::Release() {
+  SPIEL_DCHECK_TRUE(parent_);
+  SPIEL_DCHECK_TRUE(parent_->children_.at(incoming_index_).get() == this);
+  return std::move(parent_->children_.at(incoming_index_));
+}
+
+void InfostateNode::SwapParent(std::unique_ptr<InfostateNode> self,
+                               InfostateNode* target, int at_index) {
+  // This node is still who it thinks it is :)
+  SPIEL_DCHECK_TRUE(self.get() == this);
+  target->children_.at(at_index) = std::move(self);
+  this->parent_ = target;
+  this->incoming_index_ = at_index;
+}
+
+InfostateTree::InfostateTree(
+    const std::vector<const State*>& start_states,
+    const std::vector<float>& chance_reach_probs,
+    std::shared_ptr<Observer> infostate_observer, Player acting_player,
+    int max_move_ahead_limit)
+    : acting_player_(acting_player),
+      infostate_observer_(std::move(infostate_observer)),
+      root_(MakeRootNode()) {
+  SPIEL_CHECK_FALSE(start_states.empty());
+  SPIEL_CHECK_EQ(start_states.size(), chance_reach_probs.size());
+  SPIEL_CHECK_GE(acting_player_, 0);
+  SPIEL_CHECK_LT(acting_player_, start_states[0]->GetGame()->NumPlayers());
+  SPIEL_CHECK_TRUE(infostate_observer_->HasString());
+
+  int start_max_move_number = 0;
+  for (const State* start_state : start_states) {
+    start_max_move_number = std::max(start_max_move_number,
+                                     start_state->MoveNumber());
+  }
+
+  for (int i = 0; i < start_states.size(); ++i) {
+    RecursivelyBuildTree(
+        root_.get(), /*depth=*/1, *start_states[i],
+        start_max_move_number + max_move_ahead_limit,
+        chance_reach_probs[i]);
+  }
+
+  // Operations to make after building the tree.
+  RebalanceTree();
+  nodes_at_depths_.resize(tree_height() + 1);
+  CollectNodesAtDepth(mutable_root(), 0);
+  LabelNodesWithIds();
+}
+
+InfostateTree::InfostateTree(const Game& game, Player acting_player,
+                             int max_move_limit)
+    : InfostateTree({game.NewInitialState().get()}, /*chance_reach_probs=*/{1.},
+                    game.MakeObserver(kInfoStateObsType, {}),
+                    acting_player, max_move_limit) {}
+
+void InfostateTree::RebalanceTree() {
+  root_->RebalanceSubtree(tree_height(), 0);
+}
+
+void InfostateTree::CollectNodesAtDepth(InfostateNode* node, size_t depth) {
+  nodes_at_depths_[depth].push_back(node);
+  for (InfostateNode* child : node->child_iterator())
+    CollectNodesAtDepth(child, depth + 1);
+}
+
+std::ostream& InfostateTree::operator<<(std::ostream& os) const {
+  return os << "Infostate tree for player " << acting_player_ << ".\n"
+            << "Tree height: " << tree_height_ << '\n'
+            << "Root branching: " << root_branching_factor() << '\n'
+            << "Number of decision infostate nodes: " << num_decisions() << '\n'
+            << "Number of sequences: " << num_sequences() << '\n'
+            << "Number of leaves: " << num_leaves() << '\n'
+            << "Tree certificate: " << '\n'
+            << root().MakeCertificate() << '\n';
+}
+
+const std::vector<Action>& InfostateNode::TerminalHistory() const {
+  SPIEL_DCHECK_EQ(type_, kTerminalInfostateNode);
+  return terminal_history_;
+}
+
+Range<SequenceId> InfostateNode::AllSequenceIds() const {
+  return Range<SequenceId>(start_sequence_id_.id(),
+                           end_sequence_id_.id(), &tree_);
+}
+
+VecWithUniquePtrsIterator<InfostateNode> InfostateNode::child_iterator() const {
+  return VecWithUniquePtrsIterator(children_);
+}
+
+std::unique_ptr<InfostateNode> InfostateTree::MakeNode(
+    InfostateNode* parent, InfostateNodeType type,
+    const std::string& infostate_string,
+    double terminal_utility, double terminal_ch_reach_prob,
+    size_t depth, const State* originating_state) {
+  auto legal_actions =
+      originating_state && originating_state->IsPlayerActing(acting_player_)
+      ? originating_state->LegalActions(acting_player_)
+      : std::vector<Action>();
+  auto terminal_history =
+      originating_state && originating_state->IsTerminal()
+      ? originating_state->History()
+      : std::vector<Action>();
+  // Instantiate node using new to make sure that we can call
+  // the private constructor.
+  auto node = std::unique_ptr<InfostateNode>(new InfostateNode(
+      *this, parent, parent->num_children(), type, infostate_string,
+      terminal_utility, terminal_ch_reach_prob, depth,
+      std::move(legal_actions), std::move(terminal_history)));
+  return node;
+}
+
+std::unique_ptr<InfostateNode> InfostateTree::MakeRootNode() const {
+  return std::unique_ptr<InfostateNode>(new InfostateNode(
+      /*tree=*/*this, /*parent=*/nullptr, /*incoming_index=*/0,
+      /*type=*/kObservationInfostateNode,
+      /*infostate_string=*/kDummyRootNodeInfostate,
+      /*terminal_utility=*/NAN, /*chance_reach_prob=*/NAN,
+      /*depth=*/0, /*legal_actions=*/{}, /*terminal_history=*/{}));
+}
+
+void InfostateTree::UpdateLeafNode(
+    InfostateNode* node, const State& state, size_t leaf_depth,
+    double chance_reach_probs) {
+  tree_height_ = std::max(tree_height_, leaf_depth);
+  node->corresponding_states_.push_back(state.Clone());
+  node->corresponding_ch_reaches_.push_back(chance_reach_probs);
+}
+
+void InfostateTree::RecursivelyBuildTree(
+    InfostateNode* parent, size_t depth, const State& state,
+    int move_limit, double chance_reach_prob) {
+  if (state.IsTerminal())
+    return BuildTerminalNode(parent, depth, state, chance_reach_prob);
+  else if (state.IsPlayerActing(acting_player_))
+    return BuildDecisionNode(parent, depth, state, move_limit,
+                             chance_reach_prob);
+  else
+    return BuildObservationNode(parent, depth, state, move_limit,
+                                chance_reach_prob);
+}
+
+void InfostateTree::BuildTerminalNode(
+    InfostateNode* parent, size_t depth,
+    const State& state, double chance_reach_prob) {
+  const double terminal_utility = state.Returns()[acting_player_];
+  InfostateNode* terminal_node = parent->AddChild(MakeNode(
+      parent, kTerminalInfostateNode,
+      infostate_observer_->StringFrom(state, acting_player_), terminal_utility,
+      chance_reach_prob, depth, &state));
+  UpdateLeafNode(terminal_node, state, depth, chance_reach_prob);
+}
+
+void InfostateTree::BuildDecisionNode(
+    InfostateNode* parent, size_t depth, const State& state,
+    int move_limit, double chance_reach_prob) {
+  SPIEL_DCHECK_EQ(parent->type(), kObservationInfostateNode);
+  std::string info_state =
+      infostate_observer_->StringFrom(state, acting_player_);
+  InfostateNode* decision_node = parent->GetChild(info_state);
+  const bool is_leaf_node = state.MoveNumber() >= move_limit;
+
+  if (decision_node) {
+    // The decision node has been already constructed along with children
+    // for each action: these are observation nodes.
+    // Fetches the observation child and goes deeper recursively.
+    SPIEL_DCHECK_EQ(decision_node->type(), kDecisionInfostateNode);
+
+    if (is_leaf_node) {  // Do not build deeper.
+      return UpdateLeafNode(decision_node, state, depth, chance_reach_prob);
+    }
+
+    if (state.IsSimultaneousNode()) {
+      const ActionView action_view(state);
+      for (int i = 0; i < action_view.legal_actions[acting_player_].size();
+           ++i) {
+        InfostateNode* observation_node = decision_node->child_at(i);
+        SPIEL_DCHECK_EQ(observation_node->type(),
+                        kObservationInfostateNode);
+
+        for (Action flat_actions :
+             action_view.fixed_action(acting_player_, i)) {
+          std::unique_ptr<State> child = state.Child(flat_actions);
+          RecursivelyBuildTree(observation_node, depth + 2, *child,
+                               move_limit, chance_reach_prob);
+        }
+      }
+    } else {
+      std::vector<Action> legal_actions = state.LegalActions(acting_player_);
+      for (int i = 0; i < legal_actions.size(); ++i) {
+        InfostateNode* observation_node = decision_node->child_at(i);
+        SPIEL_DCHECK_EQ(observation_node->type(),
+                        kObservationInfostateNode);
+        std::unique_ptr<State> child = state.Child(legal_actions.at(i));
+        RecursivelyBuildTree(observation_node, depth + 2, *child,
+                             move_limit, chance_reach_prob);
+      }
+    }
+  } else {  // The decision node was not found yet.
+    decision_node = parent->AddChild(MakeNode(
+        parent, kDecisionInfostateNode, info_state,
+        /*terminal_utility=*/NAN, /*chance_reach_prob=*/NAN, depth, &state));
+
+    if (is_leaf_node) {  // Do not build deeper.
+      return UpdateLeafNode(decision_node, state, depth, chance_reach_prob);
+    }
+
+    // Build observation nodes right away after the decision node.
+    // This is because the player might be acting multiple times in a row:
+    // each time it might get some observations that branch the infostate
+    // tree.
+
+    if (state.IsSimultaneousNode()) {
+      ActionView action_view(state);
+      for (int i = 0; i < action_view.legal_actions[acting_player_].size();
+           ++i) {
+        // We build a dummy observation node.
+        // We can't ask for a proper infostate string or an originating state,
+        // because such a thing is not properly defined after only a partial
+        // application of actions for the sim move state
+        // (We need to supply all the actions).
+        InfostateNode* observation_node = decision_node->AddChild(MakeNode(
+            decision_node, kObservationInfostateNode,
+            /*infostate_string=*/kFillerInfostate,
+            /*terminal_utility=*/NAN, /*chance_reach_prob=*/NAN,
+            depth, /*originating_state=*/nullptr));
+
+        for (Action flat_actions :
+             action_view.fixed_action(acting_player_, i)) {
+          // Only now we can advance the state, when we have all actions.
+          std::unique_ptr<State> child = state.Child(flat_actions);
+          RecursivelyBuildTree(observation_node, depth + 2, *child,
+                               move_limit, chance_reach_prob);
+        }
+
+      }
+    } else {  // Not a sim move node.
+      for (Action a : state.LegalActions()) {
+        std::unique_ptr<State> child = state.Child(a);
+        InfostateNode* observation_node = decision_node->AddChild(MakeNode(
+            decision_node, kObservationInfostateNode,
+            infostate_observer_->StringFrom(*child, acting_player_),
+            /*terminal_utility=*/NAN, /*chance_reach_prob=*/NAN,
+            depth, child.get()));
+        RecursivelyBuildTree(observation_node, depth + 2, *child,
+                             move_limit, chance_reach_prob);
+      }
+    }
+  }
+}
+
+void InfostateTree::BuildObservationNode(
+    InfostateNode* parent, size_t depth, const State& state,
+    int move_limit, double chance_reach_prob) {
+  SPIEL_DCHECK_TRUE(state.IsChanceNode()
+                 || !state.IsPlayerActing(acting_player_));
+  const bool is_leaf_node = state.MoveNumber() >= move_limit;
+  const std::string info_state =
+      infostate_observer_->StringFrom(state, acting_player_);
+
+  InfostateNode* observation_node = parent->GetChild(info_state);
+  if (!observation_node) {
+    observation_node = parent->AddChild(MakeNode(
+        parent, kObservationInfostateNode, info_state,
+        /*terminal_utility=*/NAN, /*chance_reach_prob=*/NAN, depth, &state));
+  }
+  SPIEL_DCHECK_EQ(observation_node->type(), kObservationInfostateNode);
+
+  if (is_leaf_node) {  // Do not build deeper.
+    return UpdateLeafNode(observation_node, state, depth, chance_reach_prob);
+  }
+
+  if (state.IsChanceNode()) {
+    for (std::pair<Action, double> action_prob : state.ChanceOutcomes()) {
+      std::unique_ptr<State> child = state.Child(action_prob.first);
+      RecursivelyBuildTree(observation_node, depth + 1, *child,
+                           move_limit,
+                           chance_reach_prob * action_prob.second);
+    }
+  } else {
+    for (Action a : state.LegalActions()) {
+      std::unique_ptr<State> child = state.Child(a);
+      RecursivelyBuildTree(observation_node, depth + 1, *child,
+                           move_limit, chance_reach_prob);
+    }
+  }
+}
+int InfostateTree::root_branching_factor() const {
+  return root_->num_children();
+}
+
+std::shared_ptr<InfostateTree> MakeInfostateTree(
+    const Game& game, Player acting_player,
+    int max_move_limit) {
+  return std::shared_ptr<InfostateTree>(new InfostateTree(
+      game, acting_player, max_move_limit));
+}
+
+std::shared_ptr<InfostateTree> MakeInfostateTree(
+    const std::vector<const State*>& start_states,
+    const std::vector<float>& chance_reach_probs,
+    std::shared_ptr<Observer> infostate_observer, Player acting_player,
+    int max_move_ahead_limit) {
+  return std::shared_ptr<InfostateTree>(new InfostateTree(
+      start_states, chance_reach_probs, infostate_observer, acting_player,
+      max_move_ahead_limit));
+}
+SequenceId InfostateTree::empty_sequence() const {
+  return root().sequence_id();
+}
+Range<SequenceId> InfostateTree::AllSequenceIds() const {
+  return Range<SequenceId>(0, sequences_.size(), this);
+}
+const std::vector<std::vector<InfostateNode*>>& InfostateTree::nodes_at_depths()
+const {
+  return nodes_at_depths_;
+}
+const std::vector<InfostateNode*>& InfostateTree::nodes_at_depth(
+    size_t depth) const {
+  return nodes_at_depths_.at(depth);
+}
+const std::vector<InfostateNode*>& InfostateTree::leaf_nodes() const {
+  return nodes_at_depths_.back();
+}
+InfostateNode* InfostateTree::leaf_node(const LeafId& leaf_id) const {
+  SPIEL_DCHECK_TRUE(leaf_id.BelongsToTree(this));
+  return nodes_at_depths().back().at(leaf_id.id());
+}
+const std::vector<InfostateNode*>& InfostateTree::AllDecisionInfostates()
+const {
+  return decision_infostates_;
+}
+InfostateNode* InfostateTree::decision_infostate(
+    const DecisionId& decision_id) {
+  SPIEL_DCHECK_TRUE(decision_id.BelongsToTree(this));
+  SPIEL_DCHECK_EQ(decision_infostates_.at(decision_id.id())->type(),
+                  kDecisionInfostateNode);
+  return decision_infostates_.at(decision_id.id());
+}
+const InfostateNode* InfostateTree::decision_infostate(
+    const DecisionId& decision_id) const {
+  SPIEL_DCHECK_TRUE(decision_id.BelongsToTree(this));
+  SPIEL_DCHECK_EQ(decision_infostates_.at(decision_id.id())->type(),
+                  kDecisionInfostateNode);
+  return decision_infostates_.at(decision_id.id());
+}
+InfostateNode* InfostateTree::observation_infostate(
+    const SequenceId& sequence_id) {
+  SPIEL_DCHECK_TRUE(sequence_id.BelongsToTree(this));
+  SPIEL_DCHECK_EQ(sequences_.at(sequence_id.id())->type(),
+                  kObservationInfostateNode);
+  return sequences_.at(sequence_id.id());
+}
+const InfostateNode* InfostateTree::observation_infostate(
+    const SequenceId& sequence_id) const {
+  SPIEL_DCHECK_TRUE(sequence_id.BelongsToTree(this));
+  SPIEL_DCHECK_EQ(sequences_.at(sequence_id.id())->type(),
+                  kObservationInfostateNode);
+  return sequences_.at(sequence_id.id());
+}
+Range<DecisionId> InfostateTree::AllDecisionIds() const {
+  return Range<DecisionId>(0, decision_infostates_.size(), this);
+}
+absl::optional<DecisionId> InfostateTree::DecisionIdForSequence(
+    const SequenceId& sequence_id) const {
+  SPIEL_DCHECK_TRUE(sequence_id.BelongsToTree(this));
+  InfostateNode* node = sequences_.at(sequence_id.id());
+  SPIEL_DCHECK_TRUE(node);
+  if (node->is_root_node()) {
+    return {};
+  } else {
+    return node->parent_->decision_id();
+  }
+}
+absl::optional<InfostateNode*> InfostateTree::DecisionForSequence(
+    const SequenceId& sequence_id) {
+  SPIEL_DCHECK_TRUE(sequence_id.BelongsToTree(this));
+  InfostateNode* node = sequences_.at(sequence_id.id());
+  SPIEL_DCHECK_TRUE(node);
+  if (node->is_root_node()) {
+    return {};
+  } else {
+    return node->parent_;
+  }
+}
+bool InfostateTree::IsLeafSequence(const SequenceId& sequence_id) const {
+  SPIEL_DCHECK_TRUE(sequence_id.BelongsToTree(this));
+  InfostateNode* node = sequences_.at(sequence_id.id());
+  SPIEL_DCHECK_TRUE(node);
+  return node->start_sequence_id() == node->end_sequence_id();
+}
+std::vector<DecisionId> InfostateTree::DecisionIdsWithParentSeq(
+    const SequenceId& sequence_id) const {
+  std::vector<DecisionId> out;
+  const InfostateNode* observation_node = sequences_.at(sequence_id.id());
+  std::stack<const InfostateNode*> open_set;
+  for (const InfostateNode* child : observation_node->child_iterator()) {
+    open_set.push(child);
+  }
+  while (!open_set.empty()) {
+    const InfostateNode* node = open_set.top();
+    open_set.pop();
+    if (node->type() == kDecisionInfostateNode
+        && node->sequence_id() == sequence_id) {
+      out.push_back(node->decision_id());
+    } else {
+      for (const InfostateNode* child : node->child_iterator()) {
+        open_set.push(child);
+      }
+    }
+  }
+  return out;
+}
+
+void InfostateTree::LabelNodesWithIds() {
+  // Idea of labeling: label the leaf sequences first, and continue up the tree.
+  size_t sequence_index = 0;
+  size_t decision_index = 0;
+
+  // Do not label leaf nodes with sequences.
+  const int start_depth = nodes_at_depths_.size() - 2;
+
+  for (int depth = start_depth; depth >= 0; --depth) {
+    for (InfostateNode* node : nodes_at_depths_[depth]) {
+      if (node->type() != kDecisionInfostateNode) continue;
+      decision_infostates_.push_back(node);
+      node->decision_id_ = DecisionId(decision_index++, this);
+
+      for (InfostateNode* child : node->child_iterator()) {
+        sequences_.push_back(child);
+        child->sequence_id_ = SequenceId(sequence_index++, this);
+      }
+      // We could use sequence_index to set start and end sequences for
+      // the decision infostate right away here, however we'd like to make
+      // sure to label correctly all nodes in the tree.
+    }
+  }
+  // Finally label the last sequence (an empty sequence) in the root node.
+  sequences_.push_back(mutable_root());
+  mutable_root()->sequence_id_ = SequenceId(sequence_index, this);
+
+  CollectStartEndSequenceIds(mutable_root(), mutable_root()->sequence_id());
+}
+
+// Make a recursive call to assign the parent's sequences appropriately.
+// Collect pairs of (start, end) sequence ids from children and propagate
+// them up the tree. In case that deep nodes (close to the leaves) do not
+// have any child decision nodes, set the (start, end) to the parent sequence.
+// In this way the range iterator will be empty (start==end) and well defined.
+std::pair<size_t, size_t> InfostateTree::CollectStartEndSequenceIds(
+    InfostateNode* node, const SequenceId parent_sequence) {
+  size_t min_index = kUndefinedNodeId; // This is a large number.
+  size_t max_index = 0;
+  const SequenceId propagate_sequence_id =
+      node->sequence_id_.is_undefined()
+      ? parent_sequence
+      : node->sequence_id();  // This becomes the parent for next nodes.
+
+  for (InfostateNode* child : node->child_iterator()) {
+    auto[min_child, max_child] = CollectStartEndSequenceIds(
+        child, propagate_sequence_id);
+    min_index = std::min(min_child, min_index);
+    max_index = std::max(max_child, max_index);
+  }
+
+  if (min_index != kUndefinedNodeId) {
+    SPIEL_CHECK_LE(min_index, max_index);
+    node->start_sequence_id_ = SequenceId(min_index, this);
+    node->end_sequence_id_ = SequenceId(max_index + 1, this);
+  } else {
+    node->start_sequence_id_ = propagate_sequence_id;
+    node->end_sequence_id_ = propagate_sequence_id;
+  }
+
+  if (node->sequence_id_.is_undefined()) {
+    // Propagate children limits.
+    node->sequence_id_ = parent_sequence;
+    return {min_index, max_index};
+  } else {
+    // We have hit a defined sequence id, propagate it up.
+    return {node->sequence_id_.id(), node->sequence_id_.id()};
+  }
+}
+
+std::pair<double, SfStrategy> InfostateTree::BestResponse(
+    TreeplexVector<double>&& gradient) const {
+  SPIEL_CHECK_EQ(this, gradient.tree());
+  SPIEL_CHECK_EQ(num_sequences(), gradient.size());
+  SfStrategy response(this);
+
+  // 1. Compute counterfactual best response
+  // (i.e. in all infostates, even unreachable ones)
+  SequenceId current(0, this);
+  const double init_value = -std::numeric_limits<double>::infinity();
+  while (current.id() <= empty_sequence().id()) {
+    double max_value = init_value;
+    SequenceId max_id = current;
+    const InfostateNode* node = observation_infostate(current);
+    current = node->start_sequence_id();
+    while (current != node->end_sequence_id()) {
+      if (gradient[current] > max_value) {
+        max_value = gradient[current];
+        max_id = current;
+      }
+      current.next();
+    }
+    if (init_value != max_value) {
+      gradient[node->sequence_id()] += max_value;
+      response[max_id] = 1.;
+    }
+    current.next();
+  }
+  SPIEL_CHECK_EQ(current.id(), empty_sequence().id() + 1);
+
+  // 2. Prune away unreachable subtrees.
+  //
+  // This can be done with a more costly recursion.
+  // Instead we make a more cache-friendly double pass through the response
+  // vector: we increment the visited path by 1, resulting in a value of 2.
+  // Then we zero-out all values but 2.
+  current = empty_sequence();
+  response[current] = 2.;
+  while (!IsLeafSequence(current)) {
+    for (SequenceId seq : observation_infostate(current)->AllSequenceIds()) {
+      if (response[seq] == 1.) {
+        current = seq;
+        response[seq] += 1.;
+        break;
+      }
+    }
+  }
+  for (SequenceId seq : response.range()) {
+    response[seq] = response[seq] == 2. ? 1. : 0.;
+  }
+  SPIEL_DCHECK_TRUE(IsValidSfStrategy(response));
+  return {gradient[empty_sequence()], response};
+}
+
+double InfostateTree::BestResponseValue(LeafVector<double>&& gradient) const {
+  // Loop over all heights.
+  for (int d = tree_height_ - 1; d >= 0; d--) {
+    int left_offset = 0;
+    // Loop over all parents of current nodes.
+    for (int parent_idx = 0; parent_idx < nodes_at_depths_[d].size();
+         parent_idx++) {
+      const InfostateNode* node = nodes_at_depths_[d][parent_idx];
+      const int num_children = node->num_children();
+      const Range<LeafId> children_range = gradient.range(
+          left_offset, left_offset + num_children);
+      const LeafId parent_id(parent_idx, this);
+
+      if (node->type() == kDecisionInfostateNode) {
+        double max_value = std::numeric_limits<double>::min();
+        for (LeafId id : children_range) {
+          max_value = std::fmax(max_value, gradient[id]);
+        }
+        gradient[parent_id] = max_value;
+      } else {
+        SPIEL_DCHECK_EQ(node->type(), kObservationInfostateNode);
+        double sum_value = 0.;
+        for (LeafId id : children_range) {
+          sum_value += gradient[id];
+        }
+        gradient[parent_id] = sum_value;
+      }
+      left_offset += num_children;
+    }
+    // Check that we passed over all of the children.
+    SPIEL_DCHECK_EQ(left_offset, nodes_at_depths_[d + 1].size());
+  }
+  const LeafId root_id(0, this);
+  return gradient[root_id];
+}
+
+DecisionId InfostateTree::DecisionIdFromInfostateString(
+    const std::string& infostate_string) const {
+  for (InfostateNode* node : decision_infostates_) {
+    if (node->infostate_string() == infostate_string)
+      return node->decision_id();
+  }
+  return kUndefinedDecisionId;
+}
+
+bool CheckSum(const SfStrategy& strategy, SequenceId id, double expected_sum) {
+  if (fabs(strategy[id] - expected_sum) > 1e-13) {
+    return false;
+  }
+
+  const InfostateTree* tree = strategy.tree();
+  if (tree->IsLeafSequence(id)) {
+    return true;
+  }
+
+  double actual_sum = 0.;
+  const InfostateNode* node = tree->observation_infostate(id);
+  for (SequenceId sub_seq : node->AllSequenceIds()) {
+    actual_sum += strategy[sub_seq];
+  }
+  if (fabs(actual_sum - expected_sum) > 1e-13) {
+    return false;
+  }
+
+  for (SequenceId sub_seq : node->AllSequenceIds()) {
+    if (!CheckSum(strategy, sub_seq, strategy[sub_seq])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool IsValidSfStrategy(const SfStrategy& strategy) {
+  return CheckSum(strategy, strategy.tree()->empty_sequence(), 1.);
+}
+
+}  // namespace algorithms
+}  // namespace open_spiel

--- a/open_spiel/algorithms/infostate_tree.cc
+++ b/open_spiel/algorithms/infostate_tree.cc
@@ -55,66 +55,6 @@ InfostateNode::InfostateNode(
   );
 }
 
-const std::string& InfostateNode::infostate_string() const {
-  // Avoid working with empty infostate strings.
-  // Use Hasinfostate_string() first to check.
-  SPIEL_DCHECK_TRUE(has_infostate_string());
-  return infostate_string_;
-}
-
-bool InfostateNode::has_infostate_string() const {
-  return infostate_string_ != kFillerInfostate
-      && infostate_string_ != kDummyRootNodeInfostate;
-}
-
-double InfostateNode::terminal_utility() const {
-  SPIEL_CHECK_EQ(type_, kTerminalInfostateNode);
-  return terminal_utility_;
-}
-
-double InfostateNode::terminal_chance_reach_prob() const {
-  SPIEL_CHECK_EQ(type_, kTerminalInfostateNode);
-  return terminal_chn_reach_prob_;
-}
-
-const std::vector<Action>& InfostateNode::legal_actions() const {
-  SPIEL_CHECK_EQ(type_, kDecisionInfostateNode);
-  return legal_actions_;
-}
-
-size_t InfostateNode::corresponding_states_size() const {
-  return corresponding_states_.size();
-}
-
-const std::vector<std::unique_ptr<State>>& InfostateNode::corresponding_states()
-const {
-  SPIEL_CHECK_TRUE(is_leaf_node());
-  return corresponding_states_;
-}
-
-const std::vector<double>& InfostateNode::corresponding_chance_reach_probs()
-const {
-  SPIEL_CHECK_TRUE(is_leaf_node());
-  return corresponding_ch_reaches_;
-}
-
-const SequenceId InfostateNode::sequence_id() const {
-  SPIEL_CHECK_FALSE(sequence_id_.is_undefined());
-  return sequence_id_;
-}
-const SequenceId InfostateNode::start_sequence_id() const {
-  SPIEL_CHECK_FALSE(start_sequence_id_.is_undefined());
-  return start_sequence_id_;
-}
-const SequenceId InfostateNode::end_sequence_id() const {
-  SPIEL_CHECK_FALSE(end_sequence_id_.is_undefined());
-  return end_sequence_id_;
-}
-const DecisionId InfostateNode::decision_id() const {
-  SPIEL_CHECK_EQ(type_, kDecisionInfostateNode);
-  SPIEL_CHECK_FALSE(decision_id_.is_undefined());
-  return decision_id_;
-}
 InfostateNode* InfostateNode::AddChild(std::unique_ptr<InfostateNode> child) {
   SPIEL_CHECK_EQ(child->parent_, this);
   children_.push_back(std::move(child));
@@ -270,20 +210,6 @@ std::ostream& InfostateTree::operator<<(std::ostream& os) const {
             << "Number of leaves: " << num_leaves() << '\n'
             << "Tree certificate: " << '\n'
             << root().MakeCertificate() << '\n';
-}
-
-const std::vector<Action>& InfostateNode::TerminalHistory() const {
-  SPIEL_DCHECK_EQ(type_, kTerminalInfostateNode);
-  return terminal_history_;
-}
-
-Range<SequenceId> InfostateNode::AllSequenceIds() const {
-  return Range<SequenceId>(start_sequence_id_.id(),
-                           end_sequence_id_.id(), &tree_);
-}
-
-VecWithUniquePtrsIterator<InfostateNode> InfostateNode::child_iterator() const {
-  return VecWithUniquePtrsIterator(children_);
 }
 
 std::unique_ptr<InfostateNode> InfostateTree::MakeNode(
@@ -550,59 +476,6 @@ std::shared_ptr<InfostateTree> MakeInfostateTree(
 }
 SequenceId InfostateTree::empty_sequence() const {
   return root().sequence_id();
-}
-Range<SequenceId> InfostateTree::AllSequenceIds() const {
-  return Range<SequenceId>(0, sequences_.size(), this);
-}
-const std::vector<std::vector<InfostateNode*>>& InfostateTree::nodes_at_depths()
-const {
-  return nodes_at_depths_;
-}
-const std::vector<InfostateNode*>& InfostateTree::nodes_at_depth(
-    size_t depth) const {
-  return nodes_at_depths_.at(depth);
-}
-const std::vector<InfostateNode*>& InfostateTree::leaf_nodes() const {
-  return nodes_at_depths_.back();
-}
-InfostateNode* InfostateTree::leaf_node(const LeafId& leaf_id) const {
-  SPIEL_DCHECK_TRUE(leaf_id.BelongsToTree(this));
-  return nodes_at_depths().back().at(leaf_id.id());
-}
-const std::vector<InfostateNode*>& InfostateTree::AllDecisionInfostates()
-const {
-  return decision_infostates_;
-}
-InfostateNode* InfostateTree::decision_infostate(
-    const DecisionId& decision_id) {
-  SPIEL_DCHECK_TRUE(decision_id.BelongsToTree(this));
-  SPIEL_DCHECK_EQ(decision_infostates_.at(decision_id.id())->type(),
-                  kDecisionInfostateNode);
-  return decision_infostates_.at(decision_id.id());
-}
-const InfostateNode* InfostateTree::decision_infostate(
-    const DecisionId& decision_id) const {
-  SPIEL_DCHECK_TRUE(decision_id.BelongsToTree(this));
-  SPIEL_DCHECK_EQ(decision_infostates_.at(decision_id.id())->type(),
-                  kDecisionInfostateNode);
-  return decision_infostates_.at(decision_id.id());
-}
-InfostateNode* InfostateTree::observation_infostate(
-    const SequenceId& sequence_id) {
-  SPIEL_DCHECK_TRUE(sequence_id.BelongsToTree(this));
-  SPIEL_DCHECK_EQ(sequences_.at(sequence_id.id())->type(),
-                  kObservationInfostateNode);
-  return sequences_.at(sequence_id.id());
-}
-const InfostateNode* InfostateTree::observation_infostate(
-    const SequenceId& sequence_id) const {
-  SPIEL_DCHECK_TRUE(sequence_id.BelongsToTree(this));
-  SPIEL_DCHECK_EQ(sequences_.at(sequence_id.id())->type(),
-                  kObservationInfostateNode);
-  return sequences_.at(sequence_id.id());
-}
-Range<DecisionId> InfostateTree::AllDecisionIds() const {
-  return Range<DecisionId>(0, decision_infostates_.size(), this);
 }
 absl::optional<DecisionId> InfostateTree::DecisionIdForSequence(
     const SequenceId& sequence_id) const {

--- a/open_spiel/algorithms/infostate_tree.cc
+++ b/open_spiel/algorithms/infostate_tree.cc
@@ -416,6 +416,8 @@ int InfostateTree::root_branching_factor() const {
 std::shared_ptr<InfostateTree> MakeInfostateTree(
     const Game& game, Player acting_player,
     int max_move_limit) {
+  // Uses new instead of make_shared, because shared_ptr is not a friend and
+  // can't call private constructors.
   return std::shared_ptr<InfostateTree>(new InfostateTree(
       {game.NewInitialState().get()}, /*chance_reach_probs=*/{1.},
       game.MakeObserver(kInfoStateObsType, {}),
@@ -446,6 +448,8 @@ std::shared_ptr<InfostateTree> MakeInfostateTree(
     return true;
   }());
 
+  // We reserve a larger number of states, as infostate nodes typically contain
+  // a large number of States. (8 is an arbitrary choice though).
   std::vector<const State*> start_states;
   start_states.reserve(start_nodes.size() * 8);
   std::vector<double> chance_reach_probs;
@@ -458,6 +462,8 @@ std::shared_ptr<InfostateTree> MakeInfostateTree(
     }
   }
 
+  // Uses new instead of make_shared, because shared_ptr is not a friend and
+  // can't call private constructors.
   return std::shared_ptr<InfostateTree>(new InfostateTree(
       start_states, chance_reach_probs,
       originating_tree.infostate_observer_,

--- a/open_spiel/algorithms/infostate_tree.h
+++ b/open_spiel/algorithms/infostate_tree.h
@@ -269,6 +269,13 @@ std::shared_ptr<InfostateTree> MakeInfostateTree(
 // Creates an infostate tree based on some leaf infostate nodes coming from
 // another infostate tree, up to some move limit.
 std::shared_ptr<InfostateTree> MakeInfostateTree(
+    const std::vector<const InfostateNode*>& start_nodes,
+    int max_move_ahead_limit = 1000);
+
+// C++17 does not allow implicit conversion of non-const pointers to const
+// pointers within a vector - explanation: https://stackoverflow.com/a/2102415
+// This just adds const to the pointers and calls the other MakeInfostateTree.
+std::shared_ptr<InfostateTree> MakeInfostateTree(
     const std::vector<InfostateNode*>& start_nodes,
     int max_move_ahead_limit = 1000);
 
@@ -283,7 +290,7 @@ class InfostateTree final {
       const std::vector<const State*>& start_states,
       const std::vector<double>& chance_reach_probs,
       std::shared_ptr<Observer> infostate_observer, Player acting_player,
-      int max_move_ahead_limit = 1000);
+      int max_move_ahead_limit);
   // Friend factories.
   friend std::shared_ptr<InfostateTree> MakeInfostateTree(
       const Game&, Player, int);
@@ -291,7 +298,7 @@ class InfostateTree final {
       const std::vector<const State*>&, const std::vector<double>&,
       std::shared_ptr<Observer>, Player, int);
   friend std::shared_ptr<InfostateTree> MakeInfostateTree(
-      const std::vector<InfostateNode*>&, int);
+      const std::vector<const InfostateNode*>&, int);
 
  public:
   // -- Root accessors ---------------------------------------------------------

--- a/open_spiel/algorithms/infostate_tree.h
+++ b/open_spiel/algorithms/infostate_tree.h
@@ -494,9 +494,6 @@ class InfostateNode final {
   friend class InfostateTree;
 
  public:
-  InfostateNode(InfostateNode&&) noexcept = default;
-  virtual ~InfostateNode() = default;
-
   // -- Node accessors. --------------------------------------------------------
   const InfostateTree& tree() const { return tree_; }
   InfostateNode* parent() const { return parent_; }

--- a/open_spiel/algorithms/infostate_tree.h
+++ b/open_spiel/algorithms/infostate_tree.h
@@ -268,6 +268,7 @@ std::shared_ptr<InfostateTree> MakeInfostateTree(
 
 // Creates an infostate tree based on some leaf infostate nodes coming from
 // another infostate tree, up to some move limit.
+// This is useful for easily constructing (depth-limited) tree continuations.
 std::shared_ptr<InfostateTree> MakeInfostateTree(
     const std::vector<const InfostateNode*>& start_nodes,
     int max_move_ahead_limit = 1000);

--- a/open_spiel/algorithms/infostate_tree.h
+++ b/open_spiel/algorithms/infostate_tree.h
@@ -1,0 +1,630 @@
+// Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OPEN_SPIEL_ALGORITHMS_INFOSTATE_TREE_H_
+#define OPEN_SPIEL_ALGORITHMS_INFOSTATE_TREE_H_
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "open_spiel/spiel.h"
+
+// This file contains data structures used in imperfect information games.
+// Specifically, we implement an infostate tree, a representation of a game
+// from the perspective of an acting player.
+//
+// The information-state tree [1] contains information states, which describe
+// where the player is a) acting, b) getting observations, or c) receiving
+// terminal utilities (when the game ends). See `InfostateNodeType` for more
+// details.
+//
+// The tree can be constructed with a depth limit, so we make a distinction
+// between leaf nodes and non-leaf nodes. All terminal nodes are leaf nodes.
+//
+// The identification of infostates is based on strings from an information
+// state observer, i.e. one that is constructed using `kInfoStateObsType`.
+//
+// As algorithms typically need to store information associated to specific
+// nodes of the tree, we provide following indexing mechanisms (see the classes
+// below for more details):
+//
+// - `DecisionId` refers to a decision infostate where the player acts.
+// - `SequenceId` refers to an observation infostate that follows the decision
+//    infostate after some action.
+// - `LeafId` refers to an infostate node which is a leaf.
+//
+// All of these ids are very cheap (they are just typed `size_t`s).
+// They can be used to get a pointer to the corresponding infostate node.
+//
+// To enable some algorithmic optimizations we construct the trees "balanced".
+// We call a _balanced_ tree one which has all leaf nodes at the same depth.
+// To make the tree balanced, we may need to pad "dummy" observation nodes as
+// prefixes for the (previously too shallow) leafs. This is not too expensive,
+// as most games are balanced by default due to game rules.
+//
+// [1]: Rethinking Formal Models of Partially Observable Multiagent Decision
+//      Making https://arxiv.org/abs/1906.11110
+
+namespace open_spiel {
+namespace algorithms {
+
+// To categorize infostate nodes we use nomenclature from [2]:
+//
+// - In _decision nodes_, the acting player selects actions.
+// - In _observation nodes_ the acting player receives observations.
+//   They can correspond to State that is a chance node, or opponent's node.
+//   Importantly, they can correspond also to the acting player's node,
+//   as the player may have discovered something as a result of its action
+//   in the previous decision node. (This is especially important for the tree
+//   construction in simultaneous-move games).
+// - Additionally, we introduce _terminal nodes_, which correspond to a single
+//   terminal history.
+//
+// The terminal nodes store player's utility as well as cumulative chance reach
+// probability.
+//
+// [2]: Faster Game Solving via Predictive Blackwell Approachability:
+//      Connecting Regret Matching and Mirror Descent
+//      https://arxiv.org/abs/2007.14358
+enum InfostateNodeType {
+  kDecisionInfostateNode,
+  kObservationInfostateNode,
+  kTerminalInfostateNode
+};
+
+// Representing the game via infostates leads actually to a graph structure
+// of a forest (a collection of trees), as the player may be acting for the
+// first time in distinct situations. We trivially make it into a proper tree
+// by introducing a "dummy" root node, which we set as an observation node.
+// It can be interpreted as "the player observes the start of the game".
+// This node also corresponds to the empty sequence.
+// Following is the infostate string for this node.
+constexpr char* kDummyRootNodeInfostate = "(root)";
+
+// Sometimes we need to create infostate nodes that do not have a corresponding
+// game State, and therefore we cannot retrieve their string representations.
+// This happens in simultaneous move games or if we rebalance game trees.
+constexpr char* kFillerInfostate = "(fill)";
+
+// Forward declaration.
+class InfostateTree;
+
+namespace {
+
+// An implementation detail - Not to be used directly.
+//
+// We use various indexing schemes (SequenceId, DecisionId, LeafId) to access
+// specific nodes in the tree. Not all nodes can have an Id defined, for example
+// a DecisionId is not defined for decision nodes. In this case they will
+// default to the following value. We use this approach rather than
+// std::optional as optional creates pointers to the values, which would render
+// the following optimizations meaningless.
+constexpr size_t kUndefinedNodeId = -1;  // This is a large number.
+
+// An implementation detail - Not to be used directly.
+//
+// Create an indexing of specific infostate nodes.
+//
+// In release-mode the implementation is as cheap as the underlying size_t
+// identifier. Therefore it is preferable to pass the Ids by copy and not
+// by pointers / references.
+// Most importantly in debug-mode we add checks to make sure that we are using
+// the ids on appropriate trees and we do not try to index any opponents' trees.
+//
+// We use CRTP as it allows us to reuse the implementation for derived classes.
+template<class Self>
+class NodeId {
+  size_t identifier_ = kUndefinedNodeId;
+#ifndef NDEBUG  // Allow additional automatic debug-time checks.
+  const InfostateTree* tree_ = nullptr;
+
+ public:
+  NodeId(size_t id_value, const InfostateTree* tree_ptr)
+      : identifier_(id_value), tree_(tree_ptr) {}
+  Self& operator=(Self&& rhs) {
+    SPIEL_CHECK_TRUE(tree_ == rhs.tree_ ||
+        // The NodeId may be uninitialized, so allow to copy the rhs tree.
+        tree_ == nullptr && rhs.tree_ != nullptr);
+    identifier_ = rhs.id();
+    tree_ == rhs.tree_;
+    return this;
+  }
+  bool operator==(const Self& rhs) const {
+    SPIEL_CHECK_EQ(tree_, rhs.tree_);
+    return id() == rhs.id();
+  }
+  bool operator!=(const Self& rhs) const {
+    SPIEL_CHECK_EQ(tree_, rhs.tree_);
+    return id() != rhs.id();
+  }
+  bool BelongsToTree(const InfostateTree* other) const {
+    return tree_ == other;
+  }
+#else
+
+ public:
+  // Do not save the tree pointer, but expose the same interface
+  // so it's easy to use.
+  NodeId(size_t id_value, const InfostateTree*) : identifier_(id_value) {}
+  Self& operator=(Self&& rhs) {
+    identifier_ = rhs.id();
+    return this;
+  }
+  bool operator==(const Self& rhs) const { return id() == rhs.id(); }
+  bool operator!=(const Self& rhs) const { return id() != rhs.id(); }
+  // BelongsToTree is not implemented on purpose:
+  // It must not be called in release mode -- used only by DCHECK statements.
+#endif
+  constexpr NodeId() {}
+  size_t id() const {
+    SPIEL_CHECK_NE(identifier_, kUndefinedNodeId);
+    return identifier_;
+  }
+  bool is_undefined() const { return identifier_ == kUndefinedNodeId; }
+  void next() {
+    SPIEL_CHECK_NE(identifier_, kUndefinedNodeId);
+    ++identifier_;
+  }
+};
+
+}  // namespace
+
+
+// `SequenceId` refers to an observation infostate that follows the decision
+// infostate after following some action. It indexes the decision space of
+// an agent, and its strategy can formulated in terms of values associated with
+// the agent's sequences. See `TreeplexVector` for more details.
+// The smallest sequence ids correspond to the deepest nodes and the highest
+// value corresponds to the empty sequence.
+class SequenceId final : public NodeId<SequenceId> {
+  using NodeId<SequenceId>::NodeId;
+};
+// When the tree is still under construction and a node doesn't
+// have a final sequence id assigned yet, we use this value.
+constexpr SequenceId kUndefinedSequenceId = SequenceId();
+
+// `DecisionId` refers to an infostate node where the player acts,
+// i.e. an infostate node with the type `kDecisionInfostateNode`.
+class DecisionId final : public NodeId<DecisionId> {
+  using NodeId<DecisionId>::NodeId;
+};
+// When a node isn't a decision infostate, we use this value instead.
+constexpr DecisionId kUndefinedDecisionId = DecisionId();
+
+// `LeafId` refers to an infostate node which is a leaf. Note that this can be
+// an arbitrary infostate node type. A kTerminalInfostateNode is always
+// a leaf node.
+// Note that leaf decision nodes do not have assigned any `DecisionId`, and
+// similarly leaf observation nodes do not have assigned any `SequenceId`.
+class LeafId final : public NodeId<LeafId> {
+  using NodeId<LeafId>::NodeId;
+};
+// When a node isn't a leaf, we use this value instead.
+constexpr LeafId kUndefinedLeafId = LeafId();
+
+// Each of the Ids can be used to index an appropriate vector.
+// See below for an implementation.
+template<typename T> class TreeplexVector;
+template<typename T> class LeafVector;
+template<typename T> class DecisionVector;
+using SfStrategy = class TreeplexVector<double>;
+
+// A convenience iterator over a contiguous range of node ids.
+template<class Id>
+class RangeIterator {
+  size_t id_;
+  const InfostateTree* tree_;
+ public:
+  RangeIterator(size_t id, const InfostateTree* tree) : id_(id), tree_(tree) {}
+  RangeIterator& operator++() {
+    ++id_;
+    return *this;
+  }
+  bool operator!=(const RangeIterator& other) const {
+    return id_ != other.id_ || tree_ != other.tree_;
+  }
+  Id operator*() { return Id(id_, tree_); }
+};
+template<class Id>
+class Range {
+  const size_t start_;
+  const size_t end_;
+  const InfostateTree* tree_;
+ public:
+  Range(size_t start, size_t end, const InfostateTree* tree)
+      : start_(start), end_(end), tree_(tree) { SPIEL_CHECK_LE(start_, end_); }
+  RangeIterator<Id> begin() const { return RangeIterator<Id>(start_, tree_); }
+  RangeIterator<Id> end() const { return RangeIterator<Id>(end_, tree_); }
+};
+
+// Creates an infostate tree for a player based on the initial state
+// of the game, up to some move limit.
+std::shared_ptr<InfostateTree> MakeInfostateTree(
+    const Game& game, Player acting_player,
+    int max_move_limit = 1000);
+
+// Creates an infostate tree for a player based on some start states,
+// up to some move limit from the deepest start state.
+std::shared_ptr<InfostateTree> MakeInfostateTree(
+    const std::vector<const State*>& start_states,
+    const std::vector<float>& chance_reach_probs,
+    std::shared_ptr<Observer> infostate_observer, Player acting_player,
+    int max_move_ahead_limit = 1000);
+
+// Forward declaration.
+class InfostateNode;
+
+class InfostateTree final {
+  // Note that only MakeInfostateTree is allowed to call the constructor
+  // to ensure the trees are always allocated on heap. We do this so that all
+  // the collected pointers are valid throughout the tree's lifetime even if
+  // they are moved around.
+ private:
+  InfostateTree(const Game& game, Player acting_player,
+                int max_move_limit = 1000);
+  InfostateTree(
+      const std::vector<const State*>& start_states,
+      const std::vector<float>& chance_reach_probs,
+      std::shared_ptr<Observer> infostate_observer, Player acting_player,
+      int max_move_ahead_limit = 1000);
+  // Friend factories.
+  friend std::shared_ptr<InfostateTree> MakeInfostateTree(
+      const Game&, Player, int);
+  friend std::shared_ptr<InfostateTree> MakeInfostateTree(
+      const std::vector<const State*>&, const std::vector<float>&,
+      std::shared_ptr<Observer>, Player, int);
+
+ public:
+  // -- Root accessors ---------------------------------------------------------
+  const InfostateNode& root() const { return *root_; }
+  InfostateNode* mutable_root() { return root_.get(); }
+  int root_branching_factor() const;
+
+  // -- Tree information -------------------------------------------------------
+  Player acting_player() const { return acting_player_; }
+  // Zero-based height.
+  // (the height of a tree that contains only root node is zero.)
+  size_t tree_height() const { return tree_height_; }
+
+  // -- General statistics -----------------------------------------------------
+  size_t num_decisions() const { return decision_infostates_.size(); }
+  size_t num_sequences() const { return sequences_.size(); }
+  size_t num_leaves() const { return nodes_at_depths_.back().size(); }
+  // A function overload used for TreeVector templates.
+  size_t num_ids(DecisionId) const { return num_decisions(); }
+  size_t num_ids(SequenceId) const { return num_sequences(); }
+  size_t num_ids(LeafId) const { return num_leaves(); }
+
+  // -- Sequence operations ----------------------------------------------------
+  SequenceId empty_sequence() const;
+  InfostateNode* observation_infostate(const SequenceId& sequence_id);
+  const InfostateNode* observation_infostate(
+      const SequenceId& sequence_id) const;
+  Range<SequenceId> AllSequenceIds() const;
+  // Returns all DecisionIds which can be found in a subtree of given sequence.
+  std::vector<DecisionId> DecisionIdsWithParentSeq(const SequenceId&) const;
+  // Returns `None` if the sequence is the empty sequence.
+  absl::optional<DecisionId> DecisionIdForSequence(const SequenceId&) const;
+  // Returns `None` if the sequence is the empty sequence.
+  absl::optional<InfostateNode*> DecisionForSequence(const SequenceId&);
+  // Returns whether the sequence ends with the last action the player can make.
+  bool IsLeafSequence(const SequenceId&) const;
+
+  // -- Decision operations ----------------------------------------------------
+  InfostateNode* decision_infostate(const DecisionId& decision_id);
+  const InfostateNode* decision_infostate(const DecisionId& decision_id) const;
+  const std::vector<InfostateNode*>& AllDecisionInfostates() const;
+  Range<DecisionId> AllDecisionIds() const;
+  DecisionId DecisionIdFromInfostateString(
+      const std::string& infostate_string) const;
+
+  // -- Leaf operations --------------------------------------------------------
+  const std::vector<InfostateNode*>& leaf_nodes() const;
+  InfostateNode* leaf_node(const LeafId& leaf_id) const;
+  const std::vector<std::vector<InfostateNode*>>& nodes_at_depths() const;
+  const std::vector<InfostateNode*>& nodes_at_depth(size_t depth) const;
+
+  // -- Tree operations --------------------------------------------------------
+  // Compute best response and value based on gradient from opponents.
+  // This consumes the gradient vector, as it is used to compute the value.
+  std::pair<double, SfStrategy> BestResponse(
+      TreeplexVector<double>&& gradient) const;
+  // Compute best response value based on gradient from opponents over leaves.
+  // This consumes the gradient vector, as it is used to compute the value.
+  double BestResponseValue(LeafVector<double>&& gradient) const;
+
+  // -- For debugging ----------------------------------------------------------
+  std::ostream& operator<<(std::ostream& os) const;
+
+ private:
+  const Player acting_player_;
+  const std::shared_ptr<Observer> infostate_observer_;
+  const std::unique_ptr<InfostateNode> root_;
+  /*const*/ size_t tree_height_ = 0;
+
+  // Tree structure collections that index the respective NodeIds.
+  std::vector<InfostateNode*> decision_infostates_;
+  std::vector<InfostateNode*> sequences_;
+  // The last vector corresponds to the leaf nodes.
+  std::vector<std::vector<InfostateNode*>> nodes_at_depths_;
+
+  // Utility functions whenever we create a new node for the tree.
+  std::unique_ptr<InfostateNode> MakeNode(
+      InfostateNode* parent, InfostateNodeType type,
+      const std::string& infostate_string, double terminal_utility,
+      double terminal_ch_reach_prob, size_t depth,
+      const State* originating_state);
+  std::unique_ptr<InfostateNode> MakeRootNode() const;
+
+  // Makes sure that all tree leaves are at the same height.
+  // It inserts a linked list of dummy observation nodes with appropriate length
+  // to balance all the leaves.
+  void RebalanceTree();
+
+  void UpdateLeafNode(InfostateNode* node, const State& state,
+                      size_t leaf_depth, double chance_reach_probs);
+
+  // Build the tree.
+  void RecursivelyBuildTree(InfostateNode* parent, size_t depth,
+                            const State& state, int move_limit,
+                            double chance_reach_prob);
+  void BuildTerminalNode(InfostateNode* parent, size_t depth,
+                         const State& state, double chance_reach_prob);
+  void BuildDecisionNode(InfostateNode* parent, size_t depth,
+                         const State& state, int move_limit,
+                         double chance_reach_prob);
+  void BuildObservationNode(InfostateNode* parent, size_t depth,
+                            const State& state, int move_limit,
+                            double chance_reach_prob);
+
+  void CollectNodesAtDepth(InfostateNode* node, size_t depth);
+  void LabelNodesWithIds();
+  std::pair<size_t, size_t> CollectStartEndSequenceIds(
+      InfostateNode* node, const SequenceId parent_sequence);
+};
+
+// Iterate over a vector of unique pointers, but expose only the raw pointers.
+template<class T>
+class VecWithUniquePtrsIterator {
+  int pos_;
+  const std::vector<std::unique_ptr<T>>& vec_;
+ public:
+  explicit VecWithUniquePtrsIterator(
+      const std::vector<std::unique_ptr<T>>& vec, int pos = 0)
+      : pos_(pos), vec_(vec) {}
+  VecWithUniquePtrsIterator& operator++() {
+    pos_++;
+    return *this;
+  }
+  bool operator==(VecWithUniquePtrsIterator other) const {
+    return pos_ == other.pos_;
+  }
+  bool operator!=(VecWithUniquePtrsIterator other) const {
+    return !(*this == other);
+  }
+  T* operator*() { return vec_[pos_].get(); }
+  VecWithUniquePtrsIterator begin() const { return *this; }
+  VecWithUniquePtrsIterator end() const {
+    return VecWithUniquePtrsIterator(vec_, vec_.size());
+  }
+};
+
+class InfostateNode final {
+  // Note that all of the following members are const or they should be const.
+  // However we can't make all of  them const during the node construction
+  // because they might be computed only after the whole tree is built.
+ private:
+  // Reference to the tree this node belongs to. This reference has a valid
+  // lifetime, as it is allocated once on the heap and never moved.
+  const InfostateTree& tree_;
+  // Pointer to the parent node. Null for the root node.
+  // This is not const so that we can change it when we rebalance the tree.
+  /*const*/ InfostateNode* parent_;
+  // Position of this node in the parent's children, i.e. it holds that
+  //   parent_->children_.at(incoming_index_).get() == this.
+  //
+  // For decision nodes this corresponds also to the
+  //   State::LegalActions(player_).at(incoming_index_)
+  //
+  // This is not const so that we can change it when we rebalance the tree.
+  /*const*/ int incoming_index_;
+  // Type of the node.
+  const InfostateNodeType type_;
+  // Identifier of the infostate.
+  const std::string infostate_string_;
+  // Decision identifier of this node.
+  // This is not const as the ids are assigned after the tree is built.
+  /*const*/ DecisionId decision_id_ = kUndefinedDecisionId;
+  // Sequence identifier of this node.
+  // The first is the parent sequence of the infostate, while the last
+  // two sequence IDs represent the sequence id of the first and last action + 1
+  // at the infostate node. Because sequences assigned to an infostate
+  // are contiguous, we don't need to store all intermediate sequence IDs.
+  // We can thus use a Range iterable to make looping frictionless.
+  // This is not const as the ids can be assigned only after the tree is built.
+  /*const*/ SequenceId sequence_id_ = kUndefinedSequenceId;
+  /*const*/ SequenceId start_sequence_id_ = kUndefinedSequenceId;
+  /*const*/ SequenceId end_sequence_id_ = kUndefinedSequenceId;
+  // Sequence identifier of this node.
+  // This is not const as the ids are assigned after the tree is rebalanced.
+  /*const*/ LeafId leaf_id_ = kUndefinedLeafId;
+  // Utility of terminal state corresponding to the terminal infostate node.
+  // If the node is not terminal, the value is NaN.
+  const double terminal_utility_;
+  // Cumulative product of chance probabilities leading up to a terminal node.
+  // If the node is not terminal, the value is NaN.
+  const double terminal_chn_reach_prob_;
+  // Depth of the node, i.e. number of edges on the path from the root.
+  // Note that depth does not necessarily correspond to the MoveNumber()
+  // of corresponding states.
+  // This is not const because tree rebalancing can change this value.
+  /*const*/ size_t depth_;
+  // Children infostate nodes. Notice the node owns its children.
+  // This is not const so that we can add children.
+  /*const*/ std::vector<std::unique_ptr<InfostateNode>> children_;
+  // Store States that correspond to a leaf node.
+  // This is not const so that we can add corresponding states.
+  /*const*/ std::vector<std::unique_ptr<State>> corresponding_states_;
+  // Store chance reach probs for States that correspond to a leaf node.
+  // This is not const so that we can add corresponding reaches.
+  /*const*/ std::vector<double> corresponding_ch_reaches_;
+  // Stored only for decision nodes.
+  const std::vector<Action> legal_actions_;
+  // Stored only for terminal nodes.
+  const std::vector<Action> terminal_history_;
+
+  // Only InfostateTree is allowed to construct nodes.
+  InfostateNode(
+      const InfostateTree& tree, InfostateNode* parent, int incoming_index,
+      InfostateNodeType type, const std::string& infostate_string,
+      double terminal_utility, double terminal_ch_reach_prob, size_t depth,
+      std::vector<Action> legal_actions, std::vector<Action> terminal_history);
+  friend class InfostateTree;
+
+ public:
+  InfostateNode(InfostateNode&&) noexcept = default;
+  virtual ~InfostateNode() = default;
+
+  // -- Node accessors. --------------------------------------------------------
+  const InfostateTree& tree() const { return tree_; }
+  InfostateNode* parent() const { return parent_; }
+  int incoming_index() const { return incoming_index_; }
+  const InfostateNodeType& type() const { return type_; }
+  size_t depth() const { return depth_; }
+  bool is_root_node() const { return !parent_; }
+  bool has_infostate_string() const;
+  const std::string& infostate_string() const;
+
+  // -- Children accessors. ----------------------------------------------------
+  InfostateNode* child_at(int i) const { return children_.at(i).get(); }
+  int num_children() const { return children_.size(); }
+  VecWithUniquePtrsIterator<InfostateNode> child_iterator() const;
+
+  // -- Sequence operations. ---------------------------------------------------
+  const SequenceId sequence_id() const;
+  const SequenceId start_sequence_id() const;
+  const SequenceId end_sequence_id() const;
+  Range<SequenceId> AllSequenceIds() const;
+
+  // -- Decision operations. ---------------------------------------------------
+  const DecisionId decision_id() const;
+  const std::vector<Action>& legal_actions() const;
+
+  // -- Leaf operations. -------------------------------------------------------
+  bool is_leaf_node() const { return children_.empty(); }
+  double terminal_utility() const;
+  double terminal_chance_reach_prob() const;
+  const std::vector<std::unique_ptr<State>>& corresponding_states() const;
+  const std::vector<double>& corresponding_chance_reach_probs() const;
+  const std::vector<Action>& TerminalHistory() const;
+
+  // -- For debugging. ---------------------------------------------------------
+  std::ostream& operator<<(std::ostream& os) const;
+  // Make subtree certificate (string representation) for easy comparison
+  // of (isomorphic) trees.
+  std::string MakeCertificate() const;
+
+ private:
+  // Make sure that the subtree ends at the requested target depth by inserting
+  // dummy observation nodes with one outcome.
+  void RebalanceSubtree(int target_depth, int current_depth);
+
+  // Get the unique_ptr for this node. The usage is intended only for tree
+  // balance manipulation.
+  std::unique_ptr<InfostateNode> Release();
+
+  // Change the parent of this node by inserting it at at index
+  // of the new parent. The node at the existing position will be freed.
+  // We pass the unique ptr of itself, because calling Release might be
+  // undefined: the node we want to swap a parent for can be root of a subtree.
+  void SwapParent(std::unique_ptr<InfostateNode> self,
+                  InfostateNode* target, int at_index);
+
+  InfostateNode* AddChild(std::unique_ptr<InfostateNode> child);
+  InfostateNode* GetChild(const std::string& infostate_string) const;
+};
+
+namespace {
+
+// An implementation detail - Not to be used directly.
+//
+// Create a common TreeVector container that can be indexed
+// with the respective NodeIds. This is later specialized for the individual
+// indexing of the trees.
+template<typename T, typename Id>
+class TreeVector {
+  const InfostateTree* tree_;
+  std::vector<T> vec_;
+ public:
+  explicit TreeVector(const InfostateTree* tree)
+      : tree_(tree), vec_(tree_->num_ids(Id(kUndefinedNodeId, tree))) {}
+  TreeVector(const InfostateTree* tree, std::vector<T> vec)
+      : tree_(tree), vec_(std::move(vec)) {
+    SPIEL_CHECK_EQ(tree_->num_ids(Id(kUndefinedNodeId, tree)), vec_.size());
+  }
+  T& operator[](const Id& id) {
+    SPIEL_DCHECK_TRUE(id.BelongsToTree(tree_));
+    SPIEL_DCHECK_LE(0, id.id());
+    SPIEL_DCHECK_LT(id.id(), vec_.size());
+    return vec_[id.id()];
+  }
+  const T& operator[](const Id& id) const {
+    SPIEL_DCHECK_TRUE(id.BelongsToTree(tree_));
+    SPIEL_DCHECK_LE(0, id.id());
+    SPIEL_DCHECK_LT(id.id(), vec_.size());
+    return vec_[id.id()];
+  }
+  std::ostream& operator<<(std::ostream& os) const {
+    return os << vec_ << " (for player " << tree_->acting_player() << ')';
+  }
+  size_t size() const { return vec_.size(); }
+  Range<Id> range() { return Range<Id>(0, vec_.size(), tree_); }
+  Range<Id> range(size_t from, size_t to) { return Range<Id>(from, to, tree_); }
+  const InfostateTree* tree() const { return tree_; }
+};
+
+}  // namespace
+
+// Arrays that can be easily indexed by SequenceIds.
+// The space of all such arrays forms a treeplex [3].
+//
+// [3]: Smoothing Techniques for Computing Nash Equilibria of Sequential Games
+//      http://www.cs.cmu.edu/~sandholm/proxtreeplex.MathOfOR.pdf
+template<typename T>
+class TreeplexVector final : public TreeVector<T, SequenceId> {
+  using TreeVector<T, SequenceId>::TreeVector;
+};
+
+// Arrays that can be easily indexed by LeafIds.
+template<typename T>
+class LeafVector final : public TreeVector<T, LeafId> {
+  using TreeVector<T, LeafId>::TreeVector;
+};
+
+// Arrays that can be easily indexed by DecisionIds.
+template<typename T>
+class DecisionVector final : public TreeVector<T, DecisionId> {
+  using TreeVector<T, DecisionId>::TreeVector;
+};
+
+// Returns whether the supplied vector is a valid sequence-form strategy:
+// The probability flow has to sum up to 1 and each sequence's incoming
+// probability must be equal to outgoing probabilities.
+bool IsValidSfStrategy(const SfStrategy& stategy);
+
+}  // namespace algorithms
+}  // namespace open_spiel
+
+#endif  // OPEN_SPIEL_ALGORITHMS_INFOSTATE_TREE_H_

--- a/open_spiel/algorithms/infostate_tree.h
+++ b/open_spiel/algorithms/infostate_tree.h
@@ -249,6 +249,9 @@ class Range {
   RangeIterator<Id> end() const { return RangeIterator<Id>(end_, tree_); }
 };
 
+// Forward declaration.
+class InfostateNode;
+
 // Creates an infostate tree for a player based on the initial state
 // of the game, up to some move limit.
 std::shared_ptr<InfostateTree> MakeInfostateTree(
@@ -259,12 +262,16 @@ std::shared_ptr<InfostateTree> MakeInfostateTree(
 // up to some move limit from the deepest start state.
 std::shared_ptr<InfostateTree> MakeInfostateTree(
     const std::vector<const State*>& start_states,
-    const std::vector<float>& chance_reach_probs,
+    const std::vector<double>& chance_reach_probs,
     std::shared_ptr<Observer> infostate_observer, Player acting_player,
     int max_move_ahead_limit = 1000);
 
-// Forward declaration.
-class InfostateNode;
+// Creates an infostate tree based on some leaf infostate nodes coming from
+// another infostate tree, up to some move limit.
+std::shared_ptr<InfostateTree> MakeInfostateTree(
+    const std::vector<InfostateNode*>& start_nodes,
+    int max_move_ahead_limit = 1000);
+
 
 class InfostateTree final {
   // Note that only MakeInfostateTree is allowed to call the constructor
@@ -272,19 +279,19 @@ class InfostateTree final {
   // the collected pointers are valid throughout the tree's lifetime even if
   // they are moved around.
  private:
-  InfostateTree(const Game& game, Player acting_player,
-                int max_move_limit = 1000);
   InfostateTree(
       const std::vector<const State*>& start_states,
-      const std::vector<float>& chance_reach_probs,
+      const std::vector<double>& chance_reach_probs,
       std::shared_ptr<Observer> infostate_observer, Player acting_player,
       int max_move_ahead_limit = 1000);
   // Friend factories.
   friend std::shared_ptr<InfostateTree> MakeInfostateTree(
       const Game&, Player, int);
   friend std::shared_ptr<InfostateTree> MakeInfostateTree(
-      const std::vector<const State*>&, const std::vector<float>&,
+      const std::vector<const State*>&, const std::vector<double>&,
       std::shared_ptr<Observer>, Player, int);
+  friend std::shared_ptr<InfostateTree> MakeInfostateTree(
+      const std::vector<InfostateNode*>&, int);
 
  public:
   // -- Root accessors ---------------------------------------------------------
@@ -523,6 +530,7 @@ class InfostateNode final {
   bool is_leaf_node() const { return children_.empty(); }
   double terminal_utility() const;
   double terminal_chance_reach_prob() const;
+  size_t corresponding_states_size() const;
   const std::vector<std::unique_ptr<State>>& corresponding_states() const;
   const std::vector<double>& corresponding_chance_reach_probs() const;
   const std::vector<Action>& TerminalHistory() const;

--- a/open_spiel/algorithms/infostate_tree_test.cc
+++ b/open_spiel/algorithms/infostate_tree_test.cc
@@ -1,0 +1,474 @@
+// Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "open_spiel/algorithms/infostate_tree.h"
+
+#include <algorithm>
+#include <memory>
+#include <utility>
+
+#include "open_spiel/games/goofspiel.h"
+#include "open_spiel/games/kuhn_poker.h"
+#include "open_spiel/spiel.h"
+#include "open_spiel/spiel_utils.h"
+
+namespace open_spiel {
+namespace algorithms {
+namespace {
+
+std::string iigs2 = "goofspiel("
+                      "num_cards=2,"
+                      "imp_info=True,"
+                      "points_order=ascending"
+                    ")";
+std::string iigs3 = "goofspiel("
+                      "num_cards=3,"
+                      "imp_info=True,"
+                      "points_order=ascending"
+                    ")";
+
+bool IsNodeBalanced(const InfostateNode& node, int height,
+                    int current_depth = 0) {
+  if (node.is_leaf_node()) return height == current_depth;
+
+  for (const InfostateNode* child : node.child_iterator()) {
+    if (!IsNodeBalanced(*child, height, current_depth + 1)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool RecomputeBalance(const InfostateTree& tree) {
+  return IsNodeBalanced(tree.root(), tree.tree_height());
+}
+
+std::shared_ptr<InfostateTree> MakeTree(
+    const std::string& game_name, Player player, int max_move_limit = 1000) {
+  std::shared_ptr<InfostateTree> tree = MakeInfostateTree(
+      *LoadGame(game_name), player, max_move_limit);
+  SPIEL_CHECK_TRUE(RecomputeBalance(*tree));
+  return tree;
+}
+
+std::shared_ptr<InfostateTree> MakeTree(
+    const std::string& game_name, Player player,
+    const std::vector<std::vector<Action>>& start_histories,
+    const std::vector<float>& start_reaches, int max_move_limit = 1000) {
+  const std::shared_ptr<const Game> game = LoadGame(game_name);
+  std::vector<std::unique_ptr<State>> start_states;
+  std::vector<const State*> start_state_ptrs;
+  for (const std::vector<Action>& history : start_histories) {
+    std::unique_ptr<State> rollout = game->NewInitialState();
+    for (const Action& a : history) rollout->ApplyAction(a);
+    start_states.push_back(std::move(rollout));
+    start_state_ptrs.push_back(start_states.back().get());
+  }
+
+  std::shared_ptr<Observer> infostate_observer =
+      game->MakeObserver(kInfoStateObsType, {});
+
+  std::shared_ptr<InfostateTree> tree = MakeInfostateTree(
+      start_state_ptrs, start_reaches, infostate_observer,
+      player, max_move_limit);
+  SPIEL_CHECK_TRUE(RecomputeBalance(*tree));
+  return tree;
+}
+
+void TestRootCertificates() {
+  {
+    std::string expected_certificate =
+      "(["
+        "({}{})"  // Play Heads: HH, HT
+        "({}{})"  // Play Tails: TH, TT
+      "])";
+    for (int i = 0; i < 2; ++i) {
+      std::shared_ptr<InfostateTree> tree = MakeTree("matrix_mp", /*player=*/i);
+      SPIEL_CHECK_EQ(tree->root().MakeCertificate(), expected_certificate);
+    }
+  }
+  {
+    std::string expected_certificate =
+      "(["
+        "({}{})"  // Play 1: draw 1,1  lose 1,2
+        "({}{})"  // Play 2: win  2,1  draw 2,2
+      "])";
+    for (int i = 0; i < 2; ++i) {
+      std::shared_ptr<InfostateTree> tree = MakeTree(iigs2, /*player=*/i);
+      SPIEL_CHECK_EQ(tree->root().MakeCertificate(), expected_certificate);
+    }
+  }
+  {  // Full Kuhn test.
+    std::shared_ptr<InfostateTree> tree = MakeTree("kuhn_poker", /*player=*/0);
+    std::string expected_rebalanced_certificate =
+      // Notice all terminals are at the same depth (same indentation).
+      "((" // Root node, 1st is getting a card
+        "("  // 2nd is getting card
+          "["  // 1st acts
+            "(("  // 1st bet, and 2nd acts
+              "(({}))"
+              "(({}))"
+              "(({}))"
+              "(({}))"
+            "))"
+            "(("  // 1st checks, and 2nd acts
+              // 2nd checked
+              "(({}))"
+              "(({}))"
+              // 2nd betted
+              "[({}"
+                "{})"
+               "({}"
+                "{})]"
+            "))"
+          "]"
+        ")"
+        // Just 2 more copies.
+        "([(((({}))(({}))(({}))(({}))))(((({}))(({}))[({}{})({}{})]))])"
+        "([(((({}))(({}))(({}))(({}))))(((({}))(({}))[({}{})({}{})]))])"
+      "))";
+    SPIEL_CHECK_EQ(tree->root().MakeCertificate(),
+                   expected_rebalanced_certificate);
+  }
+  {
+    std::string expected_certificate =
+    "((("  // Root node, distribute cards.
+      "("  // 1st acts
+        // 1st betted
+        "[(({})({}))(({})({}))]"
+        // 1st checked
+        "[(({})({}))(({}{}{}{}))]"
+      ")"
+      // Just 2 more copies.
+      "([(({})({}))(({})({}))][(({})({}))(({}{}{}{}))])"
+      "([(({})({}))(({})({}))][(({})({}))(({}{}{}{}))])"
+    ")))";
+    std::shared_ptr<InfostateTree> tree = MakeTree("kuhn_poker", /*player=*/1);
+    SPIEL_CHECK_EQ(tree->root().MakeCertificate(), expected_certificate);
+  }
+  {
+    std::string expected_certificate =
+      "(["
+        "(" // Play 2
+          "[({}{})({}{})]"
+          "[({}{})({}{})]"
+          "[({}{})({}{})]"
+        ")"
+        "(" // Play 1
+          "[({}{})({}{})]"
+          "[({}{}{}{})({}{}{}{})]"
+        ")"
+        "(" // Play 3
+          "[({}{})({}{})]"
+          "[({}{}{}{})({}{}{}{})]"
+        ")"
+      "])";
+    for (int i = 0; i < 2; ++i) {
+      std::shared_ptr<InfostateTree> tree = MakeTree(iigs3, /*player=*/i);
+      SPIEL_CHECK_EQ(tree->root().MakeCertificate(), expected_certificate);
+    }
+  }
+}
+
+void TestCertificatesFromStartHistories() {
+  {
+    std::shared_ptr<InfostateTree> tree = MakeTree(
+        "kuhn_poker", /*player=*/0, /*start_histories=*/{{0, 1, 0}}, {1 / 6.});
+    std::string expected_rebalanced_certificate =
+      "(("
+        "(({}))"      // 2nd player passes
+        "[({})({})]"  // 2nd player bets
+      "))";
+    SPIEL_CHECK_EQ(tree->root().MakeCertificate(),
+                   expected_rebalanced_certificate);
+  }
+  {
+    std::string expected_certificate =
+      "("
+        "([(((({}))(({}))(({}))(({}))))(((({}))(({}))[({}{})({}{})]))])"
+        "([(((({}))(({}))(({}))(({}))))(((({}))(({}))[({}{})({}{})]))])"
+      ")";
+    std::shared_ptr<InfostateTree> tree = MakeTree(
+        "kuhn_poker", /*player=*/0,
+        /*start_histories=*/{{0}, {2}}, {1/3., 1/3.});
+    SPIEL_CHECK_EQ(tree->root().MakeCertificate(), expected_certificate);
+  }
+  {
+    std::string expected_certificate =
+      "("
+        "([(({}))(({}))][(({}))(({}{}))])"
+        "([(({}))(({}))][(({}))(({}{}))])"
+      ")";
+    std::shared_ptr<InfostateTree> tree = MakeTree(
+        "kuhn_poker", /*player=*/1,
+        /*start_histories=*/{{1, 0}, {1, 2}}, {1/6., 1/6.});
+    SPIEL_CHECK_EQ(tree->root().MakeCertificate(), expected_certificate);
+  }
+  {
+    std::string expected_certificate =
+      "("
+        "([(((({}))(({}))(({}))(({}))))(((({}))(({}))[({}{})({}{})]))])"
+        "[((((({})))))((((({})))))]"
+      ")";
+    std::shared_ptr<InfostateTree> tree = MakeTree(
+        "kuhn_poker", /*player=*/0,
+        /*start_histories=*/{{0}, {2, 1, 0, 1}},
+        /*start_reaches=*/{1/3., 1/6.});
+    SPIEL_CHECK_EQ(tree->root().MakeCertificate(), expected_certificate);
+  }
+  {
+    std::string expected_certificate =
+      "("
+        "(((({})))((({}))))"
+        "([(({}))(({}))][(({}))(({}{}))])"
+      ")";
+    std::shared_ptr<InfostateTree> tree = MakeTree(
+        "kuhn_poker", /*player=*/1, /*start_histories=*/{{1, 0}, {1, 2, 0, 1}},
+        /*start_reaches=*/{1 / 6., 1 / 6.});
+    SPIEL_CHECK_EQ(tree->root().MakeCertificate(), expected_certificate);
+  }
+  {
+    std::string expected_certificate =
+      "("
+        "[({}{})({}{})]"
+      ")";
+    std::shared_ptr<InfostateTree> tree = MakeTree(
+        "kuhn_poker", /*player=*/0,
+        /*start_histories=*/{{0, 1, 0, 1}, {0, 2, 0, 1}},
+        /*start_reaches=*/{1/6., 1/6.});
+    SPIEL_CHECK_EQ(tree->root().MakeCertificate(), expected_certificate);
+  }
+  {
+    std::string expected_certificate =
+      "("
+        "({}{})"
+        "({}{})"
+      ")";
+    std::shared_ptr<InfostateTree> tree = MakeTree(
+        "kuhn_poker", /*player=*/1,
+        /*start_histories=*/{{0, 1, 0, 1}, {0, 2, 0, 1}},
+        /*start_reaches=*/{1/6., 1/6.});
+    SPIEL_CHECK_EQ(tree->root().MakeCertificate(), expected_certificate);
+  }
+  {
+    std::shared_ptr<InfostateTree> tree = MakeTree(
+        iigs3, /*player=*/0,
+        /*start_histories=*/{{0  /* = 0 0 */},
+                             {1  /* = 1 0 */, 3  /* = 2 2 */}},
+        /*start_reaches=*/{1., 1.});
+    std::string expected_certificate =
+      "("
+        "(({}))"
+        "[({}{})({}{})]"
+      ")";
+    SPIEL_CHECK_EQ(tree->root().MakeCertificate(), expected_certificate);
+  }
+}
+
+
+void CheckTreeLeaves(const InfostateTree& tree, int move_limit) {
+  for (InfostateNode* leaf_node : tree.leaf_nodes()) {
+    SPIEL_CHECK_TRUE(leaf_node->is_leaf_node());
+    SPIEL_CHECK_TRUE(leaf_node->has_infostate_string());
+    SPIEL_CHECK_FALSE(leaf_node->corresponding_states().empty());
+
+    // Check MoveNumber() for all corresponding states.
+    //
+    // The conditions are following:
+    // - either all states are terminal, and have the same MoveNumber() that
+    //   is less or equal to move_limit,
+    // - or not all states are terminal and the MoveNumber() == move_limit.
+
+    const int num_states = leaf_node->corresponding_states().size();
+    int terminal_cnt = 0;
+    int max_move_number = std::numeric_limits<int>::min();
+    int min_move_number = std::numeric_limits<int>::max();
+    for (const std::unique_ptr<State>
+          & state : leaf_node->corresponding_states()) {
+      if (state->IsTerminal()) terminal_cnt++;
+      max_move_number = std::max(max_move_number, state->MoveNumber());
+      min_move_number = std::min(min_move_number, state->MoveNumber());
+    }
+    SPIEL_CHECK_TRUE(terminal_cnt == 0 || terminal_cnt == num_states);
+    SPIEL_CHECK_TRUE(max_move_number == min_move_number);
+    if (terminal_cnt == 0) {
+      SPIEL_CHECK_EQ(max_move_number, move_limit);
+    } else {
+      SPIEL_CHECK_LE(max_move_number, move_limit);
+    }
+  }
+}
+
+void BuildAllDepths(const std::string& game_name) {
+  std::shared_ptr<const Game> game = LoadGame(game_name);
+  const int max_moves = game->MaxMoveNumber();
+  for (int move_limit = 0; move_limit < max_moves; ++move_limit) {
+    for (int pl = 0; pl < game->NumPlayers(); ++pl) {
+      std::shared_ptr<InfostateTree> tree = MakeTree(game_name, pl, move_limit);
+      CheckTreeLeaves(*tree, move_limit);
+    }
+  }
+}
+
+void TestDepthLimitedTrees() {
+  {
+    std::string expected_certificate =
+      "("  // <dummy>
+        "("  // 1st is getting a card
+          "("  // 2nd is getting card
+            "["  // 1st acts - Node J
+                 // Depth cutoff.
+            "]"
+          ")"
+          // Repeat the same for the two other cards.
+          "([])" // Node Q
+          "([])" // Node K
+        ")"
+      ")";  // </dummy>
+    std::shared_ptr<InfostateTree> tree = MakeTree("kuhn_poker", 0, 2);
+    SPIEL_CHECK_EQ(tree->root().MakeCertificate(), expected_certificate);
+
+    for (InfostateNode* acting : tree->leaf_nodes()) {
+      SPIEL_CHECK_TRUE(acting->is_leaf_node());
+      SPIEL_CHECK_EQ(acting->type(), kDecisionInfostateNode);
+      SPIEL_CHECK_EQ(acting->corresponding_states().size(), 2);
+      SPIEL_CHECK_TRUE(acting->has_infostate_string());
+    }
+  }
+
+  BuildAllDepths("kuhn_poker");
+  BuildAllDepths("kuhn_poker(players=3)");
+  BuildAllDepths("leduc_poker");
+  BuildAllDepths("goofspiel(players=2,num_cards=3,imp_info=True)");
+  BuildAllDepths("goofspiel(players=3,num_cards=3,imp_info=True)");
+}
+
+void TestDepthLimitedSubgames() {
+  {
+    std::array<std::string, 4> expected_certificates = {
+      "(()()())",
+      "(([][])([][])([][]))",
+      "("
+        "([(())({}{})][({}{})({}{})])"
+        "([(())({}{})][({}{})({}{})])"
+        "([(())({}{})][({}{})({}{})])"
+      ")",
+      "("
+        "([(({})({}))(({})({}))][(({})({}))(({}{}{}{}))])"
+        "([(({})({}))(({})({}))][(({})({}))(({}{}{}{}))])"
+        "([(({})({}))(({})({}))][(({})({}))(({}{}{}{}))])"
+      ")"
+    };
+    std::array<int, 4> expected_leaf_counts = {3, 6, 21, 30};
+
+    for (int move_limit = 0; move_limit < 4; ++move_limit) {
+      std::shared_ptr<InfostateTree> tree = MakeTree(
+          "kuhn_poker", /*player_id=*/1,
+          {{0, 1}, {0, 2}, {1, 0}, {1, 2}, {2, 0}, {2, 1}},
+          {1/6., 1/6., 1/6., 1/6., 1/6., 1/6.},
+          /*max_move_limit=*/move_limit);
+      SPIEL_CHECK_EQ(tree->root().MakeCertificate(),
+                     expected_certificates[move_limit]);
+      SPIEL_CHECK_EQ(tree->num_leaves(), expected_leaf_counts[move_limit]);
+
+      for (InfostateNode* leaf : tree->leaf_nodes()) {
+        SPIEL_CHECK_EQ(leaf->depth(), tree->tree_height());
+      }
+    }
+  }
+}
+
+void TestSequenceIdLabeling() {
+  for (int pl = 0; pl < 2; ++pl) {
+    std::shared_ptr<InfostateTree> tree = MakeTree(
+        "kuhn_poker", /*player_id=*/pl);
+
+    for (int depth = 0; depth <= tree->tree_height(); ++depth) {
+      for (InfostateNode* node : tree->nodes_at_depth(depth)) {
+        SPIEL_CHECK_LE(node->start_sequence_id().id(), node->sequence_id().id());
+        SPIEL_CHECK_LE(node->end_sequence_id().id(), node->sequence_id().id());
+      }
+    }
+
+    // Check labeling was done from the deepest nodes.
+    size_t depth = -1;  // Some large number.
+    for (SequenceId id : tree->AllSequenceIds()) {
+      InfostateNode* node = tree->observation_infostate(id);
+      SPIEL_CHECK_LE(node->depth(), depth);
+      depth = node->depth();
+      // Longer sequences (extensions) must have the corresponding
+      // infostate nodes placed deeper.
+      for (SequenceId extension : node->AllSequenceIds()) {
+        InfostateNode* child = tree->observation_infostate(extension);
+        SPIEL_CHECK_LT(node->depth(), child->depth());
+      }
+    }
+  }
+}
+
+void TestBestResponse() {
+  std::shared_ptr<InfostateTree> tree0 = MakeTree("matrix_mp", /*player_id=*/0);
+  std::shared_ptr<InfostateTree> tree1 = MakeTree("matrix_mp", /*player_id=*/1);
+  for (double alpha = 0; alpha < 1.; alpha += 0.1) {
+    const double br_value = std::fmax(2*alpha - 1, -2*alpha + 1);
+    {
+      LeafVector<double> grad(tree0.get(), {
+         1. * alpha,         // Head, Head
+        -1. * (1. - alpha),  // Head, Tail
+        -1. *  alpha,        // Tail, Head
+         1. * (1. - alpha),  // Tail, Tail
+      });
+      SPIEL_CHECK_FLOAT_EQ(tree0->BestResponseValue(std::move(grad)), br_value);
+    }
+    {
+      LeafVector<double> grad(tree1.get(), {
+        -1. * alpha,         // Head, Head
+         1. * (1. - alpha),  // Tail, Head
+         1. * alpha,         // Head, Tail
+        -1. * (1. - alpha),  // Tail, Tail
+      });
+      SPIEL_CHECK_FLOAT_EQ(tree1->BestResponseValue(std::move(grad)), br_value);
+    }
+    {
+      TreeplexVector<double> grad(tree0.get(), {
+        -1. + 2. * alpha, 1. - 2. * alpha, 0.
+      });
+      std::pair<double, SfStrategy> actual_response =
+          tree0->BestResponse(std::move(grad));
+      SPIEL_CHECK_FLOAT_EQ(actual_response.first, br_value);
+    }
+    {
+      TreeplexVector<double> grad(tree1.get(), {
+        1. - 2. * alpha, -1. + 2. * alpha, 0.
+      });
+      std::pair<double, SfStrategy> actual_response =
+          tree1->BestResponse(std::move(grad));
+      SPIEL_CHECK_FLOAT_EQ(actual_response.first, br_value);
+    }
+  }
+}
+
+}  // namespace
+}  // namespace algorithms
+}  // namespace open_spiel
+
+int main(int argc, char** argv) {
+  open_spiel::algorithms::TestRootCertificates();
+  open_spiel::algorithms::TestCertificatesFromStartHistories();
+  open_spiel::algorithms::TestDepthLimitedTrees();
+  open_spiel::algorithms::TestDepthLimitedSubgames();
+  open_spiel::algorithms::TestSequenceIdLabeling();
+  open_spiel::algorithms::TestBestResponse();
+}

--- a/open_spiel/algorithms/infostate_tree_test.cc
+++ b/open_spiel/algorithms/infostate_tree_test.cc
@@ -112,7 +112,7 @@ void TestRootCertificates() {
   }
   {  // Full Kuhn test.
     std::shared_ptr<InfostateTree> tree = MakeTree("kuhn_poker", /*player=*/0);
-    std::string expected_rebalanced_certificate =
+    std::string expected_certificate =
       // Notice all terminals are at the same depth (same indentation).
       "((" // Root node, 1st is getting a card
         "("  // 2nd is getting card
@@ -139,8 +139,7 @@ void TestRootCertificates() {
         "([(((({}))(({}))(({}))(({}))))(((({}))(({}))[({}{})({}{})]))])"
         "([(((({}))(({}))(({}))(({}))))(((({}))(({}))[({}{})({}{})]))])"
       "))";
-    SPIEL_CHECK_EQ(tree->root().MakeCertificate(),
-                   expected_rebalanced_certificate);
+    SPIEL_CHECK_EQ(tree->root().MakeCertificate(), expected_certificate);
   }
   {
     std::string expected_certificate =
@@ -186,13 +185,12 @@ void TestCertificatesFromStartHistories() {
   {
     std::shared_ptr<InfostateTree> tree = MakeTree(
         "kuhn_poker", /*player=*/0, /*start_histories=*/{{0, 1, 0}}, {1 / 6.});
-    std::string expected_rebalanced_certificate =
+    std::string expected_certificate =
       "(("
         "(({}))"      // 2nd player passes
         "[({})({})]"  // 2nd player bets
       "))";
-    SPIEL_CHECK_EQ(tree->root().MakeCertificate(),
-                   expected_rebalanced_certificate);
+    SPIEL_CHECK_EQ(tree->root().MakeCertificate(), expected_certificate);
   }
   {
     std::string expected_certificate =


### PR DESCRIPTION
This implements infostate trees following discussion of #398 with the extra ability of constructing depth-limited infostate trees.

The tree creation is extensively tested and I have a number of algorithms that work correctly on these structures (CFR, Sequence-form LP). 

Some things which should have (more) tests:

- [ ] Best response computation.
- [ ] Compute "gradients".
- [ ] InfostateTree methods in the sections of "Sequence operations" and "Decision operations"

Tagging @gabrfarina @elkhrt @Dugy as I'd like to kindly ask you to review the code. Thank you very much!