### PR TITLE
Exploitability descent example network init patch

### DIFF
--- a/open_spiel/python/examples/exploitability_descent.py
+++ b/open_spiel/python/examples/exploitability_descent.py
@@ -68,14 +68,14 @@ def main(argv):
   # Build the network
   num_hidden = FLAGS.num_hidden
   num_layers = FLAGS.num_layers
-  x = tf.constant(loss_calculator.tabular_policy.state_in, tf.float64)
+  layer = tf.constant(loss_calculator.tabular_policy.state_in, tf.float64)
   for _ in range(num_layers):
     regularizer = (tf.keras.regularizers.l2(l=FLAGS.regularizer_scale))
     layer = tf.layers.dense(
-        x, num_hidden, activation=tf.nn.relu, kernel_regularizer=regularizer)
+        layer, num_hidden, activation=tf.nn.relu, kernel_regularizer=regularizer)
   regularizer = (tf.keras.regularizers.l2(l=FLAGS.regularizer_scale))
   layer = tf.layers.dense(
-      x, game.num_distinct_actions(), kernel_regularizer=regularizer)
+      layer, game.num_distinct_actions(), kernel_regularizer=regularizer)
   tabular_policy = loss_calculator.masked_softmax(layer)
 
   # Build the loss - exploitability descent loss plus regularizer loss


### PR DESCRIPTION
small bug in the exploitability descent example; hidden layers constructed in the network init loop weren't included in the final model