### PR TITLE
Register nullopt_t in pyspiel

### DIFF
--- a/open_spiel/python/pybind11/pyspiel.cc
+++ b/open_spiel/python/pybind11/pyspiel.cc
@@ -118,6 +118,11 @@ py::object GameParameterToPython(const GameParameter& gp) {
 PYBIND11_MODULE(pyspiel, m) {
   m.doc() = "Open Spiel";
 
+  // Needed for default parameters, e.g. of Game::MakeObserver,
+  // otherwise we get a runtime error at load time on MacOS,
+  // when loading the wheel.
+  py::class_<absl::nullopt_t> null_opt(m, "absl_nullopt_t");
+
   py::enum_<open_spiel::GameParameter::Type>(m, "GameParameterType")
       .value("UNSET", open_spiel::GameParameter::Type::kUnset)
       .value("INT", open_spiel::GameParameter::Type::kInt)


### PR DESCRIPTION
Without this, when we try to load a binary dist wheel, we get

```
>>> import pyspiel
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: arg(): could not convert default argument 'imperfect_information_observation_type: absl::lts_2020_09_23::nullopt_t' in method '<class 'pyspiel.Game'>.make_observer' into a Python object (type not registered yet?)
>>> 
```