### PR TITLE
Move GetOptimalPolicy for the game of Kuhn Poker to kuhn_poker namesp…

### DIFF
--- a/open_spiel/algorithms/best_response_test.cc
+++ b/open_spiel/algorithms/best_response_test.cc
@@ -39,29 +39,6 @@ namespace {
 
 using InfostatesAndActions = std::vector<std::pair<std::string, Action>>;
 
-// The optimal Kuhn policy is taken directly from the Python implementation in
-// open_spiel/python/algorithms/exploitability_test.py. In it, the player bets
-// with probability alpha with the jack.
-TabularPolicy GetOptimalKuhnPolicy(double alpha) {
-  double three_alpha = 3 * alpha;
-  std::unordered_map<std::string, ActionsAndProbs> policy;
-  // Player 0
-  policy["0"] = {{0, 1 - alpha}, {1, alpha}};
-  policy["0pb"] = {{0, 1}, {1, 0}};
-  policy["1"] = {{0, 1}, {1, 0}};
-  policy["1pb"] = {{0, 2. / 3. - alpha}, {1, 1. / 3. + alpha}};
-  policy["2"] = {{0, 1 - three_alpha}, {1, three_alpha}};
-  policy["2pb"] = {{0, 0}, {1, 1}};
-
-  // Player 1
-  policy["0p"] = {{0, 2. / 3.}, {1, 1. / 3.}};
-  policy["0b"] = {{0, 1}, {1, 0}};
-  policy["1p"] = {{0, 1}, {1, 0}};
-  policy["1b"] = {{0, 2. / 3.}, {1, 1. / 3.}};
-  policy["2p"] = {{0, 0}, {1, 1}};
-  policy["2b"] = {{0, 0}, {1, 1}};
-  return TabularPolicy(policy);
-}
 
 // Correct values come from the existing Python implementation in
 // open_spiel/python/algorithms/exploitability.py.
@@ -456,7 +433,7 @@ void KuhnPokerUniformBestResponseAfterSwitchingPolicies() {
 // open_spiel/algorithms/exploitability.py.
 void KuhnPokerOptimalBestResponsePid0() {
   std::shared_ptr<const Game> game = LoadGame("kuhn_poker");
-  TabularPolicy policy = GetOptimalKuhnPolicy(/*alpha=*/0.2);
+  TabularPolicy policy = kuhn_poker::GetOptimalPolicy(/*alpha=*/0.2);
   InfostatesAndActions actual_best_responses = {
       {"0", 0}, {"0pb", 0}, {"1", 0}, {"1pb", 0}, {"2", 0}, {"2pb", 1}};
   CheckBestResponseAgainstGoldenPolicy(*game, /*best_responder=*/Player{0},
@@ -467,7 +444,7 @@ void KuhnPokerOptimalBestResponsePid0() {
 // open_spiel/algorithms/exploitability.py.
 void KuhnPokerOptimalBestResponsePid1() {
   std::shared_ptr<const Game> game = LoadGame("kuhn_poker");
-  TabularPolicy policy = GetOptimalKuhnPolicy(/*alpha=*/0.2);
+  TabularPolicy policy = kuhn_poker::GetOptimalPolicy(/*alpha=*/0.2);
   InfostatesAndActions actual_best_responses = {
       {"0b", 0}, {"0p", 0}, {"1p", 0}, {"1b", 0}, {"2p", 1}, {"2b", 1}};
   CheckBestResponseAgainstGoldenPolicy(*game, /*best_responder=*/Player{1},
@@ -575,7 +552,7 @@ void KuhnPokerEFGUniformValueTestPid1() {
 
 void KuhnPokerOptimalValueTestPid0() {
   std::shared_ptr<const Game> game = LoadGame("kuhn_poker");
-  TabularPolicy policy = GetOptimalKuhnPolicy(/*alpha=*/0.2);
+  TabularPolicy policy = kuhn_poker::GetOptimalPolicy(/*alpha=*/0.2);
   std::vector<std::pair<std::string, double>> histories_and_values =
       GetKuhnOptimalBestResponseValuesPid0();
   CheckBestResponseValuesAgainstGoldenValues(
@@ -584,7 +561,7 @@ void KuhnPokerOptimalValueTestPid0() {
 
 void KuhnPokerOptimalValueTestPid1() {
   std::shared_ptr<const Game> game = LoadGame("kuhn_poker");
-  TabularPolicy policy = GetOptimalKuhnPolicy(/*alpha=*/0.2);
+  TabularPolicy policy = kuhn_poker::GetOptimalPolicy(/*alpha=*/0.2);
   std::vector<std::pair<std::string, double>> histories_and_values =
       GetKuhnOptimalBestResponseValuesPid1();
   CheckBestResponseValuesAgainstGoldenValues(

--- a/open_spiel/algorithms/history_tree_test.cc
+++ b/open_spiel/algorithms/history_tree_test.cc
@@ -405,29 +405,6 @@ void TestGetAllInfoSetsHasRightCounterFactualProbsAlwaysFoldPid1() {
                            /*best_responder=*/Player{1});
 }
 
-// The optimal Kuhn policy is taken directly from the Python implementation in
-// open_spiel/python/algorithms/exploitability_test.py. In it, the player bets
-// with probability alpha with the jack.
-TabularPolicy GetOptimalKuhnPolicy(double alpha) {
-  double three_alpha = 3 * alpha;
-  std::unordered_map<std::string, ActionsAndProbs> policy_table;
-  // Player 0
-  policy_table["0"] = {{0, 1 - alpha}, {1, alpha}};
-  policy_table["0pb"] = {{0, 1}, {1, 0}};
-  policy_table["1"] = {{0, 1}, {1, 0}};
-  policy_table["1pb"] = {{0, 2. / 3. - alpha}, {1, 1. / 3. + alpha}};
-  policy_table["2"] = {{0, 1 - three_alpha}, {1, three_alpha}};
-  policy_table["2pb"] = {{0, 0}, {1, 1}};
-
-  // Player 1
-  policy_table["0p"] = {{0, 2. / 3.}, {1, 1. / 3.}};
-  policy_table["0b"] = {{0, 1}, {1, 0}};
-  policy_table["1p"] = {{0, 1}, {1, 0}};
-  policy_table["1b"] = {{0, 2. / 3.}, {1, 1. / 3.}};
-  policy_table["2p"] = {{0, 0}, {1, 1}};
-  policy_table["2b"] = {{0, 0}, {1, 1}};
-  return TabularPolicy(policy_table);
-}
 
 // Verifies that GetAllInfoSets returns the correct counter-factual
 // probabilities when calculating a best-response as player 0 against the
@@ -443,7 +420,7 @@ void TestGetAllInfoSetsHasRightCounterFactualProbsOptimalPid0() {
       {"2, 0", 0.166666667}, {"2, 0, 0, 1", 0.055555556},
       {"2, 1", 0.166666667}, {"2, 1, 0, 1", 0.000000000}};
   std::shared_ptr<const Game> game = LoadGame("kuhn_poker");
-  TabularPolicy policy = GetOptimalKuhnPolicy(/*alpha=*/0.2);
+  TabularPolicy policy = kuhn_poker::GetOptimalPolicy(/*alpha=*/0.2);
   CheckCounterFactualProbs(*game, policy, histories_and_probs,
                            /*best_responder=*/Player{0});
 }
@@ -462,7 +439,7 @@ void TestGetAllInfoSetsHasRightCounterFactualProbsOptimalPid1() {
       {"2, 0, 0", 0.066666667}, {"2, 0, 1", 0.100000000},
       {"2, 1, 0", 0.066666667}, {"2, 1, 1", 0.100000000}};
   std::shared_ptr<const Game> game = LoadGame("kuhn_poker");
-  TabularPolicy policy = GetOptimalKuhnPolicy(/*alpha=*/0.2);
+  TabularPolicy policy = kuhn_poker::GetOptimalPolicy(/*alpha=*/0.2);
   CheckCounterFactualProbs(*game, policy, histories_and_probs,
                            /*best_responder=*/Player{1});
 }

--- a/open_spiel/algorithms/tabular_exploitability_test.cc
+++ b/open_spiel/algorithms/tabular_exploitability_test.cc
@@ -38,30 +38,6 @@ namespace {
 
 using InfostatesAndActions = std::vector<std::pair<std::string, Action>>;
 
-// The optimal Kuhn policy is taken directly from the Python implementation in
-// open_spiel/python/algorithms/exploitability_test.py. In it, the player bets
-// with probability alpha with the jack.
-TabularPolicy GetOptimalKuhnPolicy(double alpha) {
-  double three_alpha = 3 * alpha;
-  std::unordered_map<std::string, ActionsAndProbs> policy;
-  // Player 0
-  policy["0"] = {{0, 1 - alpha}, {1, alpha}};
-  policy["0pb"] = {{0, 1}, {1, 0}};
-  policy["1"] = {{0, 1}, {1, 0}};
-  policy["1pb"] = {{0, 2. / 3. - alpha}, {1, 1. / 3. + alpha}};
-  policy["2"] = {{0, 1 - three_alpha}, {1, three_alpha}};
-  policy["2pb"] = {{0, 0}, {1, 1}};
-
-  // Player 1
-  policy["0p"] = {{0, 2. / 3.}, {1, 1. / 3.}};
-  policy["0b"] = {{0, 1}, {1, 0}};
-  policy["1p"] = {{0, 1}, {1, 0}};
-  policy["1b"] = {{0, 2. / 3.}, {1, 1. / 3.}};
-  policy["2p"] = {{0, 0}, {1, 1}};
-  policy["2b"] = {{0, 0}, {1, 1}};
-  return TabularPolicy(policy);
-}
-
 // Correct values come from the existing Python implementation in
 // open_spiel/python/algorithms/exploitability.py.
 std::vector<std::pair<std::string, double>>
@@ -374,7 +350,7 @@ void KuhnPokerUniformBestResponseAfterSwitchingPolicies() {
 // open_spiel/algorithms/exploitability.py.
 void KuhnPokerOptimalBestResponsePid0() {
   std::shared_ptr<const Game> game = LoadGame("kuhn_poker");
-  TabularPolicy policy = GetOptimalKuhnPolicy(/*alpha=*/0.2);
+  TabularPolicy policy = kuhn_poker::GetOptimalPolicy(/*alpha=*/0.2);
   InfostatesAndActions actual_best_responses = {
       {"0", 0}, {"0pb", 0}, {"1", 0}, {"1pb", 0}, {"2", 0}, {"2pb", 1}};
   CheckBestResponseAgainstGoldenPolicy(*game, /*best_responder=*/Player{0},
@@ -385,7 +361,7 @@ void KuhnPokerOptimalBestResponsePid0() {
 // open_spiel/algorithms/exploitability.py.
 void KuhnPokerOptimalBestResponsePid1() {
   std::shared_ptr<const Game> game = LoadGame("kuhn_poker");
-  TabularPolicy policy = GetOptimalKuhnPolicy(/*alpha=*/0.2);
+  TabularPolicy policy = kuhn_poker::GetOptimalPolicy(/*alpha=*/0.2);
   InfostatesAndActions actual_best_responses = {
       {"0b", 0}, {"0p", 0}, {"1p", 0}, {"1b", 0}, {"2p", 1}, {"2b", 1}};
   CheckBestResponseAgainstGoldenPolicy(*game, /*best_responder=*/Player{1},
@@ -489,7 +465,7 @@ int main(int argc, char** argv) {
   // The optimal policy is a Nash equilibrium, so there are 0 gains available
   // for either player by switching.
   auto optimal_factory = [](const open_spiel::Game&) {
-    return open_spiel::algorithms::GetOptimalKuhnPolicy(/*alpha=*/0.2);
+    return open_spiel::kuhn_poker::GetOptimalPolicy(/*alpha=*/0.2);
   };
   open_spiel::algorithms::TestExploitability("kuhn_poker", optimal_factory, 0.);
   open_spiel::algorithms::TestNashConv("kuhn_poker", optimal_factory, 0.);

--- a/open_spiel/games/kuhn_poker.cc
+++ b/open_spiel/games/kuhn_poker.cc
@@ -442,5 +442,30 @@ TabularPolicy GetAlwaysBetPolicy(const Game& game) {
   return GetPrefActionPolicy(game, {ActionType::kBet});
 }
 
+TabularPolicy GetOptimalPolicy(double alpha) {
+  SPIEL_CHECK_GE(alpha, 0.);
+  SPIEL_CHECK_LE(alpha, 1./3);
+  const double three_alpha = 3 * alpha;
+  std::unordered_map<std::string, ActionsAndProbs> policy;
+
+  // All infostates have two actions: Pass (0) and Bet (1).
+  // Player 0
+  policy["0"]   = {{0, 1 - alpha},        {1, alpha}};
+  policy["0pb"] = {{0, 1},                {1, 0}};
+  policy["1"]   = {{0, 1},                {1, 0}};
+  policy["1pb"] = {{0, 2. / 3. - alpha},  {1, 1. / 3. + alpha}};
+  policy["2"]   = {{0, 1 - three_alpha},  {1, three_alpha}};
+  policy["2pb"] = {{0, 0},                {1, 1}};
+
+  // Player 1
+  policy["0p"]  = {{0, 2. / 3.},          {1, 1. / 3.}};
+  policy["0b"]  = {{0, 1},                {1, 0}};
+  policy["1p"]  = {{0, 1},                {1, 0}};
+  policy["1b"]  = {{0, 2. / 3.},          {1, 1. / 3.}};
+  policy["2p"]  = {{0, 0},                {1, 1}};
+  policy["2b"]  = {{0, 0},                {1, 1}};
+  return TabularPolicy(policy);
+}
+
 }  // namespace kuhn_poker
 }  // namespace open_spiel

--- a/open_spiel/games/kuhn_poker.h
+++ b/open_spiel/games/kuhn_poker.h
@@ -132,6 +132,10 @@ TabularPolicy GetAlwaysPassPolicy(const Game& game);
 // Returns policy that always bets.
 TabularPolicy GetAlwaysBetPolicy(const Game& game);
 
+// The optimal Kuhn policy as stated at https://en.wikipedia.org/wiki/Kuhn_poker
+// The Nash equilibrium is parametrized by alpha \in [0, 1/3].
+TabularPolicy GetOptimalPolicy(double alpha);
+
 }  // namespace kuhn_poker
 }  // namespace open_spiel
 

--- a/open_spiel/python/CMakeLists.txt
+++ b/open_spiel/python/CMakeLists.txt
@@ -21,6 +21,8 @@ set(PYTHON_BINDINGS ${PYTHON_BINDINGS}
   pybind11/games_bridge.h
   pybind11/games_chess.cc
   pybind11/games_chess.h
+  pybind11/games_kuhn_poker.cc
+  pybind11/games_kuhn_poker.h
   pybind11/games_negotiation.cc
   pybind11/games_negotiation.h
   pybind11/games_tarok.cc

--- a/open_spiel/python/games/data.py
+++ b/open_spiel/python/games/data.py
@@ -38,24 +38,4 @@ def kuhn_nash_equilibrium(alpha):
   """
   if not 0 <= alpha <= 1 / 3:
     raise ValueError("alpha ({}) must be in [0, 1/3]".format(alpha))
-  bet_probability = {
-      # Player 0
-      "0": alpha,
-      "0pb": 0,
-      "1": 0,
-      "1pb": 1 / 3 + alpha,
-      "2": 3 * alpha,
-      "2pb": 1,
-      # Player 1
-      "0p": 1 / 3,
-      "0b": 0,
-      "1p": 0,
-      "1b": 1 / 3,
-      "2p": 1,
-      "2b": 1,
-  }
-  game = pyspiel.load_game("kuhn_poker")
-  tabular_policy = policy.TabularPolicy(game)
-  for state, p in bet_probability.items():
-    tabular_policy.policy_for_key(state)[:] = [1 - p, p]
-  return tabular_policy
+  return pyspiel.kuhn_poker.get_optimal_policy(alpha)

--- a/open_spiel/python/pybind11/games_kuhn_poker.cc
+++ b/open_spiel/python/pybind11/games_kuhn_poker.cc
@@ -1,0 +1,25 @@
+// Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "open_spiel/python/pybind11/games_kuhn_poker.h"
+
+#include "open_spiel/games/kuhn_poker.h"
+#include "pybind11/include/pybind11/pybind11.h"
+
+namespace py = ::pybind11;
+
+void open_spiel::init_pyspiel_games_kuhn_poker(py::module& m) {
+  py::module sub = m.def_submodule("kuhn_poker");
+  sub.def("get_optimal_policy", &kuhn_poker::GetOptimalPolicy);
+}

--- a/open_spiel/python/pybind11/games_kuhn_poker.h
+++ b/open_spiel/python/pybind11/games_kuhn_poker.h
@@ -1,0 +1,25 @@
+// Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OPEN_SPIEL_PYTHON_PYBIND11_GAMES_KUHN_POKER_H_
+#define OPEN_SPIEL_PYTHON_PYBIND11_GAMES_KUHN_POKER_H_
+
+#include "pybind11/include/pybind11/pybind11.h"
+
+// Initialze the Python interface for games/negotiation.
+namespace open_spiel {
+void init_pyspiel_games_kuhn_poker(::pybind11::module &m);
+}
+
+#endif  // OPEN_SPIEL_PYTHON_PYBIND11_GAMES_KUHN_POKER_H_

--- a/open_spiel/python/pybind11/pyspiel.cc
+++ b/open_spiel/python/pybind11/pyspiel.cc
@@ -34,6 +34,7 @@
 #include "open_spiel/python/pybind11/games_backgammon.h"
 #include "open_spiel/python/pybind11/games_bridge.h"
 #include "open_spiel/python/pybind11/games_chess.h"
+#include "open_spiel/python/pybind11/games_kuhn_poker.h"
 #include "open_spiel/python/pybind11/games_negotiation.h"
 #include "open_spiel/python/pybind11/games_tarok.h"
 #include "open_spiel/python/pybind11/observation_history.h"
@@ -655,6 +656,7 @@ PYBIND11_MODULE(pyspiel, m) {
   init_pyspiel_games_backgammon(m);         // Backgammon game.
   init_pyspiel_games_bridge(m);  // Game-specific functions for bridge.
   init_pyspiel_games_chess(m);   // Chess game.
+  init_pyspiel_games_kuhn_poker(m);   // Kuhn Poker game.
   init_pyspiel_games_negotiation(m);  // Negotiation game.
   init_pyspiel_games_tarok(m);   // Game-specific functions for tarok.
   init_pyspiel_observer(m);      // Observers and observations.


### PR DESCRIPTION
Move GetOptimalPolicy for the game of Kuhn Poker to kuhn_poker namespace. Expose the same function via pybind.

The file `open_spiel/python/games/data.py` can be also deleted, along with its test (which can be moved to c++ side). I can do this in a subsequent PR.