### PR TITLE
fix bug in oshi_zumo where returns are sometimes inverted

### DIFF
--- a/open_spiel/algorithms/tabular_best_response_mdp_test.cc
+++ b/open_spiel/algorithms/tabular_best_response_mdp_test.cc
@@ -145,7 +145,7 @@ void OshiZumoGameTests() {
       "oshi_zumo(coins=10,size=3,min_bid=1)");
   TabularBestResponseMDP tbr1(*game, uniform_policy);
   TabularBestResponseMDPInfo br_info = tbr1.NashConv();
-  SPIEL_CHECK_FLOAT_NEAR(br_info.nash_conv, 1.997891313932980, kFloatTolerance);
+  SPIEL_CHECK_FLOAT_NEAR(br_info.nash_conv, 1.988311287477953, kFloatTolerance);
 
   TabularBestResponseMDP tbr2(*game, first_action_policy);
   TabularBestResponseMDPInfo br_info2 = tbr2.NashConv();

--- a/open_spiel/games/oshi_zumo.cc
+++ b/open_spiel/games/oshi_zumo.cc
@@ -105,9 +105,9 @@ void OshiZumoState::DoApplyActions(const std::vector<Action>& actions) {
 
   // Check winner.
   if (wrestler_pos_ == 0) {
-    winner_ = 0;
-  } else if (wrestler_pos_ == (2 * size_ + 2)) {
     winner_ = 1;
+  } else if (wrestler_pos_ == (2 * size_ + 2)) {
+    winner_ = 0;
   }
 
   total_moves_++;


### PR DESCRIPTION
In oshi_zumo, there was a bug where pushing the wrestler completely off the board counted as a loss instead of a win.  (With `Alesia`, this means that all returns were inverted, so always playing `0` was a dominant strategy.)

To repro:
```
game = pyspiel.load_game('oshi_zumo',
     {
         "coins": pyspiel.GameParameter(2),
         "size": pyspiel.GameParameter(1),
         "horizon": pyspiel.GameParameter(2)
      })
game = pyspiel.convert_to_turn_based(game)

print('off the board:')
state = game.new_initial_state().child(1).child(0).child(1).child(0)
print(state)
print(state.returns(), '\n')

print('still on the board:')
state = game.new_initial_state().child(0).child(0).child(1).child(0)
print(state)
print(state.returns())
```

prints
```
off the board:
Coins: 0 2, Field: #...W

[-1.0, 1.0] 
```

and

```
still on the board:
Coins: 1 2, Field: #..W#

[1.0, -1.0]
```