### PR TITLE
Ensure move_number_ is decremented by UndoAction().

### DIFF
--- a/open_spiel/games/backgammon.cc
+++ b/open_spiel/games/backgammon.cc
@@ -510,6 +510,7 @@ void BackgammonState::UndoAction(int player, Action action) {
   }
   turn_history_info_.pop_back();
   history_.pop_back();
+  --move_number_;
 }
 
 Action BackgammonState::TranslateAction(int from1, int from2,

--- a/open_spiel/games/breakthrough.cc
+++ b/open_spiel/games/breakthrough.cc
@@ -371,6 +371,7 @@ void BreakthroughState::UndoAction(Player player, Action action) {
     }
   }
   history_.pop_back();
+  --move_number_;
 }
 
 std::unique_ptr<State> BreakthroughState::Clone() const {

--- a/open_spiel/games/catch.cc
+++ b/open_spiel/games/catch.cc
@@ -175,6 +175,7 @@ void CatchState::UndoAction(Player player, Action move) {
       std::min(std::max(paddle_col_ - direction, 0), num_columns_ - 1);
   --ball_row_;
   history_.pop_back();
+  --move_number_;
 }
 
 std::unique_ptr<State> CatchState::Clone() const {

--- a/open_spiel/games/chess.cc
+++ b/open_spiel/games/chess.cc
@@ -360,6 +360,7 @@ void ChessState::UndoAction(Player player, Action action) {
   --repetitions_[current_board_.HashValue()];
   moves_history_.pop_back();
   history_.pop_back();
+  --move_number_;
   current_board_ = start_board_;
   for (const Move& move : moves_history_) {
     current_board_.ApplyMove(move);

--- a/open_spiel/games/cliff_walking.cc
+++ b/open_spiel/games/cliff_walking.cc
@@ -178,6 +178,7 @@ void CliffWalkingState::UndoAction(Player player, Action move) {
   player_col_ = std::min(std::max(player_col_, 0), width_ - 1);
   --time_counter_;
   history_.pop_back();
+  --move_number_;
 }
 
 std::unique_ptr<State> CliffWalkingState::Clone() const {

--- a/open_spiel/games/dark_chess.cc
+++ b/open_spiel/games/dark_chess.cc
@@ -539,6 +539,7 @@ void DarkChessState::UndoAction(Player player, Action action) {
   --repetitions_[current_board_.HashValue()];
   moves_history_.pop_back();
   history_.pop_back();
+  --move_number_;
   current_board_ = start_board_;
   for (const chess::Move& move : moves_history_) {
     current_board_.ApplyMove(move);

--- a/open_spiel/games/dark_hex.cc
+++ b/open_spiel/games/dark_hex.cc
@@ -270,6 +270,7 @@ void DarkHexState::UndoAction(Player player, Action move) {
   action_sequence_.pop_back();
 
   history_.pop_back();
+  --move_number_;
 }
 
 DarkHexGame::DarkHexGame(const GameParameters& params)

--- a/open_spiel/games/deep_sea.cc
+++ b/open_spiel/games/deep_sea.cc
@@ -155,6 +155,7 @@ void DeepSeaState::UndoAction(Player player, Action move) {
   --player_row_;
   direction_history_.pop_back();
   history_.pop_back();
+  --move_number_;
 }
 
 void DeepSeaState::DoApplyAction(Action move) {

--- a/open_spiel/games/go.cc
+++ b/open_spiel/games/go.cc
@@ -195,6 +195,7 @@ void GoState::UndoAction(Player player, Action action) {
   // We don't have direct undo functionality, but copying the board and
   // replaying all actions is still pretty fast (> 1 million undos/second).
   history_.pop_back();
+  --move_number_;
   ResetBoard();
   for (auto [_, action] : history_) {
     DoApplyAction(action);

--- a/open_spiel/games/kuhn_poker.cc
+++ b/open_spiel/games/kuhn_poker.cc
@@ -322,6 +322,7 @@ void KuhnState::UndoAction(Player player, Action move) {
     winner_ = kInvalidPlayer;
   }
   history_.pop_back();
+  --move_number_;
 }
 
 std::vector<std::pair<Action, double>> KuhnState::ChanceOutcomes() const {

--- a/open_spiel/games/phantom_ttt.cc
+++ b/open_spiel/games/phantom_ttt.cc
@@ -263,6 +263,7 @@ void PhantomTTTState::UndoAction(Player player, Action move) {
   action_sequence_.pop_back();
 
   history_.pop_back();
+  --move_number_;
   // Note, do not change the player.. this will already have been done above
   // if necessary.
 }

--- a/open_spiel/games/sheriff.cc
+++ b/open_spiel/games/sheriff.cc
@@ -224,6 +224,7 @@ void SheriffState::UndoAction(Player player, Action action_id) {
   SPIEL_CHECK_TRUE(!history_.empty() &&
                    (history_.back() == PlayerAction{player, action_id}));
   history_.pop_back();
+  --move_number_;
 
   if (!bribes_.empty()) {
     if (bribes_.size() == inspection_feedback_.size()) {

--- a/open_spiel/games/tic_tac_toe.cc
+++ b/open_spiel/games/tic_tac_toe.cc
@@ -180,6 +180,7 @@ void TicTacToeState::UndoAction(Player player, Action move) {
   outcome_ = kInvalidPlayer;
   num_moves_ -= 1;
   history_.pop_back();
+  --move_number_;
 }
 
 std::unique_ptr<State> TicTacToeState::Clone() const {

--- a/open_spiel/games/tiny_bridge.cc
+++ b/open_spiel/games/tiny_bridge.cc
@@ -788,6 +788,7 @@ std::unique_ptr<State> TinyBridgePlayState::Clone() const {
 void TinyBridgePlayState::UndoAction(Player player, Action action) {
   actions_.pop_back();
   history_.pop_back();
+  --move_number_;
 }
 
 std::string TinyBridgePlayState::ToString() const {

--- a/open_spiel/tests/basic_tests.cc
+++ b/open_spiel/tests/basic_tests.cc
@@ -171,6 +171,8 @@ void TestUndo(std::unique_ptr<State> state,
     SPIEL_CHECK_EQ(state->ToString(), prev->state->ToString());
     // We also check that UndoActions correctly updates history_.
     SPIEL_CHECK_EQ(state->History(), prev->state->History());
+    // And correctly updates move_number_.
+    SPIEL_CHECK_EQ(state->MoveNumber(), prev->state->MoveNumber());
   }
 }
 


### PR DESCRIPTION
https://github.com/deepmind/open_spiel/blob/df657bccc51c9fab3e3eec941abaf1a1c6139d84/open_spiel/spiel.h#L546-L548

`--move_number_` is not called in most game implementations of UndoAction(). This PR tests for this by adding a line of code to TestUndo() in basic_tests.cc, and addresses the issue by adding `--move_number_` to every game that doesn't already implement it (except efg_game, which is a special case).

It's worth noting that not every game that implements UndoAction() tests it. We could add RandomSimTestWithUndo() to these game tests. It's slow test, but running even just a single simulation is a decent test of the UndoAction function. If there's a desire to add this test I'll gladly update the PR. Cheers!