### PR TITLE
Add legal actions with one player to python binding

### DIFF
--- a/open_spiel/python/pybind11/python_games.cc
+++ b/open_spiel/python/pybind11/python_games.cc
@@ -62,6 +62,11 @@ std::vector<Action> PyState::LegalActions() const {
                               LegalActions);
 }
 
+std::vector<Action> PyState::LegalActions(Player player) const {
+  PYBIND11_OVERLOAD_PURE_NAME(std::vector<Action>, State, "legal_actions",
+                              LegalActions, player);
+}
+
 std::string PyState::ActionToString(Player player, Action action_id) const {
   PYBIND11_OVERLOAD_PURE_NAME(std::string, State, "_action_to_string",
                               ActionToString, player, action_id);

--- a/open_spiel/python/pybind11/python_games.h
+++ b/open_spiel/python/pybind11/python_games.h
@@ -68,6 +68,7 @@ class PyState : public State, public py::trampoline_self_life_support {
   // Implementation of the State API.
   Player CurrentPlayer() const override;
   std::vector<Action> LegalActions() const override;
+  std::vector<Action> LegalActions(Player player) const override;
   std::string ActionToString(Player player, Action action_id) const override;
   std::string ToString() const override;
   bool IsTerminal() const override;


### PR DESCRIPTION
Current legal_actions(self) is pass through the python binding but not legal_actions(self, player). Therefore when trying to convert a simultaneous python game to turn based python game, the state has no legal actions. Convert_to_turn_based function does not seems to have been tested in python, which may explain this issue. For 'more' explanations, please refer to https://github.com/TheoCabannes/open_spiel/issues/6