### PR TITLE
Update requirements for Jax and its dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,14 +20,15 @@ tensorflow-probability < 0.8.0, >= 0.7.0
 cvxopt == 1.2.5
 networkx == 2.4
 mock == 4.0.2
-optax == 0.0.1
+optax == 0.0.2
+chex == 0.0.3
 matplotlib == 3.2.2
 nashpy == 0.0.19
 scipy == 1.4.1
 attrs == 19.3.0
-jax == 0.1.67
-jaxlib == 0.1.47
-dm-haiku == 0.0.1
+jax == 0.2.7
+jaxlib == 0.1.57
+dm-haiku == 0.0.3
 dataclasses == 0.7; python_version < "3.7"
 hypothesis==5.38.0
 torch==1.7.0


### PR DESCRIPTION
This is to fix the tests on Travis due to not having chex pinned at a specific version, but also upgrading the other ones to newer versions.