### PR TITLE
Expose _use_observation as environment property

### DIFF
--- a/open_spiel/python/rl_environment.py
+++ b/open_spiel/python/rl_environment.py
@@ -376,6 +376,11 @@ class Environment(object):
         dtype=int,
     )
 
+  # Environment properties
+  @property
+  def use_observation(self):
+    return self._use_observation
+
   # Game properties
   @property
   def name(self):


### PR DESCRIPTION
Exposing this private attribute as a property is needed for the OpenSpiel wrapper in Acme https://github.com/deepmind/acme/pull/87.