### PR TITLE
Make changes necessary for pip sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,6 @@
+# python package requirements
+include requirements.txt
+
 # pybind files
 recursive-include pybind11/include/pybind11 *.h
 recursive-include pybind11/pybind11 *.py
@@ -9,3 +12,5 @@ recursive-include open_spiel CMakeLists.txt *.cc *.cpp *.h *.hpp
 # abseil CMake files
 recursive-include open_spiel/abseil-cpp/CMake **
 recursive-include open_spiel/abseil-cpp/ *.cmake *.inc
+
+

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,17 @@
+# Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Lint as: python3
 """An integration test building and testing open_spiel wheel."""
 import os

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,17 +1,3 @@
-# Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 # Lint as: python3
 """An integration test building and testing open_spiel wheel."""
 import os
@@ -29,16 +15,9 @@ def get_distutils_tempdir():
 
 @nox.session(python="3")
 def tests(session):
-  """Run the build and tests via setup.py."""
-  # Explicitly pull out CC and CXX if they are specified.
-  child_env = {}
-  if os.environ.get("CC") is not None:
-    child_env["CC"] = os.environ.get("CC")
-  if os.environ.get("CXX") is not None:
-    child_env["CXX"] = os.environ.get("CXX")
-  print("nox build child environment:")
-  print(child_env)
   session.install("-r", "requirements.txt")
+  child_env = os.environ.copy()
+  child_env["OPEN_SPIEL_BUILD_ALL"] = "ON"
   session.run("python3", "setup.py", "build", env=child_env)
   session.run("python3", "setup.py", "install", env=child_env)
   session.cd(os.path.join("build", get_distutils_tempdir()))

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,3 @@
-# Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 # Lint as: python3
 """The setup script for setuptools.
 
@@ -45,6 +31,12 @@ class BuildExt(build_ext):
   """
 
   def run(self):
+    self._check_build_environment()
+    for ext in self.extensions:
+      self.build_extension(ext)
+
+  def _check_build_environment(self):
+    """Check for required build tools: CMake, C++ compiler, and python dev."""
     try:
       subprocess.check_call(["cmake", "--version"])
     except OSError as e:
@@ -52,29 +44,57 @@ class BuildExt(build_ext):
       raise RuntimeError(
           f"CMake must be installed to build the following extensions: {ext_names}"
       ) from e
+    print("Found CMake")
 
-    for ext in self.extensions:
-      self.build_extension(ext)
+    cxx = "clang++"
+    if os.environ.get("CXX") is not None:
+      cxx = os.environ.get("CXX")
+    try:
+      subprocess.check_call([cxx, "--version"])
+    except OSError as e:
+      ext_names = ", ".join(e.name for e in self.extensions)
+      raise RuntimeError(
+          "{} must be installed to build the following extensions: {}".format(
+              cxx, ext_names)
+      ) from e
+    print("Found C++ compiler: {}".format(cxx))
+
+    try:
+      subprocess.check_call(["python3-config", "--help"])
+    except OSError as e:
+      ext_names = ", ".join(e.name for e in self.extensions)
+      raise RuntimeError(
+          "Python3 development files (python3-dev) must be installed to build"
+          + "the following extensions: {}".format(ext_names)
+      ) from e
+    print("Found python3 dev files.")
 
   def build_extension(self, ext):
-    compiler = "clang++"
-    if os.environ.get("CXX") is not None:
-      compiler = os.environ.get("CXX")
     extension_dir = os.path.abspath(
         os.path.dirname(self.get_ext_fullpath(ext.name)))
+    cxx = "clang++"
+    if os.environ.get("CXX") is not None:
+      cxx = os.environ.get("CXX")
     cmake_args = [
         f"-DPython3_EXECUTABLE={sys.executable}",
-        "-DCMAKE_CXX_COMPILER=" + compiler,
+        f"-DCMAKE_CXX_COMPILER={cxx}",
         f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extension_dir}",
     ]
     if not os.path.exists(self.build_temp):
       os.makedirs(self.build_temp)
-    env = os.environ.copy()
     subprocess.check_call(
-        ["cmake", ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env)
-    subprocess.check_call(["make", f"-j{os.cpu_count()}"],
-                          cwd=self.build_temp,
-                          env=env)
+        ["cmake", ext.sourcedir] + cmake_args, cwd=self.build_temp)
+    env = os.environ.copy()
+    if os.environ.get("OPEN_SPIEL_BUILD_ALL") is not None:
+      # Build everything (necessary for nox tests)
+      subprocess.check_call(["make", f"-j{os.cpu_count()}"],
+                            cwd=self.build_temp,
+                            env=env)
+    else:
+      # Build only pyspiel (for pip package)
+      subprocess.check_call(["make", "pyspiel", f"-j{os.cpu_count()}"],
+                            cwd=self.build_temp,
+                            env=env)
 
 
 def _get_requirements(requirements_file):  # pylint: disable=g-doc-args
@@ -94,9 +114,17 @@ def _parse_line(s):
   return requirement.strip()
 
 
+# Get the requirements from file. During nox tests, this is in the current
+# directory, but when installing from pip it is in the parent directory
+req_file = ""
+if os.path.exists("requirements.txt"):
+  req_file = "requirements.txt"
+else:
+  req_file = "../requirements.txt"
+
 setuptools.setup(
-    name="pyspiel",
-    version="0.0.1rc2",
+    name="open_spiel",
+    version="0.2.0",
     license="Apache 2.0",
     author="The OpenSpiel authors",
     author_email="open_spiel@google.com",
@@ -104,7 +132,7 @@ setuptools.setup(
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     url="https://github.com/deepmind/open_spiel",
-    install_requires=_get_requirements("requirements.txt"),
+    install_requires=_get_requirements(req_file),
     ext_modules=[CMakeExtension("pyspiel", sourcedir="open_spiel")],
     cmdclass={"build_ext": BuildExt},
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,17 @@
+# Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Lint as: python3
 """The setup script for setuptools.
 
@@ -54,8 +68,9 @@ class BuildExt(build_ext):
     except OSError as e:
       ext_names = ", ".join(e.name for e in self.extensions)
       raise RuntimeError(
-          "{} must be installed to build the following extensions: {}".format(
-              cxx, ext_names)
+          "A C++ compiler that supports c++17 must be installed to build the "
+          + "following extensions: {}".format(ext_names)
+          + ". We recommend: Clang version >= 7.0.0."
       ) from e
     print("Found C++ compiler: {}".format(cxx))
 


### PR DESCRIPTION
- setup.py: Add checks for C++ compiler and python-dev headers
- setup.py: Look for requirements.txt in current and parent directory
- setup.py & noxfile.py: Add flag to determine building and testing everything as opposed to just pyspiel
- Add requirements.txt to MANIFEST.in (read by setup.py)
- Change name to `open_spiel` and version to `0.2.0`
- Use compiler specified by CXX environment variable and drop down to default of clang++