### PR TITLE
Moved shared methods of outcome and external mccfrs into base class

### DIFF
--- a/open_spiel/python/algorithms/cfr.py
+++ b/open_spiel/python/algorithms/cfr.py
@@ -114,7 +114,7 @@ def _update_average_policy(average_policy, info_state_nodes):
 
 
 class _CFRSolverBase(object):
-  r"""A base classe for both CFR and CFR-BR.
+  r"""A base class for both CFR and CFR-BR.
 
   The main iteration loop is implemented in `evaluate_and_update_policy`:
 

--- a/open_spiel/python/algorithms/external_sampling_mccfr.py
+++ b/open_spiel/python/algorithms/external_sampling_mccfr.py
@@ -29,13 +29,11 @@ class AverageType(enum.Enum):
   FULL = 1
 
 
-class ExternalSamplingSolver(object):
+class ExternalSamplingSolver(mccfr._MCCFRSolverBase):
   """An implementation of external sampling MCCFR."""
 
   def __init__(self, game, average_type=AverageType.SIMPLE):
-    self._game = game
-    self._infostates = {}  # infostate keys -> [regrets, avg strat]
-    self._num_players = game.num_players()
+    super().__init__(game)
     # How to average the strategy. The 'simple' type does the averaging for
     # player i + 1 mod num_players on player i's regret update pass; in two
     # players this corresponds to the standard implementation (updating the
@@ -71,67 +69,6 @@ class ExternalSamplingSolver(object):
     if self._average_type == AverageType.FULL:
       reach_probs = np.ones(self._num_players, dtype=np.float64)
       self._full_update_average(self._game.new_initial_state(), reach_probs)
-
-  def _lookup_infostate_info(self, info_state_key, num_legal_actions):
-    """Looks up an information set table for the given key.
-
-    Args:
-      info_state_key: information state key (string identifier).
-      num_legal_actions: number of legal actions at this information state.
-
-    Returns:
-      A list of:
-        - the average regrets as a numpy array of shape [num_legal_actions]
-        - the average strategy as a numpy array of shape
-        [num_legal_actions].
-          The average is weighted using `my_reach`
-    """
-    retrieved_infostate = self._infostates.get(info_state_key, None)
-    if retrieved_infostate is not None:
-      return retrieved_infostate
-
-    # Start with a small amount of regret and total accumulation, to give a
-    # uniform policy: this will get erased fast.
-    self._infostates[info_state_key] = [
-        np.ones(num_legal_actions, dtype=np.float64) / 1000.0,
-        np.ones(num_legal_actions, dtype=np.float64) / 1000.0,
-    ]
-    return self._infostates[info_state_key]
-
-  def _add_regret(self, info_state_key, action_idx, amount):
-    self._infostates[info_state_key][mccfr.REGRET_INDEX][action_idx] += amount
-
-  def _add_avstrat(self, info_state_key, action_idx, amount):
-    self._infostates[info_state_key][
-        mccfr.AVG_POLICY_INDEX][action_idx] += amount
-
-  def average_policy(self):
-    """Computes the average policy, containing the policy for all players.
-
-    Returns:
-      An average policy instance that should only be used during
-      the lifetime of solver object.
-    """
-    return mccfr.AveragePolicy(self._infostates)
-
-  def _regret_matching(self, regrets, num_legal_actions):
-    """Applies regret matching to get a policy.
-
-    Args:
-      regrets: numpy array of regrets for each action.
-      num_legal_actions: number of legal actions at this state.
-
-    Returns:
-      numpy array of the policy indexed by the index of legal action in the
-      list.
-    """
-    positive_regrets = np.maximum(regrets,
-                                  np.zeros(num_legal_actions, dtype=np.float64))
-    sum_pos_regret = positive_regrets.sum()
-    if sum_pos_regret <= 0:
-      return np.ones(num_legal_actions, dtype=np.float64) / num_legal_actions
-    else:
-      return positive_regrets / sum_pos_regret
 
   def _full_update_average(self, state, reach_probs):
     """Performs a full update average.

--- a/open_spiel/python/algorithms/mccfr.py
+++ b/open_spiel/python/algorithms/mccfr.py
@@ -15,6 +15,7 @@
 """Python base module for the implementations of Monte Carlo Counterfactual Regret Minimization."""
 
 from open_spiel.python import policy
+import numpy as np
 
 REGRET_INDEX = 0
 AVG_POLICY_INDEX = 1
@@ -30,7 +31,6 @@ class AveragePolicy(policy.Policy):
 
   def action_probabilities(self, state, player_id=None):
     """Returns the MCCFR average policy for a player in a state.
-
     If the policy is not defined for the provided state, a uniform
     random policy is returned.
 
@@ -57,3 +57,72 @@ class AveragePolicy(policy.Policy):
         retrieved_infostate[AVG_POLICY_INDEX] /
         retrieved_infostate[AVG_POLICY_INDEX].sum())
     return {legal_actions[i]: avstrat[i] for i in range(len(legal_actions))}
+
+
+class _MCCFRSolverBase(object):
+  """A base class for both outcome MCCFR and external MCCFR"""
+
+  def __init__(self, game):
+    self._game = game
+    self._infostates = {}  # infostate keys -> [regrets, avg strat]
+    self._num_players = game.num_players()
+
+  def _lookup_infostate_info(self, info_state_key, num_legal_actions):
+    """Looks up an information set table for the given key.
+
+    Args:
+      info_state_key: information state key (string identifier).
+      num_legal_actions: number of legal actions at this information state.
+
+    Returns:
+      A list of:
+        - the average regrets as a numpy array of shape [num_legal_actions]
+        - the average strategy as a numpy array of shape
+        [num_legal_actions].
+          The average is weighted using `my_reach`
+    """
+    retrieved_infostate = self._infostates.get(info_state_key, None)
+    if retrieved_infostate is not None:
+      return retrieved_infostate
+
+    # Start with a small amount of regret and total accumulation, to give a
+    # uniform policy: this will get erased fast.
+    self._infostates[info_state_key] = [
+        np.ones(num_legal_actions, dtype=np.float64) / 1e6,
+        np.ones(num_legal_actions, dtype=np.float64) / 1e6,
+    ]
+    return self._infostates[info_state_key]
+
+  def _add_regret(self, info_state_key, action_idx, amount):
+    self._infostates[info_state_key][REGRET_INDEX][action_idx] += amount
+
+  def _add_avstrat(self, info_state_key, action_idx, amount):
+    self._infostates[info_state_key][AVG_POLICY_INDEX][action_idx] += amount
+
+  def average_policy(self):
+    """Computes the average policy, containing the policy for all players.
+
+    Returns:
+      An average policy instance that should only be used during
+      the lifetime of solver object.
+    """
+    return AveragePolicy(self._infostates)
+
+  def _regret_matching(self, regrets, num_legal_actions):
+    """Applies regret matching to get a policy.
+
+    Args:
+      regrets: numpy array of regrets for each action.
+      num_legal_actions: number of legal actions at this state.
+
+    Returns:
+      numpy array of the policy indexed by the index of legal action in the
+      list.
+    """
+    positive_regrets = np.maximum(regrets,
+                                  np.zeros(num_legal_actions, dtype=np.float64))
+    sum_pos_regret = positive_regrets.sum()
+    if sum_pos_regret <= 0:
+      return np.ones(num_legal_actions, dtype=np.float64) / num_legal_actions
+    else:
+      return positive_regrets / sum_pos_regret

--- a/open_spiel/python/algorithms/outcome_sampling_mccfr.py
+++ b/open_spiel/python/algorithms/outcome_sampling_mccfr.py
@@ -23,13 +23,11 @@ import open_spiel.python.algorithms.mccfr as mccfr
 import pyspiel
 
 
-class OutcomeSamplingSolver(object):
+class OutcomeSamplingSolver(mccfr._MCCFRSolverBase):
   """An implementation of outcome sampling MCCFR."""
 
   def __init__(self, game):
-    self._game = game
-    self._infostates = {}  # infostate keys -> [regrets, avg strat]
-    self._num_players = game.num_players()
+    super().__init__(game)
     # This is the epsilon exploration factor. When sampling episodes, the
     # updating player will sampling according to expl * uniform + (1 - expl) *
     # current_policy.
@@ -50,67 +48,6 @@ class OutcomeSamplingSolver(object):
       state = self._game.new_initial_state()
       self._episode(
           state, update_player, my_reach=1.0, opp_reach=1.0, sample_reach=1.0)
-
-  def _lookup_infostate_info(self, info_state_key, num_legal_actions):
-    """Looks up an information set table for the given key.
-
-    Args:
-      info_state_key: information state key (string identifier).
-      num_legal_actions: number of legal actions at this information state.
-
-    Returns:
-      A list of:
-        - the average regrets as a numpy array of shape [num_legal_actions]
-        - the average strategy as a numpy array of shape
-        [num_legal_actions].
-          The average is weighted using `my_reach`
-    """
-    retrieved_infostate = self._infostates.get(info_state_key, None)
-    if retrieved_infostate is not None:
-      return retrieved_infostate
-
-    # Start with a small amount of regret and total accumulation, to give a
-    # uniform policy: this will get erased fast.
-    self._infostates[info_state_key] = [
-        np.ones(num_legal_actions, dtype=np.float64) / 1e6,
-        np.ones(num_legal_actions, dtype=np.float64) / 1e6,
-    ]
-    return self._infostates[info_state_key]
-
-  def _add_regret(self, info_state_key, action_idx, amount):
-    self._infostates[info_state_key][mccfr.REGRET_INDEX][action_idx] += amount
-
-  def _add_avstrat(self, info_state_key, action_idx, amount):
-    self._infostates[info_state_key][
-        mccfr.AVG_POLICY_INDEX][action_idx] += amount
-
-  def average_policy(self):
-    """Computes the average policy, containing the policy for all players.
-
-    Returns:
-      An average policy instance should only be used during
-      the lifetime of solver object.
-    """
-    return mccfr.AveragePolicy(self._infostates)
-
-  def _regret_matching(self, regrets, num_legal_actions):
-    """Applies regret matching to get a policy.
-
-    Args:
-      regrets: numpy array of regrets for each action.
-      num_legal_actions: number of legal actions at this state.
-
-    Returns:
-      numpy array of the policy indexed by the index of legal action in the
-      list.
-    """
-    positive_regrets = np.maximum(regrets,
-                                  np.zeros(num_legal_actions, dtype=np.float64))
-    sum_pos_regret = positive_regrets.sum()
-    if sum_pos_regret <= 0:
-      return np.ones(num_legal_actions, dtype=np.float64) / num_legal_actions
-    else:
-      return positive_regrets / sum_pos_regret
 
   def _baseline(self, state, info_state, aidx):  # pylint: disable=unused-argument
     # Default to vanilla outcome sampling


### PR DESCRIPTION
I moved the shared methods of outcome and external mccfrs into the base class `_MCCFRSolverBase`, implemented in the module `mccfr.py`. Specifically, the methods moved are the following: `_lookup_infostate_info`, `_add_regret`, `_add_avstrat`, `average_policy`, `_regret_matching`.

Also, I noticed that the external sampling version had an initialization constant of `np.ones(num_legal_actions, dtype=np.float64) / 1000` for regrets and average strategy of a new infostate rather than `np.ones(num_legal_actions, dtype=np.float64) / 1e6` (method `_lookup_infostate_info`). I moved to `1/1e6`, as it is done on the C++ side.
As a result, the external mccfr test outputs slightly changed. I report here the results (comparison can be done with results reported [here](https://github.com/deepmind/open_spiel/pull/513#event-4389559891) ):
Kuhn2P, conv = 0.742222018437585
Kuhn2P, conv = 0.652778289351194
Kuhn3P, conv = 1.2682291839371136
Kuhn3P, conv = 1.7094910613902536
Leduc2P, conv = 4.887937425632959
Leduc2P, conv = 4.813561937379362

The outcome mccfr test outputs remained the same (as expected).