### PR TITLE
Add new bidding rule to Liar's dice and make the number of faces configurable

### DIFF
--- a/open_spiel/games/liars_dice.h
+++ b/open_spiel/games/liars_dice.h
@@ -36,13 +36,26 @@
 namespace open_spiel {
 namespace liars_dice {
 
+enum BiddingRule {
+  // The player may bid a higher quantity of any particular face, or the same
+  // quantity of a higher face (allowing a player to "re-assert" a face value
+  // they believe prevalent if another player increased the face value on their
+  // bid).
+  kResetFace = 1,
+
+  // The player may bid a higher quantity of the same face, or any particular
+  // quantity of a higher face (allowing a player to "reset" the quantity).
+  kResetQuantity = 2
+};
+
 class LiarsDiceGame;
 
 class LiarsDiceState : public State {
  public:
   explicit LiarsDiceState(std::shared_ptr<const Game> game, int total_num_dice,
                           int max_dice_per_player,
-                          const std::vector<int>& num_dice, int dice_sides);
+                          const std::vector<int>& num_dice, int dice_sides,
+                          BiddingRule bidding_rule);
   LiarsDiceState(const LiarsDiceState&) = default;
 
   void Reset(const GameParameters& params);
@@ -87,6 +100,7 @@ class LiarsDiceState : public State {
   std::vector<int> num_dice_;         // How many dice each player has.
   std::vector<int> num_dice_rolled_;  // Number of dice currently rolled.
   int dice_sides_;                    // Number of faces on each die.
+  BiddingRule bidding_rule_;
 
   // Used to encode the information state.
   std::vector<int> bidseq_;
@@ -125,6 +139,7 @@ class LiarsDiceGame : public Game {
   std::vector<int> num_dice_;  // How many dice each player has.
   int max_dice_per_player_;    // Maximum value in num_dice_ vector.
   int dice_sides_;             // Number of faces on each die.
+  BiddingRule bidding_rule_;
 };
 }  // namespace liars_dice
 }  // namespace open_spiel

--- a/open_spiel/games/liars_dice.h
+++ b/open_spiel/games/liars_dice.h
@@ -31,6 +31,7 @@
 //   "players"     int    number of players                      (default = 2)
 //   "numdice"     int    number of dice per player              (default = 1)
 //   "numdiceX"    int    overridden number of dice for player X (default = 1)
+//   "dice_sides"  int    number of sides on each die            (default = 6)
 
 namespace open_spiel {
 namespace liars_dice {
@@ -41,7 +42,7 @@ class LiarsDiceState : public State {
  public:
   explicit LiarsDiceState(std::shared_ptr<const Game> game, int total_num_dice,
                           int max_dice_per_player,
-                          const std::vector<int>& num_dice);
+                          const std::vector<int>& num_dice, int dice_sides);
   LiarsDiceState(const LiarsDiceState&) = default;
 
   void Reset(const GameParameters& params);
@@ -65,6 +66,10 @@ class LiarsDiceState : public State {
  private:
   void ResolveWinner();
 
+  // Get the quantity and face of the bid from an integer.
+  // The bids starts at 0 and go to total_dice*dice_sides-1 (inclusive).
+  std::pair<int, int> GetQuantityFace(int bid) const;
+
   // Initialized to invalid values. Use Game::NewInitialState().
   Player cur_player_;  // Player whose turn it is.
   int cur_roller_;     // Player currently rolling dice.
@@ -81,6 +86,7 @@ class LiarsDiceState : public State {
   std::vector<std::vector<int>> dice_outcomes_;
   std::vector<int> num_dice_;         // How many dice each player has.
   std::vector<int> num_dice_rolled_;  // Number of dice currently rolled.
+  int dice_sides_;                    // Number of faces on each die.
 
   // Used to encode the information state.
   std::vector<int> bidseq_;
@@ -109,10 +115,6 @@ class LiarsDiceGame : public Game {
   // Return the total number of dice in the game.
   int total_num_dice() const { return total_num_dice_; }
 
-  // Get the quantity and face of the bid from an integer.
-  // The bids starts at 1 and go to total_dice*6+1.
-  static std::pair<int, int> GetQuantityFace(int bid, int total_dice);
-
  private:
   // Number of players.
   int num_players_;
@@ -122,8 +124,8 @@ class LiarsDiceGame : public Game {
 
   std::vector<int> num_dice_;  // How many dice each player has.
   int max_dice_per_player_;    // Maximum value in num_dice_ vector.
+  int dice_sides_;             // Number of faces on each die.
 };
-
 }  // namespace liars_dice
 }  // namespace open_spiel
 

--- a/open_spiel/integration_tests/playthroughs/liars_dice.txt
+++ b/open_spiel/integration_tests/playthroughs/liars_dice.txt
@@ -6,7 +6,7 @@ GameType.information = Information.IMPERFECT_INFORMATION
 GameType.long_name = "Liars Dice"
 GameType.max_num_players = 2
 GameType.min_num_players = 2
-GameType.parameter_specification = ["dice_sides", "numdice", "players"]
+GameType.parameter_specification = ["bidding_rule", "dice_sides", "numdice", "players"]
 GameType.provides_information_state_string = True
 GameType.provides_information_state_tensor = True
 GameType.provides_observation_string = False
@@ -19,7 +19,7 @@ GameType.utility = Utility.ZERO_SUM
 NumDistinctActions() = 13
 PolicyTensorShape() = [13]
 MaxChanceOutcomes() = 6
-GetParameters() = {dice_sides=6,numdice=1,players=2}
+GetParameters() = {bidding_rule=reset-face,dice_sides=6,numdice=1,players=2}
 NumPlayers() = 2
 MinUtility() = -1.0
 MaxUtility() = 1.0
@@ -51,66 +51,88 @@ ChanceOutcomes() = [{0, 0.166666666667}, {1, 0.166666666667}, {2, 0.166666666667
 LegalActions() = [0, 1, 2, 3, 4, 5]
 StringLegalActions() = ["Roll 1", "Roll 2", "Roll 3", "Roll 4", "Roll 5", "Roll 6"]
 
-# Apply action "Roll 6"
-action: 5
+# Apply action "Roll 2"
+action: 1
 
 # State 1
-# 6 -1 - chance node, current roller is player 1
+# 2 -1 - chance node, current roller is player 1
 IsTerminal() = False
-History() = [5]
-HistoryString() = "5"
+History() = [1]
+HistoryString() = "1"
 IsChanceNode() = True
 IsSimultaneousNode() = False
 CurrentPlayer() = -1
-InformationStateString(0) = "6"
+InformationStateString(0) = "2"
 InformationStateString(1) = "-1"
-InformationStateTensor(0): ◉◯◯◯◯◯◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯
+InformationStateTensor(0): ◉◯◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯
 InformationStateTensor(1): ◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯
-ObservationTensor(0): ◉◯◯◯◯◯◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯
+ObservationTensor(0): ◉◯◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯
 ObservationTensor(1): ◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯
 ChanceOutcomes() = [{0, 0.166666666667}, {1, 0.166666666667}, {2, 0.166666666667}, {3, 0.166666666667}, {4, 0.166666666667}, {5, 0.166666666667}]
 LegalActions() = [0, 1, 2, 3, 4, 5]
 StringLegalActions() = ["Roll 1", "Roll 2", "Roll 3", "Roll 4", "Roll 5", "Roll 6"]
 
-# Apply action "Roll 1"
-action: 0
+# Apply action "Roll 2"
+action: 1
 
 # State 2
-# 6 1
+# 2 2
 IsTerminal() = False
-History() = [5, 0]
-HistoryString() = "5 0"
+History() = [1, 1]
+HistoryString() = "1 1"
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = 0
-InformationStateString(0) = "6"
-InformationStateString(1) = "1"
-InformationStateTensor(0): ◉◯◯◯◯◯◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯
-InformationStateTensor(1): ◯◉◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯
-ObservationTensor(0): ◉◯◯◯◯◯◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯
-ObservationTensor(1): ◯◉◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯
+InformationStateString(0) = "2"
+InformationStateString(1) = "2"
+InformationStateTensor(0): ◉◯◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯
+InformationStateTensor(1): ◯◉◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯
+ObservationTensor(0): ◉◯◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯
+ObservationTensor(1): ◯◉◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯
 Rewards() = [0.0, 0.0]
 Returns() = [0.0, 0.0]
 LegalActions() = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
-StringLegalActions() = ["1-1", "2-1", "1-2", "2-2", "1-3", "2-3", "1-4", "2-4", "1-5", "2-5", "1-6", "2-6"]
+StringLegalActions() = ["1-1", "1-2", "1-3", "1-4", "1-5", "1-6", "2-1", "2-2", "2-3", "2-4", "2-5", "2-6"]
 
-# Apply action "1-6"
-action: 10
+# Apply action "1-2"
+action: 1
 
 # State 3
-# 6 1 1-6
+# 2 2 1-2
 IsTerminal() = False
-History() = [5, 0, 10]
-HistoryString() = "5 0 10"
+History() = [1, 1, 1]
+HistoryString() = "1 1 1"
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = 1
-InformationStateString(0) = "6 1-6"
-InformationStateString(1) = "1 1-6"
-InformationStateTensor(0): ◉◯◯◯◯◯◯◉◯◯◯◯◯◯◯◯◯◯◉◯◯
-InformationStateTensor(1): ◯◉◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◉◯◯
-ObservationTensor(0): ◉◯◯◯◯◯◯◉◯◯◯◯◯◯◯◯◯◯◉◯◯
-ObservationTensor(1): ◯◉◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◉◯◯
+InformationStateString(0) = "2 1-2"
+InformationStateString(1) = "2 1-2"
+InformationStateTensor(0): ◉◯◯◉◯◯◯◯◯◉◯◯◯◯◯◯◯◯◯◯◯
+InformationStateTensor(1): ◯◉◯◉◯◯◯◯◯◉◯◯◯◯◯◯◯◯◯◯◯
+ObservationTensor(0): ◉◯◯◉◯◯◯◯◯◉◯◯◯◯◯◯◯◯◯◯◯
+ObservationTensor(1): ◯◉◯◉◯◯◯◯◯◉◯◯◯◯◯◯◯◯◯◯◯
+Rewards() = [0.0, 0.0]
+Returns() = [0.0, 0.0]
+LegalActions() = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+StringLegalActions() = ["1-3", "1-4", "1-5", "1-6", "2-1", "2-2", "2-3", "2-4", "2-5", "2-6", "Liar"]
+
+# Apply action "2-5"
+action: 10
+
+# State 4
+# 2 2 1-2 2-5
+IsTerminal() = False
+History() = [1, 1, 1, 10]
+HistoryString() = "1 1 1 10"
+IsChanceNode() = False
+IsSimultaneousNode() = False
+CurrentPlayer() = 0
+InformationStateString(0) = "2 1-2 2-5"
+InformationStateString(1) = "2 1-2 2-5"
+InformationStateTensor(0): ◉◯◯◉◯◯◯◯◯◉◯◯◯◯◯◯◯◯◉◯◯
+InformationStateTensor(1): ◯◉◯◉◯◯◯◯◯◉◯◯◯◯◯◯◯◯◉◯◯
+ObservationTensor(0): ◉◯◯◉◯◯◯◯◯◉◯◯◯◯◯◯◯◯◉◯◯
+ObservationTensor(1): ◯◉◯◉◯◯◯◯◯◉◯◯◯◯◯◯◯◯◉◯◯
 Rewards() = [0.0, 0.0]
 Returns() = [0.0, 0.0]
 LegalActions() = [11, 12]
@@ -119,20 +141,20 @@ StringLegalActions() = ["2-6", "Liar"]
 # Apply action "2-6"
 action: 11
 
-# State 4
-# 6 1 1-6 2-6
+# State 5
+# 2 2 1-2 2-5 2-6
 IsTerminal() = False
-History() = [5, 0, 10, 11]
-HistoryString() = "5 0 10 11"
+History() = [1, 1, 1, 10, 11]
+HistoryString() = "1 1 1 10 11"
 IsChanceNode() = False
 IsSimultaneousNode() = False
-CurrentPlayer() = 0
-InformationStateString(0) = "6 1-6 2-6"
-InformationStateString(1) = "1 1-6 2-6"
-InformationStateTensor(0): ◉◯◯◯◯◯◯◉◯◯◯◯◯◯◯◯◯◯◉◉◯
-InformationStateTensor(1): ◯◉◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◉◉◯
-ObservationTensor(0): ◉◯◯◯◯◯◯◉◯◯◯◯◯◯◯◯◯◯◉◉◯
-ObservationTensor(1): ◯◉◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◉◉◯
+CurrentPlayer() = 1
+InformationStateString(0) = "2 1-2 2-5 2-6"
+InformationStateString(1) = "2 1-2 2-5 2-6"
+InformationStateTensor(0): ◉◯◯◉◯◯◯◯◯◉◯◯◯◯◯◯◯◯◉◉◯
+InformationStateTensor(1): ◯◉◯◉◯◯◯◯◯◉◯◯◯◯◯◯◯◯◉◉◯
+ObservationTensor(0): ◉◯◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◉◉◯
+ObservationTensor(1): ◯◉◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◉◉◯
 Rewards() = [0.0, 0.0]
 Returns() = [0.0, 0.0]
 LegalActions() = [12]
@@ -141,19 +163,19 @@ StringLegalActions() = ["Liar"]
 # Apply action "Liar"
 action: 12
 
-# State 5
-# 6 1 1-6 2-6 Liar
+# State 6
+# 2 2 1-2 2-5 2-6 Liar
 IsTerminal() = True
-History() = [5, 0, 10, 11, 12]
-HistoryString() = "5 0 10 11 12"
+History() = [1, 1, 1, 10, 11, 12]
+HistoryString() = "1 1 1 10 11 12"
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = -4
-InformationStateString(0) = "6 1-6 2-6 Liar"
-InformationStateString(1) = "1 1-6 2-6 Liar"
-InformationStateTensor(0): ◉◯◯◯◯◯◯◉◯◯◯◯◯◯◯◯◯◯◉◉◉
-InformationStateTensor(1): ◯◉◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◉◉◉
-ObservationTensor(0): ◉◯◯◯◯◯◯◉◯◯◯◯◯◯◯◯◯◯◯◉◉
-ObservationTensor(1): ◯◉◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◉◉
-Rewards() = [1.0, -1.0]
-Returns() = [1.0, -1.0]
+InformationStateString(0) = "2 1-2 2-5 2-6 Liar"
+InformationStateString(1) = "2 1-2 2-5 2-6 Liar"
+InformationStateTensor(0): ◉◯◯◉◯◯◯◯◯◉◯◯◯◯◯◯◯◯◉◉◉
+InformationStateTensor(1): ◯◉◯◉◯◯◯◯◯◉◯◯◯◯◯◯◯◯◉◉◉
+ObservationTensor(0): ◉◯◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◉◉
+ObservationTensor(1): ◯◉◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◉◉
+Rewards() = [-1.0, 1.0]
+Returns() = [-1.0, 1.0]

--- a/open_spiel/integration_tests/playthroughs/liars_dice.txt
+++ b/open_spiel/integration_tests/playthroughs/liars_dice.txt
@@ -6,7 +6,7 @@ GameType.information = Information.IMPERFECT_INFORMATION
 GameType.long_name = "Liars Dice"
 GameType.max_num_players = 2
 GameType.min_num_players = 2
-GameType.parameter_specification = ["numdice", "players"]
+GameType.parameter_specification = ["dice_sides", "numdice", "players"]
 GameType.provides_information_state_string = True
 GameType.provides_information_state_tensor = True
 GameType.provides_observation_string = False
@@ -19,7 +19,7 @@ GameType.utility = Utility.ZERO_SUM
 NumDistinctActions() = 13
 PolicyTensorShape() = [13]
 MaxChanceOutcomes() = 6
-GetParameters() = {numdice=1,players=2}
+GetParameters() = {dice_sides=6,numdice=1,players=2}
 NumPlayers() = 2
 MinUtility() = -1.0
 MaxUtility() = 1.0
@@ -51,131 +51,109 @@ ChanceOutcomes() = [{0, 0.166666666667}, {1, 0.166666666667}, {2, 0.166666666667
 LegalActions() = [0, 1, 2, 3, 4, 5]
 StringLegalActions() = ["Roll 1", "Roll 2", "Roll 3", "Roll 4", "Roll 5", "Roll 6"]
 
-# Apply action "Roll 2"
-action: 1
+# Apply action "Roll 6"
+action: 5
 
 # State 1
-# 2 -1 - chance node, current roller is player 1
+# 6 -1 - chance node, current roller is player 1
 IsTerminal() = False
-History() = [1]
-HistoryString() = "1"
+History() = [5]
+HistoryString() = "5"
 IsChanceNode() = True
 IsSimultaneousNode() = False
 CurrentPlayer() = -1
-InformationStateString(0) = "2"
+InformationStateString(0) = "6"
 InformationStateString(1) = "-1"
-InformationStateTensor(0): ◉◯◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯
+InformationStateTensor(0): ◉◯◯◯◯◯◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯
 InformationStateTensor(1): ◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯
-ObservationTensor(0): ◉◯◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯
+ObservationTensor(0): ◉◯◯◯◯◯◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯
 ObservationTensor(1): ◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯
 ChanceOutcomes() = [{0, 0.166666666667}, {1, 0.166666666667}, {2, 0.166666666667}, {3, 0.166666666667}, {4, 0.166666666667}, {5, 0.166666666667}]
 LegalActions() = [0, 1, 2, 3, 4, 5]
 StringLegalActions() = ["Roll 1", "Roll 2", "Roll 3", "Roll 4", "Roll 5", "Roll 6"]
 
-# Apply action "Roll 5"
-action: 4
+# Apply action "Roll 1"
+action: 0
 
 # State 2
-# 2 5
+# 6 1
 IsTerminal() = False
-History() = [1, 4]
-HistoryString() = "1 4"
+History() = [5, 0]
+HistoryString() = "5 0"
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = 0
-InformationStateString(0) = "2"
-InformationStateString(1) = "5"
-InformationStateTensor(0): ◉◯◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯
-InformationStateTensor(1): ◯◉◯◯◯◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯
-ObservationTensor(0): ◉◯◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯
-ObservationTensor(1): ◯◉◯◯◯◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯
+InformationStateString(0) = "6"
+InformationStateString(1) = "1"
+InformationStateTensor(0): ◉◯◯◯◯◯◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯
+InformationStateTensor(1): ◯◉◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯
+ObservationTensor(0): ◉◯◯◯◯◯◯◉◯◯◯◯◯◯◯◯◯◯◯◯◯
+ObservationTensor(1): ◯◉◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯
 Rewards() = [0.0, 0.0]
 Returns() = [0.0, 0.0]
 LegalActions() = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
-StringLegalActions() = ["1-1", "1-2", "1-3", "1-4", "1-5", "1-6", "2-1", "2-2", "2-3", "2-4", "2-5", "2-6"]
+StringLegalActions() = ["1-1", "2-1", "1-2", "2-2", "1-3", "2-3", "1-4", "2-4", "1-5", "2-5", "1-6", "2-6"]
 
-# Apply action "1-2"
-action: 1
+# Apply action "1-6"
+action: 10
 
 # State 3
-# 2 5 1-2
+# 6 1 1-6
 IsTerminal() = False
-History() = [1, 4, 1]
-HistoryString() = "1 4 1"
+History() = [5, 0, 10]
+HistoryString() = "5 0 10"
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = 1
-InformationStateString(0) = "2 1-2"
-InformationStateString(1) = "5 1-2"
-InformationStateTensor(0): ◉◯◯◉◯◯◯◯◯◉◯◯◯◯◯◯◯◯◯◯◯
-InformationStateTensor(1): ◯◉◯◯◯◯◉◯◯◉◯◯◯◯◯◯◯◯◯◯◯
-ObservationTensor(0): ◉◯◯◉◯◯◯◯◯◉◯◯◯◯◯◯◯◯◯◯◯
-ObservationTensor(1): ◯◉◯◯◯◯◉◯◯◉◯◯◯◯◯◯◯◯◯◯◯
+InformationStateString(0) = "6 1-6"
+InformationStateString(1) = "1 1-6"
+InformationStateTensor(0): ◉◯◯◯◯◯◯◉◯◯◯◯◯◯◯◯◯◯◉◯◯
+InformationStateTensor(1): ◯◉◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◉◯◯
+ObservationTensor(0): ◉◯◯◯◯◯◯◉◯◯◯◯◯◯◯◯◯◯◉◯◯
+ObservationTensor(1): ◯◉◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◉◯◯
 Rewards() = [0.0, 0.0]
 Returns() = [0.0, 0.0]
-LegalActions() = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
-StringLegalActions() = ["1-3", "1-4", "1-5", "1-6", "2-1", "2-2", "2-3", "2-4", "2-5", "2-6", "Liar"]
+LegalActions() = [11, 12]
+StringLegalActions() = ["2-6", "Liar"]
 
-# Apply action "1-5"
-action: 4
+# Apply action "2-6"
+action: 11
 
 # State 4
-# 2 5 1-2 1-5
+# 6 1 1-6 2-6
 IsTerminal() = False
-History() = [1, 4, 1, 4]
-HistoryString() = "1 4 1 4"
+History() = [5, 0, 10, 11]
+HistoryString() = "5 0 10 11"
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = 0
-InformationStateString(0) = "2 1-2 1-5"
-InformationStateString(1) = "5 1-2 1-5"
-InformationStateTensor(0): ◉◯◯◉◯◯◯◯◯◉◯◯◉◯◯◯◯◯◯◯◯
-InformationStateTensor(1): ◯◉◯◯◯◯◉◯◯◉◯◯◉◯◯◯◯◯◯◯◯
-ObservationTensor(0): ◉◯◯◉◯◯◯◯◯◉◯◯◉◯◯◯◯◯◯◯◯
-ObservationTensor(1): ◯◉◯◯◯◯◉◯◯◉◯◯◉◯◯◯◯◯◯◯◯
+InformationStateString(0) = "6 1-6 2-6"
+InformationStateString(1) = "1 1-6 2-6"
+InformationStateTensor(0): ◉◯◯◯◯◯◯◉◯◯◯◯◯◯◯◯◯◯◉◉◯
+InformationStateTensor(1): ◯◉◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◉◉◯
+ObservationTensor(0): ◉◯◯◯◯◯◯◉◯◯◯◯◯◯◯◯◯◯◉◉◯
+ObservationTensor(1): ◯◉◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◉◉◯
 Rewards() = [0.0, 0.0]
 Returns() = [0.0, 0.0]
-LegalActions() = [5, 6, 7, 8, 9, 10, 11, 12]
-StringLegalActions() = ["1-6", "2-1", "2-2", "2-3", "2-4", "2-5", "2-6", "Liar"]
-
-# Apply action "2-3"
-action: 8
-
-# State 5
-# 2 5 1-2 1-5 2-3
-IsTerminal() = False
-History() = [1, 4, 1, 4, 8]
-HistoryString() = "1 4 1 4 8"
-IsChanceNode() = False
-IsSimultaneousNode() = False
-CurrentPlayer() = 1
-InformationStateString(0) = "2 1-2 1-5 2-3"
-InformationStateString(1) = "5 1-2 1-5 2-3"
-InformationStateTensor(0): ◉◯◯◉◯◯◯◯◯◉◯◯◉◯◯◯◉◯◯◯◯
-InformationStateTensor(1): ◯◉◯◯◯◯◉◯◯◉◯◯◉◯◯◯◉◯◯◯◯
-ObservationTensor(0): ◉◯◯◉◯◯◯◯◯◯◯◯◉◯◯◯◉◯◯◯◯
-ObservationTensor(1): ◯◉◯◯◯◯◉◯◯◯◯◯◉◯◯◯◉◯◯◯◯
-Rewards() = [0.0, 0.0]
-Returns() = [0.0, 0.0]
-LegalActions() = [9, 10, 11, 12]
-StringLegalActions() = ["2-4", "2-5", "2-6", "Liar"]
+LegalActions() = [12]
+StringLegalActions() = ["Liar"]
 
 # Apply action "Liar"
 action: 12
 
-# State 6
-# 2 5 1-2 1-5 2-3 Liar
+# State 5
+# 6 1 1-6 2-6 Liar
 IsTerminal() = True
-History() = [1, 4, 1, 4, 8, 12]
-HistoryString() = "1 4 1 4 8 12"
+History() = [5, 0, 10, 11, 12]
+HistoryString() = "5 0 10 11 12"
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = -4
-InformationStateString(0) = "2 1-2 1-5 2-3 Liar"
-InformationStateString(1) = "5 1-2 1-5 2-3 Liar"
-InformationStateTensor(0): ◉◯◯◉◯◯◯◯◯◉◯◯◉◯◯◯◉◯◯◯◉
-InformationStateTensor(1): ◯◉◯◯◯◯◉◯◯◉◯◯◉◯◯◯◉◯◯◯◉
-ObservationTensor(0): ◉◯◯◉◯◯◯◯◯◯◯◯◯◯◯◯◉◯◯◯◉
-ObservationTensor(1): ◯◉◯◯◯◯◉◯◯◯◯◯◯◯◯◯◉◯◯◯◉
-Rewards() = [-1.0, 1.0]
-Returns() = [-1.0, 1.0]
+InformationStateString(0) = "6 1-6 2-6 Liar"
+InformationStateString(1) = "1 1-6 2-6 Liar"
+InformationStateTensor(0): ◉◯◯◯◯◯◯◉◯◯◯◯◯◯◯◯◯◯◉◉◉
+InformationStateTensor(1): ◯◉◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◉◉◉
+ObservationTensor(0): ◉◯◯◯◯◯◯◉◯◯◯◯◯◯◯◯◯◯◯◉◉
+ObservationTensor(1): ◯◉◉◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◯◉◉
+Rewards() = [1.0, -1.0]
+Returns() = [1.0, -1.0]


### PR DESCRIPTION
This PR addresses #487 by adding a new bidding rule to Liar's dice. 

This PR also makes the number of faces of each die in play configurable via a `GameParam`. While no tests have been added, I have checked the resulting game against the game generated by our own internal generator, and the games coincide.