### PR TITLE
Fix heap overflow in deep sea

### DIFF
--- a/open_spiel/games/deep_sea.cc
+++ b/open_spiel/games/deep_sea.cc
@@ -128,7 +128,9 @@ std::string DeepSeaState::ObservationString(Player player) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
 
-  std::string str(size_ * size_, '.');
+  // We need to account for the possibility that `player_row == size_` at
+  // terminal states, so that's why we add the +1.
+  std::string str((size_ + 1) * size_, '.');
   str[player_row_ * size_ + player_col_] = 'x';
   return str;
 }


### PR DESCRIPTION
Address sanitizer was reporting a heap overflow in deep sea. After a bit of digging I think I understand the bug, and I think this patch should be enough to fix it. However, I am not familiar with the game, so it would be better for someone to take a second look and confirm that no further action is required to fix this.