### PR TITLE
Remove absl::optional from Python API

### DIFF
--- a/open_spiel/python/observation.py
+++ b/open_spiel/python/observation.py
@@ -64,7 +64,10 @@ class _Observation:
   """Contains an observation from a game."""
 
   def __init__(self, game, imperfect_information_observation_type, params):
-    obs = game.make_observer(imperfect_information_observation_type, params)
+    if imperfect_information_observation_type is not None:
+      obs = game.make_observer(imperfect_information_observation_type, params)
+    else:
+      obs = game.make_observer(params)
     self._observation = pyspiel._Observation(game, obs)
     self.dict = {}
     if self._observation.has_tensor():

--- a/open_spiel/python/pybind11/pyspiel.cc
+++ b/open_spiel/python/pybind11/pyspiel.cc
@@ -113,11 +113,6 @@ py::object GameParameterToPython(const GameParameter& gp) {
 PYBIND11_MODULE(pyspiel, m) {
   m.doc() = "Open Spiel";
 
-  // Needed for default parameters, e.g. of Game::MakeObserver,
-  // otherwise we get a runtime error at load time on MacOS,
-  // when loading the wheel.
-  py::class_<absl::nullopt_t> null_opt(m, "absl_nullopt_t");
-
   py::enum_<open_spiel::GameParameter::Type>(m, "GameParameterType")
       .value("UNSET", open_spiel::GameParameter::Type::kUnset)
       .value("INT", open_spiel::GameParameter::Type::kInt)
@@ -413,9 +408,15 @@ PYBIND11_MODULE(pyspiel, m) {
       .def("max_chance_nodes_in_history", &Game::MaxChanceNodesInHistory)
       .def("max_move_number", &Game::MaxMoveNumber)
       .def("max_history_length", &Game::MaxHistoryLength)
-      .def("make_observer", &Game::MakeObserver,
-           py::arg("imperfect_information_observation_type") = absl::nullopt,
-           py::arg("params") = GameParameters())
+      .def("make_observer",
+          [](const Game& game, IIGObservationType iig_obs_type,
+             const GameParameters& params) {
+             return game.MakeObserver(iig_obs_type, params);
+          })
+      .def("make_observer",
+          [](const Game& game, const GameParameters& params) {
+             return game.MakeObserver(absl::nullopt, params);
+          })
       .def("__str__", &Game::ToString)
       .def("__repr__", &Game::ToString)
       .def("__eq__",

--- a/open_spiel/python/pybind11/python_games.cc
+++ b/open_spiel/python/pybind11/python_games.cc
@@ -179,7 +179,8 @@ std::shared_ptr<Observer> PyGame::MakeObserver(
   py::object h = py::cast(this);
   py::function f = h.attr("make_py_observer");
   if (!f) SpielFatalError("make_py_observer not implemented");
-  py::object observer = f(iig_obs_type, params);
+  py::object observer = (iig_obs_type.has_value() ?
+      f(iig_obs_type.value(), params) : f(params));
   return std::make_shared<PyObserver>(observer);
 }
 


### PR DESCRIPTION
absl::optional is causing problems when testing the bdist_wheel. This PR removes the single instance causing problems (`Game::MakeObserver`) and replaces it with two overloads that achieve the same functionality.

absl::optional is not "officially" supported by pybind11. There is a project that aims to bring in proper support for absl types: [pybind11_pyspiel](https://github.com/pybind/pybind11_abseil). This seems like a cool project, ~but it would introduce an unnecessary dependency on bazel~ (<-- corrected, thanks @jblespiau), but it would add another dependency which I'd really prefer to avoid for now until we really need it. 

For details, see the commits in my fork: https://github.com/lanctot/open_spiel_py39_cibuildwheel

Tagging @elkhrt and @michalsustr whom it may affect. 