### PR TITLE
Use legal_chance_outcomes bindings to simplify _legal_actions in python.

### DIFF
--- a/open_spiel/python/games/iterated_prisoners_dilemma.py
+++ b/open_spiel/python/games/iterated_prisoners_dilemma.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Python implementation of iterated prisoner's dilemma. 
+"""Python implementation of iterated prisoner's dilemma.
 
 This is primarily here to demonstrate simultaneous-move games in Python.
 """

--- a/open_spiel/python/games/iterated_prisoners_dilemma.py
+++ b/open_spiel/python/games/iterated_prisoners_dilemma.py
@@ -113,7 +113,7 @@ class IteratedPrisonersDilemmaState(pyspiel.State):
   def _legal_actions(self, player):
     """Returns a list of legal actions, sorted in ascending order."""
     if player == pyspiel.PlayerId.CHANCE:
-      return [Chance.CONTINUE, Chance.STOP]
+      return self.legal_chance_outcomes()
     else:
       return [Action.COOPERATE, Action.DEFECT]
 

--- a/open_spiel/python/games/iterated_prisoners_dilemma.py
+++ b/open_spiel/python/games/iterated_prisoners_dilemma.py
@@ -112,10 +112,8 @@ class IteratedPrisonersDilemmaState(pyspiel.State):
 
   def _legal_actions(self, player):
     """Returns a list of legal actions, sorted in ascending order."""
-    if player == pyspiel.PlayerId.CHANCE:
-      return self.legal_chance_outcomes()
-    else:
-      return [Action.COOPERATE, Action.DEFECT]
+    assert player >= 0
+    return [Action.COOPERATE, Action.DEFECT]
 
   def chance_outcomes(self):
     """Returns the possible chance outcomes and their probabilities."""

--- a/open_spiel/python/games/iterated_prisoners_dilemma.py
+++ b/open_spiel/python/games/iterated_prisoners_dilemma.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Python implementation of iterated prisoner's dilemma.
+"""Python implementation of iterated prisoner's dilemma. 
 
 This is primarily here to demonstrate simultaneous-move games in Python.
 """

--- a/open_spiel/python/games/kuhn_poker.py
+++ b/open_spiel/python/games/kuhn_poker.py
@@ -110,7 +110,7 @@ class KuhnPokerState(pyspiel.State):
   def _legal_actions(self, player):
     """Returns a list of legal actions, sorted in ascending order."""
     if player == pyspiel.PlayerId.CHANCE:
-      return sorted(_DECK - set(self.cards))
+      return self.legal_chance_outcomes()
     else:
       return [Action.PASS, Action.BET]
 

--- a/open_spiel/python/games/kuhn_poker.py
+++ b/open_spiel/python/games/kuhn_poker.py
@@ -109,10 +109,8 @@ class KuhnPokerState(pyspiel.State):
 
   def _legal_actions(self, player):
     """Returns a list of legal actions, sorted in ascending order."""
-    if player == pyspiel.PlayerId.CHANCE:
-      return self.legal_chance_outcomes()
-    else:
-      return [Action.PASS, Action.BET]
+    assert player >= 0
+    return [Action.PASS, Action.BET]
 
   def chance_outcomes(self):
     """Returns the possible chance outcomes and their probabilities."""

--- a/open_spiel/python/pybind11/pyspiel.cc
+++ b/open_spiel/python/pybind11/pyspiel.cc
@@ -296,9 +296,7 @@ PYBIND11_MODULE(pyspiel, m) {
            (std::vector<int>(State::*)(int) const) & State::LegalActionsMask)
       .def("legal_actions_mask",
            (std::vector<int>(State::*)(void) const) & State::LegalActionsMask)
-      .def("legal_chance_outcomes",
-           (std::vector<open_spiel::Action>(State::*)(void) const) &
-               State::LegalChanceOutcomes)
+      .def("legal_chance_outcomes", &State::LegalChanceOutcomes)
       .def("action_to_string", (std::string(State::*)(Player, Action) const) &
                                    State::ActionToString)
       .def("action_to_string",

--- a/open_spiel/python/pybind11/pyspiel.cc
+++ b/open_spiel/python/pybind11/pyspiel.cc
@@ -296,7 +296,6 @@ PYBIND11_MODULE(pyspiel, m) {
            (std::vector<int>(State::*)(int) const) & State::LegalActionsMask)
       .def("legal_actions_mask",
            (std::vector<int>(State::*)(void) const) & State::LegalActionsMask)
-      .def("legal_chance_outcomes", &State::LegalChanceOutcomes)
       .def("action_to_string", (std::string(State::*)(Player, Action) const) &
                                    State::ActionToString)
       .def("action_to_string",

--- a/open_spiel/python/pybind11/pyspiel.cc
+++ b/open_spiel/python/pybind11/pyspiel.cc
@@ -296,6 +296,9 @@ PYBIND11_MODULE(pyspiel, m) {
            (std::vector<int>(State::*)(int) const) & State::LegalActionsMask)
       .def("legal_actions_mask",
            (std::vector<int>(State::*)(void) const) & State::LegalActionsMask)
+      .def("legal_chance_outcomes",
+           (std::vector<open_spiel::Action>(State::*)(void) const) &
+               State::LegalChanceOutcomes)
       .def("action_to_string", (std::string(State::*)(Player, Action) const) &
                                    State::ActionToString)
       .def("action_to_string",

--- a/open_spiel/python/pybind11/python_games.cc
+++ b/open_spiel/python/pybind11/python_games.cc
@@ -63,6 +63,7 @@ std::vector<Action> PyState::LegalActions() const {
 
 std::vector<Action> PyState::LegalActions(Player player) const {
   if (IsTerminal()) return {};
+  if (IsChanceNode()) return LegalChanceOutcomes();
   if ((player == CurrentPlayer()) || (player >= 0 && IsSimultaneousNode())) {
     PYBIND11_OVERLOAD_PURE_NAME(std::vector<Action>, State, "_legal_actions",
                                 LegalActions, player);


### PR DESCRIPTION
It seems to be easier to only have to implement chance_outcomes and not _legal_actions when chance nodes are used in python.
The code in C++ seems to be done with this philosophy but the python binding does not enable this.
This PR adds the python binding to enable using legal_change_outcomes() and change the two python examples.