### PR TITLE
Add missing registrations of types to Python API

### DIFF
--- a/open_spiel/python/pybind11/observer.cc
+++ b/open_spiel/python/pybind11/observer.cc
@@ -34,16 +34,6 @@ void init_pyspiel_observer(py::module& m) {
       .def_readonly("name", &TensorInfo::name)
       .def_readonly("shape", &TensorInfo::shape)
       .def("__str__", &TensorInfo::DebugString);
-  
-  py::enum_<PrivateInfoType>(m, "PrivateInfoType")
-      .value("NONE", PrivateInfoType::kNone)
-      .value("SINGLE_PLAYER", PrivateInfoType::kSinglePlayer)
-      .value("ALL_PLAYERS", PrivateInfoType::kAllPlayers);
-
-  py::class_<IIGObservationType>(m, "IIGObservationType")
-      .def_readonly("public_info", &IIGObservationType::public_info)
-      .def_readonly("perfect_recall", &IIGObservationType::perfect_recall)
-      .def_readonly("private_info", &IIGObservationType::private_info);
 
   // C++ Observation, intended only for the Python Observation class, not
   // for general Python code.

--- a/open_spiel/python/pybind11/observer.cc
+++ b/open_spiel/python/pybind11/observer.cc
@@ -34,6 +34,16 @@ void init_pyspiel_observer(py::module& m) {
       .def_readonly("name", &TensorInfo::name)
       .def_readonly("shape", &TensorInfo::shape)
       .def("__str__", &TensorInfo::DebugString);
+  
+  py::enum_<PrivateInfoType>(m, "PrivateInfoType")
+      .value("NONE", PrivateInfoType::kNone)
+      .value("SINGLE_PLAYER", PrivateInfoType::kSinglePlayer)
+      .value("ALL_PLAYERS", PrivateInfoType::kAllPlayers);
+
+  py::class_<IIGObservationType>(m, "IIGObservationType")
+      .def_readonly("public_info", &IIGObservationType::public_info)
+      .def_readonly("perfect_recall", &IIGObservationType::perfect_recall)
+      .def_readonly("private_info", &IIGObservationType::private_info);
 
   // C++ Observation, intended only for the Python Observation class, not
   // for general Python code.

--- a/open_spiel/python/pybind11/pyspiel.cc
+++ b/open_spiel/python/pybind11/pyspiel.cc
@@ -113,10 +113,12 @@ py::object GameParameterToPython(const GameParameter& gp) {
 PYBIND11_MODULE(pyspiel, m) {
   m.doc() = "Open Spiel";
 
-  // Needed for default parameters, e.g. of Game::MakeObserver,
-  // otherwise we get a runtime error at load time on MacOS,
-  // when loading the wheel.
+  // These are needed for default parameters, e.g. of Game::MakeObserver,
+  // otherwise we get a runtime error at load time on MacOS building &
+  // loading the bdist_wheel.
   py::class_<absl::nullopt_t> null_opt(m, "absl_nullopt_t");
+  py::class_<absl::optional<open_spiel::IIGObservationType>>
+      opt_iig_obs_type(m, "absl_opt_iig_obs_type");
 
   py::enum_<open_spiel::GameParameter::Type>(m, "GameParameterType")
       .value("UNSET", open_spiel::GameParameter::Type::kUnset)

--- a/open_spiel/python/pybind11/pyspiel.cc
+++ b/open_spiel/python/pybind11/pyspiel.cc
@@ -117,8 +117,6 @@ PYBIND11_MODULE(pyspiel, m) {
   // otherwise we get a runtime error at load time on MacOS building &
   // loading the bdist_wheel.
   py::class_<absl::nullopt_t> null_opt(m, "absl_nullopt_t");
-  py::class_<absl::optional<open_spiel::IIGObservationType>>
-      opt_iig_obs_type(m, "absl_opt_iig_obs_type");
 
   py::enum_<open_spiel::GameParameter::Type>(m, "GameParameterType")
       .value("UNSET", open_spiel::GameParameter::Type::kUnset)
@@ -157,6 +155,9 @@ PYBIND11_MODULE(pyspiel, m) {
       .def_readonly("public_info", &IIGObservationType::public_info)
       .def_readonly("perfect_recall", &IIGObservationType::perfect_recall)
       .def_readonly("private_info", &IIGObservationType::private_info);
+
+  py::class_<absl::optional<open_spiel::IIGObservationType>>
+      opt_iig_obs_type(m, "absl_opt_iig_obs_type");
 
   py::class_<UniformProbabilitySampler> uniform_sampler(
       m, "UniformProbabilitySampler");


### PR DESCRIPTION
This seems to be necessary when running the bdist_wheel on MacOS. 

Otherwise we get errors of the form:

```
======================================================================
ERROR: test_no_invalid_public_observations (absl.testing.parameterized.EnforceAPIPartialTree_markov_soccer_Test)
absl.testing.parameterized.EnforceAPIPartialTree_markov_soccer_Test.test_no_invalid_public_observations
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/runner/work/open_spiel_py39_cibuildwheel/open_spiel_py39_cibuildwheel/open_spiel/python/../integration_tests/api_test.py", line 414, in test_no_invalid_public_observations
    public_observation = make_observation(
  File "/Users/runner/hostedtoolcache/Python/3.9.4/x64/lib/python3.9/site-packages/open_spiel/python/observation.py", line 101, in make_observation
    return _Observation(game, imperfect_information_observation_type, params or
  File "/Users/runner/hostedtoolcache/Python/3.9.4/x64/lib/python3.9/site-packages/open_spiel/python/observation.py", line 67, in __init__
    obs = game.make_observer(imperfect_information_observation_type, params)
TypeError: make_observer(): incompatible function arguments. The following argument types are supported:
    1. (self: pyspiel.Game, imperfect_information_observation_type: absl::lts_2020_09_23::optional<open_spiel::IIGObservationType> = <pyspiel.absl_nullopt_t object at 0x10b4379f0>, params: Dict[str, pyspiel.GameParameter] = {}) -> open_spiel::Observer

Invoked with: markov_soccer(), <pyspiel.IIGObservationType object at 0x10d9a96b0>, {}
```

Failed run on a fork, see: https://github.com/lanctot/open_spiel_py39_cibuildwheel/actions/runs/807340314