### PR TITLE
Fix GLIBCXX_3.4.29 not found error in the Julia wrapper

### DIFF
--- a/open_spiel/julia/CMakeLists.txt
+++ b/open_spiel/julia/CMakeLists.txt
@@ -14,11 +14,5 @@ install(TARGETS spieljl
     LIBRARY DESTINATION lib
 )
 
-# This is failing now too (in addition to thread_test). Temporarily disabling.
-# See https://github.com/deepmind/open_spiel/pull/593 and
-# https://github.com/deepmind/open_spiel/pull/596 for discussion.
-# add_test(NAME julia_test COMMAND julia --project=${CMAKE_CURRENT_SOURCE_DIR}
-#                                        -e "using Pkg; Pkg.build(); Pkg.test()")
-
-
-
+add_test(NAME julia_test COMMAND julia --project=${CMAKE_CURRENT_SOURCE_DIR}
+                                       -e "using Pkg; Pkg.build(); Pkg.test()")

--- a/open_spiel/scripts/install.sh
+++ b/open_spiel/scripts/install.sh
@@ -177,7 +177,11 @@ if [[ ${OPEN_SPIEL_BUILD_WITH_JULIA:-"OFF"} == "ON" ]]; then
       mv jill.sh $JULIA_INSTALLER
     fi
     bash $JULIA_INSTALLER -y -v 1.6.1
-    rm $HOME/packages/julias/julia-1.6.1/lib/julia/libstdc++.so.6
+    # This is needed on Ubuntu 19.10 and above, see:
+    # https://github.com/deepmind/open_spiel/issues/201
+    if [[ -f /usr/lib/x86_64-linux-gnu/libstdc++.so.6 ]]; then
+      cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6 $HOME/packages/julias/julia-1.6.1/lib/julia
+    fi
     # Should install in $HOME/.local/bin which was added to the path above
     [[ -x `which julia` ]] && [ "$(julia -e 'println(VERSION >= v"1.6.0-rc1")')" == "true" ] || die "julia not found PATH after install."
   fi

--- a/open_spiel/scripts/install.sh
+++ b/open_spiel/scripts/install.sh
@@ -176,7 +176,7 @@ if [[ ${OPEN_SPIEL_BUILD_WITH_JULIA:-"OFF"} == "ON" ]]; then
       curl https://raw.githubusercontent.com/abelsiqueira/jill/master/jill.sh -o jill.sh
       mv jill.sh $JULIA_INSTALLER
     fi
-    JULIA_VERSION=1.6.0-rc1 bash $JULIA_INSTALLER -y
+    JULIA_VERSION=1.6.1 bash $JULIA_INSTALLER -y
     # Should install in $HOME/.local/bin which was added to the path above
     [[ -x `which julia` ]] && [ "$(julia -e 'println(VERSION >= v"1.6.0-rc1")')" == "true" ] || die "julia not found PATH after install."
   fi

--- a/open_spiel/scripts/install.sh
+++ b/open_spiel/scripts/install.sh
@@ -176,7 +176,8 @@ if [[ ${OPEN_SPIEL_BUILD_WITH_JULIA:-"OFF"} == "ON" ]]; then
       curl https://raw.githubusercontent.com/abelsiqueira/jill/master/jill.sh -o jill.sh
       mv jill.sh $JULIA_INSTALLER
     fi
-    JULIA_VERSION=1.6.1 bash $JULIA_INSTALLER -y
+    bash $JULIA_INSTALLER -y -v 1.6.1
+    rm $HOME/packages/julias/julia-1.6.1/lib/julia/libstdc++.so.6
     # Should install in $HOME/.local/bin which was added to the path above
     [[ -x `which julia` ]] && [ "$(julia -e 'println(VERSION >= v"1.6.0-rc1")')" == "true" ] || die "julia not found PATH after install."
   fi


### PR DESCRIPTION
It seems this version is not shipped with Julia@v1.6.1. The only way left is to make a symlink or remove libstdc++.so.6 from the prebuilt julia binary.

- [ ] Check whether making a symlink works or not.