### PR TITLE
Test of simultaneous python game and conversion to turn based with dummy dynamic routing game

### DIFF
--- a/open_spiel/integration_tests/playthroughs/python_dynamic_routing_game.txt
+++ b/open_spiel/integration_tests/playthroughs/python_dynamic_routing_game.txt
@@ -1,0 +1,169 @@
+game: python_dynamic_routing_game
+
+GameType.chance_mode = ChanceMode.DETERMINISTIC
+GameType.dynamics = Dynamics.SIMULTANEOUS
+GameType.information = Information.PERFECT_INFORMATION
+GameType.long_name = "Python Dynamic Routing Game"
+GameType.max_num_players = 3
+GameType.min_num_players = 0
+GameType.parameter_specification = []
+GameType.provides_information_state_string = True
+GameType.provides_information_state_tensor = True
+GameType.provides_observation_string = True
+GameType.provides_observation_tensor = True
+GameType.provides_factored_observation_string = False
+GameType.reward_model = RewardModel.TERMINAL
+GameType.short_name = "python_dynamic_routing_game"
+GameType.utility = Utility.GENERAL_SUM
+
+NumDistinctActions() = 2
+PolicyTensorShape() = [2]
+MaxChanceOutcomes() = 0
+GetParameters() = {}
+NumPlayers() = 3
+MinUtility() = -3.0
+MaxUtility() = 0.0
+UtilitySum() = 0.0
+InformationStateTensorShape() = [1]
+InformationStateTensorLayout() = TensorLayout.CHW
+InformationStateTensorSize() = 1
+ObservationTensorShape() = [1]
+ObservationTensorLayout() = TensorLayout.CHW
+ObservationTensorSize() = 1
+MaxGameLength() = 2
+ToString() = "python_dynamic_routing_game()"
+
+# State 0
+# Vehicle locations: ['O', 'O', 'A'], time: 0.
+IsTerminal() = False
+History() = []
+HistoryString() = ""
+IsChanceNode() = False
+IsSimultaneousNode() = True
+CurrentPlayer() = PlayerId.SIMULTANEOUS
+InformationStateString(0) = ""
+InformationStateString(1) = ""
+InformationStateString(2) = ""
+InformationStateTensor(0).observation: ◯
+InformationStateTensor(1).observation: ◯
+InformationStateTensor(2).observation: ◯
+ObservationString(0) = ""
+ObservationString(1) = ""
+ObservationString(2) = ""
+PublicObservationString() = ""
+PrivateObservationString(0) = ""
+PrivateObservationString(1) = ""
+PrivateObservationString(2) = ""
+ObservationTensor(0): ◯
+ObservationTensor(1): ◯
+ObservationTensor(2): ◯
+Rewards() = [0.0, 0.0, 0.0]
+Returns() = [-0.0, -0.0, -0.0]
+LegalActions(0) = [0]
+LegalActions(1) = [0]
+LegalActions(2) = [1]
+StringLegalActions(0) = ["Vehicle 0 would like to move to A."]
+StringLegalActions(1) = ["Vehicle 1 would like to move to A."]
+StringLegalActions(2) = ["Vehicle 2 would like to move to D."]
+
+# Apply joint action ["Vehicle 0 would like to move to A.", "Vehicle 1 would like to move to A.", "Vehicle 2 would like to move to D."]
+actions: [0, 0, 1]
+
+# State 1
+# Vehicle locations: ['A', 'A', 'D'], time: 1.
+IsTerminal() = False
+History() = [0, 0, 1]
+HistoryString() = "0, 0, 1"
+IsChanceNode() = False
+IsSimultaneousNode() = True
+CurrentPlayer() = PlayerId.SIMULTANEOUS
+InformationStateString(0) = ""
+InformationStateString(1) = ""
+InformationStateString(2) = ""
+InformationStateTensor(0).observation: ◯
+InformationStateTensor(1).observation: ◯
+InformationStateTensor(2).observation: ◯
+ObservationString(0) = ""
+ObservationString(1) = ""
+ObservationString(2) = ""
+PublicObservationString() = ""
+PrivateObservationString(0) = ""
+PrivateObservationString(1) = ""
+PrivateObservationString(2) = ""
+ObservationTensor(0): ◯
+ObservationTensor(1): ◯
+ObservationTensor(2): ◯
+Rewards() = [0.0, 0.0, 0.0]
+Returns() = [-0.0, -0.0, -0.0]
+LegalActions(0) = [1]
+LegalActions(1) = [1]
+LegalActions(2) = [-1]
+StringLegalActions(0) = ["Vehicle 0 would like to move to D."]
+StringLegalActions(1) = ["Vehicle 1 would like to move to D."]
+StringLegalActions(2) = ["Vehicle 2 reach a sink node or its destination."]
+
+# Apply joint action ["Vehicle 0 would like to move to D.", "Vehicle 1 would like to move to D.", "Vehicle 2 reach a sink node or its destination."]
+actions: [1, 1, -1]
+
+# State 2
+# Vehicle locations: ['D', 'D', 'D'], time: 2.
+IsTerminal() = False
+History() = [0, 0, 1, 1, 1, -1]
+HistoryString() = "0, 0, 1, 1, 1, -1"
+IsChanceNode() = False
+IsSimultaneousNode() = True
+CurrentPlayer() = PlayerId.SIMULTANEOUS
+InformationStateString(0) = ""
+InformationStateString(1) = ""
+InformationStateString(2) = ""
+InformationStateTensor(0).observation: ◯
+InformationStateTensor(1).observation: ◯
+InformationStateTensor(2).observation: ◯
+ObservationString(0) = ""
+ObservationString(1) = ""
+ObservationString(2) = ""
+PublicObservationString() = ""
+PrivateObservationString(0) = ""
+PrivateObservationString(1) = ""
+PrivateObservationString(2) = ""
+ObservationTensor(0): ◯
+ObservationTensor(1): ◯
+ObservationTensor(2): ◯
+Rewards() = [0.0, 0.0, 0.0]
+Returns() = [-0.0, -0.0, -1]
+LegalActions(0) = [-1]
+LegalActions(1) = [-1]
+LegalActions(2) = [-1]
+StringLegalActions(0) = ["Vehicle 0 reach a sink node or its destination."]
+StringLegalActions(1) = ["Vehicle 1 reach a sink node or its destination."]
+StringLegalActions(2) = ["Vehicle 2 reach a sink node or its destination."]
+
+# Apply joint action ["Vehicle 0 reach a sink node or its destination.", "Vehicle 1 reach a sink node or its destination.", "Vehicle 2 reach a sink node or its destination."]
+actions: [-1, -1, -1]
+
+# State 3
+# Vehicle locations: ['D', 'D', 'D'], time: 3.
+IsTerminal() = True
+History() = [0, 0, 1, 1, 1, -1, -1, -1, -1]
+HistoryString() = "0, 0, 1, 1, 1, -1, -1, -1, -1"
+IsChanceNode() = False
+IsSimultaneousNode() = False
+CurrentPlayer() = PlayerId.TERMINAL
+InformationStateString(0) = ""
+InformationStateString(1) = ""
+InformationStateString(2) = ""
+InformationStateTensor(0).observation: ◯
+InformationStateTensor(1).observation: ◯
+InformationStateTensor(2).observation: ◯
+ObservationString(0) = ""
+ObservationString(1) = ""
+ObservationString(2) = ""
+PublicObservationString() = ""
+PrivateObservationString(0) = ""
+PrivateObservationString(1) = ""
+PrivateObservationString(2) = ""
+ObservationTensor(0): ◯
+ObservationTensor(1): ◯
+ObservationTensor(2): ◯
+Rewards() = [-2.0, -2.0, -1.0]
+Returns() = [-2, -2, -1]

--- a/open_spiel/python/CMakeLists.txt
+++ b/open_spiel/python/CMakeLists.txt
@@ -179,6 +179,7 @@ set(PYTHON_TESTS ${PYTHON_TESTS}
   environments/catch_test.py
   environments/cliff_walking_test.py
   games/data_test.py
+  games/dynamic_routing_game_test.py
   games/tic_tac_toe_test.py
   tests/bot_test.py
   tests/games_bridge_test.py

--- a/open_spiel/python/algorithms/generate_playthrough.py
+++ b/open_spiel/python/algorithms/generate_playthrough.py
@@ -28,6 +28,7 @@ import numpy as np
 
 from open_spiel.python.games import kuhn_poker  # pylint: disable=unused-import
 from open_spiel.python.games import tic_tac_toe  # pylint: disable=unused-import
+from open_spiel.python.games import dynamic_routing_game  # pylint: disable=unused-import
 from open_spiel.python.observation import make_observation
 import pyspiel
 

--- a/open_spiel/python/games/dynamic_routing_game.py
+++ b/open_spiel/python/games/dynamic_routing_game.py
@@ -105,7 +105,7 @@ _MOVEMENT_TO_ACTION, _ACTION_TO_ROAD_SECTION =\
 class DynamicRoutingGame(pyspiel.Game):
     """TODO(theo): write docstring.
     """
-    def __init__(self, params=None, num_players: int = 3):
+    def __init__(self, params=None, num_players: int = 2):
         max_number_time_step = 2
         game_info = pyspiel.GameInfo(
             num_distinct_actions=len(_ACTION_TO_ROAD_SECTION),

--- a/open_spiel/python/games/dynamic_routing_game.py
+++ b/open_spiel/python/games/dynamic_routing_game.py
@@ -1,0 +1,287 @@
+# Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as python3
+"""Simple implementation of dynamic routing game to test API.
+
+The dynamic routing game is based on the paper: A mean field route choice game
+by R. Salhab, J. Le Ny and R. P. Malhamé, 2018 IEEE CDC.
+We consider:
+- the following network:
+    O --> A --> D
+- two vehicles trying to reach D from O.
+The two vehicles leave the origin O at the beginning of the game.
+At O, they can only go at A. Then at A they can only go at D. At D, both
+vehicles cannot do any actions and the game is finished.
+
+Later, to add some complexity, we will add a third vehicle who leaves A to
+reach D at the beginning of the game. In this case, at time O, vehicles 0 and 1
+go from O to A and vehicle 2 goes from A to D. Then at time 1, vehicles 0 and 1
+go from A to D, vehicle 2 cannot do anything and the game is finished.
+
+Later a more complex network can considered, with routing choice at
+intersections and probability to stay on a link as a function of the number of
+cars on the link. Currently this is not done to test the API.
+"""
+
+import numpy as np
+from typing import Dict, Iterable, List, NewType, Set, Tuple
+
+import pyspiel
+
+RoadSection = NewType("RoadSection", str)
+
+_GAME_TYPE = pyspiel.GameType(
+    short_name="python_markov_dynamic_routing_game",
+    long_name="Python Markov Dynamic Routing Game",
+    dynamics=pyspiel.GameType.Dynamics.SIMULTANEOUS,
+    chance_mode=pyspiel.GameType.ChanceMode.DETERMINISTIC,
+    information=pyspiel.GameType.Information.PERFECT_INFORMATION,
+    utility=pyspiel.GameType.Utility.GENERAL_SUM,
+    reward_model=pyspiel.GameType.RewardModel.TERMINAL,
+    max_num_players=3,
+    min_num_players=0,
+    provides_information_state_string=True,
+    provides_information_state_tensor=True,
+    provides_observation_string=True,
+    provides_observation_tensor=True,
+    parameter_specification={})
+_NETWORK_ADJACENCY_LIST = {"O": ["A"], "A": ["D"]}
+
+
+# movement to actions and action to road section can be created from
+# a function.
+def _movement_to_string(origin: RoadSection, destination: RoadSection) -> str:
+    return f"{origin}->{destination}"
+
+
+def _create_movement_to_action_and_action_to_road_section(
+    network_adjacency_list: Dict[RoadSection, Iterable[RoadSection]]
+) -> Tuple[Dict[str, int], Dict[int, RoadSection]]:
+    """Create dictionary that maps movement to action.
+
+    The dictionary that maps movement to action is used to define the action
+    from a movement that a vehicle would like to do. The dictionary that maps
+    an action to the destintion of the movement is used to move a vehicle that
+    does an action to the destination of its movement.
+    Args:
+        network_adjacency_list: adjacency list of the network.
+    Returns:
+        movement_to_action: dictionary with key begin a movement for example
+            "O->A" and value the action numbers. Action numbers are succesive
+            integers indexed from 0.
+        action_to_road_section: map an action number to the end node of the
+            movement. if movement_to_action["O->A"] = 0 then,
+            action_to_road_section[0] = "A"
+    """
+    movement_to_action = {}
+    action_to_road_section = {}
+    action_number = 0
+    for origin, successors in network_adjacency_list.items():
+        for destination in successors:
+            movement_to_action[_movement_to_string(origin, destination)] =\
+                action_number
+            action_to_road_section[action_number] = destination
+            action_number += 1
+    return movement_to_action, action_to_road_section
+
+
+_MOVEMENT_TO_ACTION, _ACTION_TO_ROAD_SECTION =\
+    _create_movement_to_action_and_action_to_road_section(
+        _NETWORK_ADJACENCY_LIST)
+
+
+class DynamicRoutingGame(pyspiel.Game):
+    """TODO(theo): write docstring.
+    """
+    def __init__(self, params=None, num_players: int = 2):
+        max_number_time_step = 2
+        game_info = pyspiel.GameInfo(
+            num_distinct_actions=len(_ACTION_TO_ROAD_SECTION),
+            max_chance_outcomes=0,
+            num_players=num_players,
+            min_utility=-max_number_time_step-1,
+            max_utility=0,
+            max_game_length=max_number_time_step)
+        super().__init__(_GAME_TYPE, game_info, dict())
+
+    def new_initial_state(self) -> "DynamicRoutingGame":
+        """Returns a state corresponding to the start of a game."""
+        return DynamicRoutingGame(self)
+
+    def make_py_observer(self, iig_obs_type=None, params=None):
+        """Returns an object used for observing game state."""
+        return NetworkObserver()
+
+
+class DynamicRoutingGameState(pyspiel.State):
+    """TODO(theo): write docstring.
+
+    Attributes:
+      _current_time_step:
+      _is_terminal:
+      _max_time_step:
+      _max_travel_time:
+      _num_distinct_actions:
+      _num_players:
+      _vehicle_at_destination:
+      _vehicle_destinations:
+      _vehicle_final_travel_times:
+      _vehicle_locations:
+    """
+    _current_time_step: int
+    _is_terminal: bool
+    _max_time_step: int
+    _max_travel_time: float
+    _num_distinct_actions: int
+    _num_players: int
+    _vehicle_at_destination: Set[int]
+    _vehicle_destinations: List[RoadSection]
+    _vehicle_final_travel_times: List[float]
+    _vehicle_locations: List[RoadSection]
+
+    def __init__(self, game: DynamicRoutingGame):
+        """Constructor; should only be called by Game.new_initial_state."""
+        super().__init__(game)
+        self._current_time_step = 0
+        self._is_terminal = False
+        self._max_time_step = game.max_game_length()
+        self._max_travel_time = - game.min_utility()
+        self._num_distinct_actions = game.num_distinct_actions()
+        self._num_players = game.num_players()
+        self._vehicle_at_destination = set()
+        self._vehicle_destinations = ["D" for _ in self._num_players]
+        self._vehicle_final_travel_times = [0.0 for _ in self._num_players]
+        if self._num_players == 2:
+            self._vehicle_locations = ["O", "O"]
+        elif self._num_players == 3:
+            self._vehicle_locations = ["O", "O", "A"]
+        else:
+            raise ValueError("The game should have 2 or 3 players.")
+
+    def current_player(self) -> pyspiel.PlayerId:
+        """Returns SIMULTANEOUS if the game is not over, otherwise TERMINAL."""
+        return (pyspiel.PlayerId.TERMINAL if self._is_terminal
+                else pyspiel.PlayerId.SIMULTANEOUS)
+
+    def assert_valid_action(self, action: int, location: str = ""):
+        assert isinstance(action, int)
+        assert action >= 0
+        assert action < self._num_distinct_actions
+        if location:
+            successors = _NETWORK_ADJACENCY_LIST[location]
+        assert action in successors, (
+              f"Invalid action {action}. It is not a successors of "
+              f"{location}: {successors}.")
+
+    def assert_valid_player(self, player: int):
+        assert isinstance(player, int)
+        assert player >= 0
+        assert player < self._num_players
+
+    def legal_actions(self, player: int = None) -> List[int]:
+        """TODO(Theo): write docstring.
+        """
+        if self._is_terminal:
+            return []
+        self.assert_valid_player(player)
+        if player in self._vehicle_at_destination:
+            # If the vehicle is at destination it cannot do anything.
+            return [pyspiel.INVALID_ACTION]
+        location = self._vehicle_locations[player]
+        successors = _NETWORK_ADJACENCY_LIST[location]
+        if successors:
+            assert isinstance(successors, Iterable)
+            assert all([self.assert_valid_action(s) for s in successors])
+            return sorted([_MOVEMENT_TO_ACTION[_movement_to_string(location,
+                                                                   successor)]
+                           for successor in successors])
+        return [pyspiel.INVALID_ACTION]
+
+    def _apply_actions(self, actions: List[int]):
+        """TODO(Theo): Applies the specified action to the state."""
+        assert len(actions) == self._num_players, (
+          f"Each player does not have an actions. Actions has {len(actions)} "
+          f"elements, it should have {self._num_players}.")
+        for vehicle_id, action in enumerate(actions):
+            # Has the vehicle already reached its destination?
+            if vehicle_id in self._vehicle_at_destination:
+                continue
+            location = self._vehicle_locations[vehicle_id]
+            # Has the vehicle just reached its destination?
+            if (location == self._vehicle_destinations[vehicle_id]):
+                self._vehicle_final_travel_times[vehicle_id] =\
+                  self._current_time_step
+                self._vehicle_at_destination.add(vehicle_id)
+            if action != pyspiel.INVALID_ACTION:
+                self.assert_valid_action(action, location)
+                self._vehicle_locations[vehicle_id] =\
+                    _ACTION_TO_ROAD_SECTION[action]
+                # TODO(Theo): Enable mix strategies.
+        self._current_time_step += 1
+        # Is the game finished?
+        if (self._current_time_step >= self._max_time_step or
+                all(map(lambda a: a == pyspiel.INVALID_ACTION, actions))):
+            self._is_terminal = True
+            for vehicle_id in range(self._num_players):
+                if vehicle_id not in self._vehicle_at_destination:
+                    self._vehicle_final_travel_times[vehicle_id] =\
+                      self._max_travel_time
+        elif len(self._vehicle_at_destination) == self._num_players:
+            self._is_terminal = True
+
+    def _action_to_string(self, player, action) -> str:
+        """Action -> string."""
+        self.assert_valid_player(player)
+        if action == pyspiel.INVALID_ACTION:
+            return f"Vehicle {player} reach a sink node or its destination."
+        self.assert_valid_action(action)
+        return (f"Vehicle {player} would like to move to "
+                f"{_ACTION_TO_ROAD_SECTION[action]}.")
+
+    def is_terminal(self) -> bool:
+        """Returns True if the game is over."""
+        return self._is_terminal
+
+    def returns(self) -> List[float]:
+        """Total reward for each player over the course of the game so far."""
+        return [- travel_time
+                for travel_time in self._vehicle_final_travel_times]
+
+    def __str__(self) -> str:
+        """String for debug purposes. No particular semantics are required."""
+        return (f"Vehicle locations: {self._vehicle_locations}, "
+                f"time: {self._current_time_step}.")
+
+
+class NetworkObserver:
+    """Dummy observer for algorithm to work."""
+
+    def __init__(self, shape: int = 1):
+        """TODO(Theo): docstring."""
+        self.tensor = np.zeros(np.prod(shape), np.float32)
+        self.dict = {"observation": np.reshape(self.tensor, shape)}
+
+    def set_from(self, state, player):
+        """TODO(Theo): docstring."""
+        obs = self.dict["observation"]
+        obs.fill(0)
+
+    def string_from(self, state, player):
+        """TODO(Theo): docstring."""
+        return ""
+
+
+# Register the game with the OpenSpiel library
+pyspiel.register_game(_GAME_TYPE, DynamicRoutingGame)

--- a/open_spiel/python/games/dynamic_routing_game.py
+++ b/open_spiel/python/games/dynamic_routing_game.py
@@ -268,7 +268,7 @@ class DynamicRoutingGameState(pyspiel.State):
                 self._vehicle_at_destination.add(vehicle_id)
         self._current_time_step += 1
         # Is the game finished?
-        if (self._current_time_step > self._max_time_step or
+        if (self._current_time_step >= self._max_time_step or
                 all(map(lambda a: a == pyspiel.INVALID_ACTION, actions))):
             self._is_terminal = True
             for vehicle_id in range(self._num_players):

--- a/open_spiel/python/games/dynamic_routing_game_test.py
+++ b/open_spiel/python/games/dynamic_routing_game_test.py
@@ -1,0 +1,55 @@
+# Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as python3
+"""Tests for Python Dynamic Routing Game."""
+
+from absl.testing import absltest
+
+from open_spiel.python.algorithms import generate_playthrough
+from open_spiel.python.games import dynamic_routing_game  # pylint: disable=unused-import
+import pyspiel
+
+
+class DynamicRoutingGameTest(absltest.TestCase):
+
+    def test_game_from_cc(self):
+        """Runs our standard game tests, checking API consistency."""
+        game = pyspiel.load_game("python_dynamic_routing_game")
+        pyspiel.random_sim_test(game, num_sims=10, serialize=False,
+                                verbose=True)
+
+    def test_generate_playthrough(self):
+        """Check if playthrough can be generated."""
+        generate_playthrough.playthrough("python_dynamic_routing_game", None)
+
+    def test_convert_to_turn_based(self):
+        """Check if the game can be converted to turn based game."""
+        game = pyspiel.load_game("python_dynamic_routing_game")
+        pyspiel.convert_to_turn_based(game)
+
+    def test_action_consistency_convert_to_turn_based(self):
+        """Check if the sequential game is consistent with the game."""
+        game = pyspiel.load_game("python_dynamic_routing_game")
+        seq_game = pyspiel.convert_to_turn_based(game)
+        state = game.new_initial_state()
+        seq_state = seq_game.new_initial_state()
+        self.assertEqual(
+            state.legal_actions(seq_state.current_player()),
+            seq_state.legal_actions(),
+            msg="The sequential actions are not correct.")
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/open_spiel/python/games/dynamic_routing_game_test.py
+++ b/open_spiel/python/games/dynamic_routing_game_test.py
@@ -17,6 +17,7 @@
 
 from absl.testing import absltest
 
+from open_spiel.python.algorithms import cfr
 from open_spiel.python.algorithms import generate_playthrough
 from open_spiel.python.games import dynamic_routing_game  # pylint: disable=unused-import
 import pyspiel
@@ -49,6 +50,12 @@ class DynamicRoutingGameTest(absltest.TestCase):
             state.legal_actions(seq_state.current_player()),
             seq_state.legal_actions(),
             msg="The sequential actions are not correct.")
+
+    def test_cfr_on_turn_based_game(self):
+        """Check if CFR can be applied to the sequential game."""
+        game = pyspiel.load_game("python_dynamic_routing_game")
+        seq_game = pyspiel.convert_to_turn_based(game)
+        cfr.CFRSolver(seq_game)
 
 
 if __name__ == "__main__":

--- a/open_spiel/python/pybind11/pyspiel.cc
+++ b/open_spiel/python/pybind11/pyspiel.cc
@@ -263,7 +263,7 @@ PYBIND11_MODULE(pyspiel, m) {
       .def(py::init<int, int, int, double, double, double, int>(),
            py::arg("num_distinct_actions"), py::arg("max_chance_outcomes"),
            py::arg("num_players"), py::arg("min_utility"),
-           py::arg("max_utility"), py::arg("utility_sum"),
+           py::arg("max_utility"), py::arg("utility_sum") = 0,
            py::arg("max_game_length"))
       .def(py::init<const GameInfo&>())
       .def_readonly("num_distinct_actions", &GameInfo::num_distinct_actions)

--- a/open_spiel/python/pybind11/python_games.cc
+++ b/open_spiel/python/pybind11/python_games.cc
@@ -62,6 +62,11 @@ std::vector<Action> PyState::LegalActions() const {
                               LegalActions);
 }
 
+std::vector<Action> PyState::LegalActions(Player player) const {
+  PYBIND11_OVERLOAD_PURE_NAME(std::vector<Action>, State, "legal_actions",
+                              LegalActions, player);
+}
+
 std::string PyState::ActionToString(Player player, Action action_id) const {
   PYBIND11_OVERLOAD_PURE_NAME(std::string, State, "_action_to_string",
                               ActionToString, player, action_id);

--- a/open_spiel/python/pybind11/python_games.h
+++ b/open_spiel/python/pybind11/python_games.h
@@ -68,6 +68,7 @@ class PyState : public State, public py::trampoline_self_life_support {
   // Implementation of the State API.
   Player CurrentPlayer() const override;
   std::vector<Action> LegalActions() const override;
+  std::vector<Action> LegalActions(Player player) const override;
   std::string ActionToString(Player player, Action action_id) const override;
   std::string ToString() const override;
   bool IsTerminal() const override;


### PR DESCRIPTION
The goal of this PR is:
- to create a test for the following issues:
   - https://github.com/deepmind/open_spiel/issues/588
   - https://github.com/deepmind/open_spiel/pull/587
   - https://github.com/deepmind/open_spiel/pull/584
- to add example of simultaneous game solved with conversion to sequential games with imperfect information with python.

Thank you a lot for considering my contribution.
The game is a dummy version of [A mean field route choice game](http://www.professeurs.polymtl.ca/jerome.le-ny/docs/proceedings/2018_CDC_MFGrouteChoice_Salhab.pdf) by R. Salhab, J. Le Ny and R. P. Malhamé, 2018 IEEE CDC.
This implementation targets to implement a "more realistic" dynamic routing game than this paper (the notion of cost and travel time in the paper is not linked to the actual graph traversal time). This implementation also targets to solve the game with an optimal control approach using mean field games. Hopefully it can become a part of open spiel.