### PR TITLE
Fix 2 typos in python/games/tic_tac_toe.py

### DIFF
--- a/open_spiel/python/games/tic_tac_toe.py
+++ b/open_spiel/python/games/tic_tac_toe.py
@@ -167,7 +167,7 @@ class TicTacToeState(object):
   def player_reward(self, player):
     return self.rewards()[player]
 
-  def player_returns(self, player):
+  def player_return(self, player):
     return self.returns()[player]
 
   def is_chance_node(self):
@@ -221,7 +221,7 @@ class TicTacToeState(object):
 class TicTacToeGame(object):
   """A python-only version of the Tic-Tac-Toe game.
 
-  This class implements all the pyspiel.Gae API functions. Please see spiel.h
+  This class implements all the pyspiel.Game API functions. Please see spiel.h
   for more thorough documentation of each function.
 
   Note that this class does not inherit from pyspiel.Game since pickle

--- a/open_spiel/python/tests/games_sim_test.py
+++ b/open_spiel/python/tests/games_sim_test.py
@@ -169,6 +169,9 @@ class GamesSimTest(parameterized.TestCase):
         self.assertEmpty(state.legal_actions(player))
       # Print utilities for each player.
       utilities = state.returns()
+      # Check that player returns are correct
+      for player in range(game.num_players()):
+        self.assertEqual(state.player_return(player), utilities[player])
       # Check that each one is in range
       for utility in utilities:
         self.assertGreaterEqual(utility, game.min_utility())


### PR DESCRIPTION
Fix a typo in the docstring, and correct the name of the method from `player_returns` to `player_return`