### PR TITLE
Update requirements for TF 2.4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,4 +33,4 @@ dataclasses == 0.7; python_version < "3.7"
 hypothesis==5.38.0
 torch==1.7.0
 six==1.15.0
-testresources=2.0.1
+testresources==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@
 # We do pick the latest version for Tensorflow and Jax on purpose.
 pip >= 20.0.2
 absl-py == 0.10.0
-tensorflow == 2.4.0
+tensorflow == 2.4.1
 IPython == 5.8.0
 tensorflow-probability < 0.8.0, >= 0.7.0
 cvxopt == 1.2.5
@@ -32,3 +32,5 @@ dm-haiku == 0.0.3
 dataclasses == 0.7; python_version < "3.7"
 hypothesis==5.38.0
 torch==1.7.0
+six==1.15.0
+testresources=2.0.1


### PR DESCRIPTION
TF 2.4.0 is crashing (illegal instruction) on a Ubuntu 20.04 installation that is up-to-date, and causing problems with pip installation for a release. This was required to finally fix TF, and is the most recent version.