### PR TITLE
Update travis.yml: move some tests to Ubuntu 20.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
       - TRAVIS_USE_NOX=0
       - BUILD_SHARED_LIB="ON"
       - BUILD_WITH_ORTOOLS="ON"
-      - BUILD_WITH_ORTOOLS_DOWNLOAD_URL="https://github.com/google/or-tools/releases/download/v8.0/or-tools_ubuntu-18.04_v8.0.8283.tar.gz"
+      - BUILD_WITH_ORTOOLS_DOWNLOAD_URL="https://github.com/google/or-tools/releases/download/v8.0/or-tools_ubuntu-20.04_v8.0.8283.tar.gz"
   # Build and test on MacOS. We use a single target, with all dependencies.
   - os: osx
     osx_image: xcode10.3  # macOS 10.14 (Mojave), release on March 25, 2019.

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@
 # Travis CI or another service (CircleCI, etc).
 
 language: c
+compiler: clang
 
 cache: pip
 git:
@@ -32,6 +33,7 @@ matrix:
     env:
       - OS_PYTHON_VERSION=3.8
       - TRAVIS_USE_NOX=0
+      - CC=/usr/bin/clang
       - CXX=/usr/bin/clang++
   # Build and run tests with all optional dependencies, including building a
   # shared library with linkable third party dependencies in place.
@@ -41,6 +43,7 @@ matrix:
       - OS_PYTHON_VERSION=3.8
       - DEFAULT_OPTIONAL_DEPENDENCY="ON"
       - TRAVIS_USE_NOX=0
+      - CC=/usr/bin/clang
       - CXX=/usr/bin/clang++
       - BUILD_SHARED_LIB="ON"
       - BUILD_WITH_ORTOOLS="ON"
@@ -60,6 +63,7 @@ matrix:
     env:
       - OS_PYTHON_VERSION=3.8
       - TRAVIS_USE_NOX=1
+      - CC=/usr/bin/clang
       - CXX=/usr/bin/clang++
   # Build and test on MacOS. We use a single target, with all dependencies and
   # use nox.

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@
 # Travis CI or another service (CircleCI, etc).
 
 language: c
-compiler: clang
 
 cache: pip
 git:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,17 @@ matrix:
     env:
       - OS_PYTHON_VERSION=3.6
       - TRAVIS_USE_NOX=0
+  - os: linux
+    dist: focal # Ubuntu 20.04 LTS
+    env:
+      - OS_PYTHON_VERSION=3.8
+      - TRAVIS_USE_NOX=0
   # Build and run tests with all optional dependencies, including building a
   # shared library with linkable third party dependencies in place.
   - os: linux
     dist: focal # Ubuntu 20.04 LTS
     env:
-      - OS_PYTHON_VERSION=3.6
+      - OS_PYTHON_VERSION=3.8
       - DEFAULT_OPTIONAL_DEPENDENCY="ON"
       - TRAVIS_USE_NOX=0
       - BUILD_SHARED_LIB="ON"
@@ -51,21 +56,13 @@ matrix:
   - os: linux
     dist: focal # Ubuntu 20.04 LTS
     env:
-      - OS_PYTHON_VERSION=3.6
-      - TRAVIS_USE_NOX=1
-  # Build and run tests with all optional dependencies and use nox
-  - os: linux
-    dist: bionic # Ubuntu 18.04.2 LTS released on 26 April 2018
-    env:
-      - OS_PYTHON_VERSION=3.6
-      - DEFAULT_OPTIONAL_DEPENDENCY="ON"
+      - OS_PYTHON_VERSION=3.8
       - TRAVIS_USE_NOX=1
   # Build and test on MacOS. We use a single target, with all dependencies and
   # use nox.
   - os: osx
     osx_image: xcode10.3  # macOS 10.14 (Mojave), release on March 25, 2019.
     env:
-      - DEFAULT_OPTIONAL_DEPENDENCY="ON"
       - TRAVIS_USE_NOX=1
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ matrix:
     env:
       - OS_PYTHON_VERSION=3.6
       - TRAVIS_USE_NOX=0
+      - CC=/usr/local/clang-7.0.0/bin/clang
+      - CXX=/usr/local/clang-7.0.0/bin/clang++
   - os: linux
     dist: focal # Ubuntu 20.04 LTS
     env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
   # Build and run tests with all optional dependencies, including building a
   # shared library with linkable third party dependencies in place.
   - os: linux
-    dist: bionic # Ubuntu 18.04.2 LTS released on 26 April 2018
+    dist: focal # Ubuntu 20.04 LTS
     env:
       - OS_PYTHON_VERSION=3.6
       - DEFAULT_OPTIONAL_DEPENDENCY="ON"
@@ -49,7 +49,7 @@ matrix:
   # Build and run tests without all optional dependencies (default behavior) and
   # use nox
   - os: linux
-    dist: bionic # Ubuntu 18.04.2 LTS released on 26 April 2018
+    dist: focal # Ubuntu 20.04 LTS
     env:
       - OS_PYTHON_VERSION=3.6
       - TRAVIS_USE_NOX=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ matrix:
     env:
       - OS_PYTHON_VERSION=3.8
       - TRAVIS_USE_NOX=0
+      - CXX=/usr/bin/clang++
   # Build and run tests with all optional dependencies, including building a
   # shared library with linkable third party dependencies in place.
   - os: linux
@@ -40,6 +41,7 @@ matrix:
       - OS_PYTHON_VERSION=3.8
       - DEFAULT_OPTIONAL_DEPENDENCY="ON"
       - TRAVIS_USE_NOX=0
+      - CXX=/usr/bin/clang++
       - BUILD_SHARED_LIB="ON"
       - BUILD_WITH_ORTOOLS="ON"
       - BUILD_WITH_ORTOOLS_DOWNLOAD_URL="https://github.com/google/or-tools/releases/download/v8.0/or-tools_ubuntu-20.04_v8.0.8283.tar.gz"
@@ -58,6 +60,7 @@ matrix:
     env:
       - OS_PYTHON_VERSION=3.8
       - TRAVIS_USE_NOX=1
+      - CXX=/usr/bin/clang++
   # Build and test on MacOS. We use a single target, with all dependencies and
   # use nox.
   - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,14 @@ matrix:
       - TRAVIS_USE_NOX=1
       - CC=/usr/bin/clang
       - CXX=/usr/bin/clang++
+  # Ubuntu 18.04
+  - os: linux
+    dist: bionic # Ubuntu 18.04
+    env:
+      - OS_PYTHON_VERSION=3.6
+      - TRAVIS_USE_NOX=1
+      - CC=/usr/local/clang-7.0.0/bin/clang
+      - CXX=/usr/local/clang-7.0.0/bin/clang++
   # Build and test on MacOS. We use a single target, with all dependencies and
   # use nox.
   - os: osx

--- a/noxfile.py
+++ b/noxfile.py
@@ -29,9 +29,17 @@ def get_distutils_tempdir():
 
 @nox.session(python="3")
 def tests(session):
+  # Explicitly pull out CC and CXX if they are specified.
+  child_env = {}  
+  if os.environ.get("CC") is not None:
+    child_env["CC"] = os.environ.get("CC")
+  if os.environ.get("CXX") is not None:
+    child_env["CXX"] = os.environ.get("CXX")
+  print("nox build child environment:")
+  print(child_env)
   session.install("-r", "requirements.txt")
-  session.run("python3", "setup.py", "build")
-  session.run("python3", "setup.py", "install")
+  session.run("python3", "setup.py", "build", env=child_env)
+  session.run("python3", "setup.py", "install", env=child_env)
   session.cd(os.path.join("build", get_distutils_tempdir()))
   session.run(
       "ctest", f"-j{4*os.cpu_count()}", "--output-on-failure", external=True)

--- a/open_spiel/CMakeLists.txt
+++ b/open_spiel/CMakeLists.txt
@@ -28,7 +28,6 @@ set (CMAKE_CXX_STANDARD 17)
 
 # Use libc++
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -lc++abi")
 
 # Set default build type.
 if(NOT BUILD_TYPE)

--- a/open_spiel/CMakeLists.txt
+++ b/open_spiel/CMakeLists.txt
@@ -25,7 +25,6 @@ if(NOT WIN32)
 endif()
 
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 
 # Set default build type.
 if(NOT BUILD_TYPE)

--- a/open_spiel/CMakeLists.txt
+++ b/open_spiel/CMakeLists.txt
@@ -26,6 +26,10 @@ endif()
 
 set (CMAKE_CXX_STANDARD 17)
 
+# Use libc++
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -lc++abi")
+
 # Set default build type.
 if(NOT BUILD_TYPE)
    set(BUILD_TYPE Testing

--- a/open_spiel/CMakeLists.txt
+++ b/open_spiel/CMakeLists.txt
@@ -26,9 +26,6 @@ endif()
 
 set (CMAKE_CXX_STANDARD 17)
 
-# Use libc++
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-
 # Set default build type.
 if(NOT BUILD_TYPE)
    set(BUILD_TYPE Testing

--- a/open_spiel/CMakeLists.txt
+++ b/open_spiel/CMakeLists.txt
@@ -24,7 +24,8 @@ if(NOT WIN32)
   set(BoldWhite   "${Esc}[1;37m")
 endif()
 
-set (CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 
 # Set default build type.
 if(NOT BUILD_TYPE)

--- a/open_spiel/scripts/build_and_run_tests.sh
+++ b/open_spiel/scripts/build_and_run_tests.sh
@@ -56,10 +56,10 @@ set -e  # exit when any command fails
 MYDIR="$(dirname "$(realpath "$0")")"
 source "${MYDIR}/global_variables.sh"
 
-CXX=`which clang++`
+CXX=${CXX:-`which clang++`}
 if [ ! -x $CXX ]
 then
-  echo -n "clang++ not found in the path (the clang C++ compiler is needed to "
+  echo -n "clang++ not found (the clang C++ compiler is needed to "
   echo "compile OpenSpiel). Exiting..."
   exit 1
 fi

--- a/open_spiel/scripts/install.sh
+++ b/open_spiel/scripts/install.sh
@@ -187,12 +187,17 @@ if [[ ${BUILD_WITH_JULIA:-"OFF"} == "ON" ]]; then
     # Now install Julia
     JULIA_INSTALLER="open_spiel/scripts/jill.sh"
     if [[ ! -f $JULIA_INSTALLER ]]; then
-    curl https://raw.githubusercontent.com/abelsiqueira/jill/master/jill.sh -o jill.sh
-    mv jill.sh $JULIA_INSTALLER
+      curl https://raw.githubusercontent.com/abelsiqueira/jill/master/jill.sh -o jill.sh
+      mv jill.sh $JULIA_INSTALLER
     fi
     JULIA_VERSION=1.3.1 bash $JULIA_INSTALLER -y
     # Should install in $HOME/.local/bin which was added to the path above
     [[ -x `which julia` ]] || die "julia not found PATH after install."
+    # This is needed on Ubuntu 19.10 and above, see:
+    # https://github.com/deepmind/open_spiel/issues/201
+    if [[ -f /usr/lib/x86_64-linux-gnu/libstdc++.so.6 ]]; then
+      cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6 $HOME/packages/julias/julia-1.3.1/lib/julia
+    fi
   fi
 
   # Install dependencies.

--- a/open_spiel/scripts/travis_script.sh
+++ b/open_spiel/scripts/travis_script.sh
@@ -35,7 +35,6 @@ source ./venv/bin/activate
 python3 --version
 pip3 install --upgrade -r requirements.txt -q
 
-# Use libc++
-CXX_FLAGS="-stdlib=libc++" ./open_spiel/scripts/build_and_run_tests.sh
+./open_spiel/scripts/build_and_run_tests.sh
 
 deactivate

--- a/open_spiel/scripts/travis_script.sh
+++ b/open_spiel/scripts/travis_script.sh
@@ -35,5 +35,7 @@ source ./venv/bin/activate
 python3 --version
 pip3 install --upgrade -r requirements.txt -q
 
-./open_spiel/scripts/build_and_run_tests.sh
+# Use libc++
+CXX_FLAGS="-stdlib=libc++" ./open_spiel/scripts/build_and_run_tests.sh
+
 deactivate

--- a/open_spiel/scripts/travis_script.sh
+++ b/open_spiel/scripts/travis_script.sh
@@ -27,7 +27,7 @@ fi
 
 sudo -H pip3 install --upgrade pip
 sudo -H pip3 install --upgrade setuptools
-sudo -H pip3 install --force-reinstall virtualenv
+sudo -H pip3 install --force-reinstall virtualenv==20.0.23
 
 virtualenv -p python3 ./venv
 source ./venv/bin/activate

--- a/setup.py
+++ b/setup.py
@@ -57,18 +57,22 @@ class BuildExt(build_ext):
       self.build_extension(ext)
 
   def build_extension(self, ext):
+    compiler = "clang++"
+    if os.environ.get("CXX") is not None:
+      compiler = os.environ.get("CXX")
     extension_dir = os.path.abspath(
         os.path.dirname(self.get_ext_fullpath(ext.name)))
     cmake_args = [
         f"-DPython3_EXECUTABLE={sys.executable}",
-        "-DCMAKE_CXX_COMPILER=clang++",
+        "-DCMAKE_CXX_COMPILER=" + compiler,
         f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extension_dir}",
     ]
     if not os.path.exists(self.build_temp):
       os.makedirs(self.build_temp)
-    subprocess.check_call(
-        ["cmake", ext.sourcedir] + cmake_args, cwd=self.build_temp)
     env = os.environ.copy()
+    subprocess.check_call(
+        ["cmake", ext.sourcedir] + cmake_args,
+        cwd=self.build_temp, env=env)
     subprocess.check_call(["make", f"-j{os.cpu_count()}"],
                           cwd=self.build_temp,
                           env=env)


### PR DESCRIPTION
- Move the main big test (optional dependencies on) to Ubuntu 20.04
- Keep the standard no-optional deps test to Ubuntu 18.04
- Switch the order of these for the nox tests to cover all four possibilities