### PR TITLE
Fix typo in argslib

### DIFF
--- a/open_spiel/scripts/argslib.sh
+++ b/open_spiel/scripts/argslib.sh
@@ -107,7 +107,7 @@ function _check_parse_value {
 
 function _parse_arg {
   # one argment: --name=value
-  IFS="=" read -ra parts <<< $@
+  IFS="=" read -ra parts <<< "$@"
   [ ${#parts[@]} -eq 2 ] || _die "Incorrect syntax: $@"
   for (( i=0; i<$argslib_n; i++ ))
   do


### PR DESCRIPTION
After the last fix to argslib, I accidentally broke the build on MacOS. 

This is a fix that changes the parse argument function to use quoted string and only look at the first argument.