### PR TITLE
Update description of max_game_length in spiel.h.

### DIFF
--- a/open_spiel/spiel.h
+++ b/open_spiel/spiel.h
@@ -166,7 +166,9 @@ struct GameInfo {
   double utility_sum;
 
   // The maximum number of player decisions in a game. Does not include chance
-  // events.
+  // events. For a simultaneous action game, this is the maximum number of joint
+  // decisions. In a turn-based game, this is the maximum number of individual
+  // decisions summed over all players.
   int max_game_length;
 };
 


### PR DESCRIPTION
 Use description of MaxGameLength().

Currently the description of MaxGameLength() is more exhaustive than the description of max_game_length.
This makes the code a little bit hard the understand. I wonder if it would make sense to only describe each variable once and refer to the description in the other docstrings.