### PR TITLE
mccfr.AveragePolicy: make to_tabular() work

### DIFF
--- a/open_spiel/python/algorithms/external_sampling_mccfr.py
+++ b/open_spiel/python/algorithms/external_sampling_mccfr.py
@@ -112,7 +112,7 @@ class ExternalSamplingSolver(object):
       An average policy instance that should only be used during
       the lifetime of solver object.
     """
-    return mccfr.AveragePolicy(self._infostates)
+    return mccfr.AveragePolicy(self._game, list(range(self._num_players)), self._infostates)
 
   def _regret_matching(self, regrets, num_legal_actions):
     """Applies regret matching to get a policy.

--- a/open_spiel/python/algorithms/external_sampling_mccfr_test.py
+++ b/open_spiel/python/algorithms/external_sampling_mccfr_test.py
@@ -39,6 +39,10 @@ class ExternalSamplingMCCFRTest(absltest.TestCase):
     conv = exploitability.nash_conv(game, es_solver.average_policy())
     print("Leduc2P, conv = {}".format(conv))
     self.assertLess(conv, 5)
+    # ensure that to_tabular() works on the returned policy and the tabular policy is equivalent
+    tabular_policy = es_solver.average_policy().to_tabular()
+    conv2 = exploitability.nash_conv(game, tabular_policy)
+    self.assertEqual(conv, conv2)
 
   def test_external_sampling_leduc_2p_full(self):
     np.random.seed(SEED)

--- a/open_spiel/python/algorithms/mccfr.py
+++ b/open_spiel/python/algorithms/mccfr.py
@@ -23,9 +23,10 @@ AVG_POLICY_INDEX = 1
 class AveragePolicy(policy.Policy):
   """A policy object representing the average policy for MCCFR algorithms."""
 
-  def __init__(self, infostates):
+  def __init__(self, game, player_ids, infostates):
     # Do not create a copy of the dictionary
     # but work on the same object
+    super().__init__(game, player_ids)
     self._infostates = infostates
 
   def action_probabilities(self, state, player_id=None):

--- a/open_spiel/python/algorithms/outcome_sampling_mccfr.py
+++ b/open_spiel/python/algorithms/outcome_sampling_mccfr.py
@@ -91,7 +91,7 @@ class OutcomeSamplingSolver(object):
       An average policy instance should only be used during
       the lifetime of solver object.
     """
-    return mccfr.AveragePolicy(self._infostates)
+    return mccfr.AveragePolicy(self._game, list(range(self._num_players)), self._infostates)
 
   def _regret_matching(self, regrets, num_legal_actions):
     """Applies regret matching to get a policy.

--- a/open_spiel/python/algorithms/outcome_sampling_mccfr_test.py
+++ b/open_spiel/python/algorithms/outcome_sampling_mccfr_test.py
@@ -55,6 +55,10 @@ class OutcomeSamplingMCCFRTest(absltest.TestCase):
     conv = exploitability.nash_conv(game, os_solver.average_policy())
     print("Kuhn2P, conv = {}".format(conv))
     self.assertLess(conv, 0.17)
+    # ensure that to_tabular() works on the returned policy and the tabular policy is equivalent
+    tabular_policy = os_solver.average_policy().to_tabular()
+    conv2 = exploitability.nash_conv(game, tabular_policy)
+    self.assertEqual(conv, conv2)
 
   def test_outcome_sampling_kuhn_3p(self):
     np.random.seed(SEED)


### PR DESCRIPTION
`mccfr.AveragePolicy.to_tabular()` was erroring with `AttributeError: 'AveragePolicy' object has no attribute 'game'`.  This fixes it and adds 2 regression tests.