### PR TITLE
Create python MFG module and import it in automatic tests.

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -37,7 +37,7 @@ that both the C++ and the Python implementation behave the same.
 We describe here only the simplest and fastest way to add a new game. It is
 ideal to first be aware of the general API (see `spiel.h`).
 
-1.  Choose a game to copy from in `games/` (or `python/games/`). Suggested games:
+1.  Choose a game to copy from in `games/` (or `python/games/` or `python/mfg/games/`). Suggested games:
     Tic-Tac-Toe and Breakthrough for perfect information without chance events,
     Backgammon or Pig for perfect information games with chance events, Goofspiel
     and Oshi-Zumo for simultaneous move games, and Leduc poker and Liar’s dice
@@ -49,7 +49,7 @@ ideal to first be aware of the general API (see `spiel.h`).
 3.  Configure CMake:
     *   If you are working with C++: add the new game’s source files to `games/CMakeLists.txt`.
     *   If you are working with C++: add the new game’s test target to `games/CMakeLists.txt`.
-    *   If you are working with Python: add the test to `python/CMakeLists.txt` and import it in `python/games/__init__.py`
+    *   If you are working with Python: add the test to `python/CMakeLists.txt` and import it in `python/games/__init__.py` (or `python/mfg/games/__init__.py` if you are working with mean field games).
 4.  Update boilerplate C++/Python code:
     *   In `new_game.h`, rename the header guard at the the top and bottom of
         the file.

--- a/open_spiel/integration_tests/playthroughs/python_mfg_crowd_modelling.txt
+++ b/open_spiel/integration_tests/playthroughs/python_mfg_crowd_modelling.txt
@@ -1,0 +1,311 @@
+game: python_mfg_crowd_modelling
+
+GameType.chance_mode = ChanceMode.EXPLICIT_STOCHASTIC
+GameType.dynamics = Dynamics.MEAN_FIELD
+GameType.information = Information.PERFECT_INFORMATION
+GameType.long_name = "Python Mean Field Crowd Modelling"
+GameType.max_num_players = 1
+GameType.min_num_players = 1
+GameType.parameter_specification = ["horizon", "size"]
+GameType.provides_information_state_string = True
+GameType.provides_information_state_tensor = False
+GameType.provides_observation_string = True
+GameType.provides_observation_tensor = True
+GameType.provides_factored_observation_string = False
+GameType.reward_model = RewardModel.REWARDS
+GameType.short_name = "python_mfg_crowd_modelling"
+GameType.utility = Utility.GENERAL_SUM
+
+NumDistinctActions() = 3
+PolicyTensorShape() = [3]
+MaxChanceOutcomes() = 10
+GetParameters() = {horizon=10,size=10}
+NumPlayers() = 1
+MinUtility() = -inf
+MaxUtility() = inf
+UtilitySum() = 0.0
+ObservationTensorShape() = x: [10], t: [10]
+ObservationTensorLayout() = TensorLayout.CHW
+ObservationTensorSize() = 20
+MaxGameLength() = 10
+ToString() = "python_mfg_crowd_modelling(horizon=10,size=10)"
+
+# State 0
+# initial
+IsTerminal() = False
+History() = []
+HistoryString() = ""
+IsChanceNode() = True
+IsSimultaneousNode() = False
+CurrentPlayer() = PlayerId.CHANCE
+InformationStateString(0) = ""
+ObservationString(0) = "initial"
+PublicObservationString() = "initial"
+PrivateObservationString(0) = ""
+ObservationTensor(0).x: ◉◉◉◉◉◉◉◉◉◉
+ObservationTensor(0).t: ◯◯◯◯◯◯◯◯◯◯
+ChanceOutcomes() = [(0, 0.1), (1, 0.1), (2, 0.1), (3, 0.1), (4, 0.1), (5, 0.1), (6, 0.1), (7, 0.1), (8, 0.1), (9, 0.1)]
+LegalActions() = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+StringLegalActions() = ["init_state=0", "init_state=1", "init_state=2", "init_state=3", "init_state=4", "init_state=5", "init_state=6", "init_state=7", "init_state=8", "init_state=9"]
+
+# Apply action "init_state=4"
+action: 4
+
+# State 1
+# (4, 0)
+IsTerminal() = False
+History() = [4]
+HistoryString() = "4"
+IsChanceNode() = False
+IsSimultaneousNode() = False
+CurrentPlayer() = 0
+InformationStateString(0) = "4"
+ObservationString(0) = "(4, 0)"
+PublicObservationString() = "(4, 0)"
+PrivateObservationString(0) = ""
+ObservationTensor(0).x: ◯◯◯◯◉◯◯◯◯◯
+ObservationTensor(0).t: ◯◯◯◯◯◯◯◯◯◯
+Rewards() = [3.1025850929940457]
+Returns() = [3.1025850929940457]
+LegalActions() = [0, 1, 2]
+StringLegalActions() = ["-1", "0", "1"]
+
+# Apply action "0"
+action: 1
+
+# State 2
+# (4, 0)_a
+IsTerminal() = False
+History() = [4, 1]
+HistoryString() = "4, 1"
+IsChanceNode() = False
+IsSimultaneousNode() = False
+CurrentPlayer() = PlayerId.MEAN_FIELD
+InformationStateString(0) = "4, 1"
+ObservationString(0) = "(4, 0)_a"
+PublicObservationString() = "(4, 0)_a"
+PrivateObservationString(0) = ""
+ObservationTensor(0).x: ◯◯◯◯◉◯◯◯◯◯
+ObservationTensor(0).t: ◯◯◯◯◯◯◯◯◯◯
+Rewards() = [0.0]
+Returns() = [3.1025850929940457]
+DistributionSupport() = ['(0, 0)', '(1, 0)', '(2, 0)', '(3, 0)', '(4, 0)', '(5, 0)', '(6, 0)', '(7, 0)', '(8, 0)', '(9, 0)']
+
+# Set mean field distribution to be uniform
+action: update_distribution
+
+# State 3
+# (4, 0)_a_mu
+IsTerminal() = False
+History() = [4, 1]
+HistoryString() = "4, 1"
+IsChanceNode() = True
+IsSimultaneousNode() = False
+CurrentPlayer() = PlayerId.CHANCE
+InformationStateString(0) = "4, 1"
+ObservationString(0) = "(4, 0)_a_mu"
+PublicObservationString() = "(4, 0)_a_mu"
+PrivateObservationString(0) = ""
+ObservationTensor(0).x: ◯◯◯◯◉◯◯◯◯◯
+ObservationTensor(0).t: ◯◯◯◯◯◯◯◯◯◯
+ChanceOutcomes() = [(0, 0.3333333333333333), (1, 0.3333333333333333), (2, 0.3333333333333333)]
+LegalActions() = [0, 1, 2]
+StringLegalActions() = ["-1", "0", "1"]
+
+# Apply action "0"
+action: 1
+
+# State 4
+# (4, 1)
+IsTerminal() = False
+History() = [4, 1, 1]
+HistoryString() = "4, 1, 1"
+IsChanceNode() = False
+IsSimultaneousNode() = False
+CurrentPlayer() = 0
+InformationStateString(0) = "4, 1, 1"
+ObservationString(0) = "(4, 1)"
+PublicObservationString() = "(4, 1)"
+PrivateObservationString(0) = ""
+ObservationTensor(0).x: ◯◯◯◯◉◯◯◯◯◯
+ObservationTensor(0).t: ◯◯◯◯◯◯◯◯◯◯
+Rewards() = [3.1025850929940457]
+Returns() = [6.2051701859880914]
+LegalActions() = [0, 1, 2]
+StringLegalActions() = ["-1", "0", "1"]
+
+# Apply action "0"
+action: 1
+
+# State 5
+# (4, 1)_a
+IsTerminal() = False
+History() = [4, 1, 1, 1]
+HistoryString() = "4, 1, 1, 1"
+IsChanceNode() = False
+IsSimultaneousNode() = False
+CurrentPlayer() = PlayerId.MEAN_FIELD
+InformationStateString(0) = "4, 1, 1, 1"
+ObservationString(0) = "(4, 1)_a"
+PublicObservationString() = "(4, 1)_a"
+PrivateObservationString(0) = ""
+ObservationTensor(0).x: ◯◯◯◯◉◯◯◯◯◯
+ObservationTensor(0).t: ◯◯◯◯◯◯◯◯◯◯
+Rewards() = [0.0]
+Returns() = [6.2051701859880914]
+DistributionSupport() = ['(0, 1)', '(1, 1)', '(2, 1)', '(3, 1)', '(4, 1)', '(5, 1)', '(6, 1)', '(7, 1)', '(8, 1)', '(9, 1)']
+
+# Set mean field distribution to be uniform
+action: update_distribution
+
+# State 6
+# Apply action "1"
+action: 2
+
+# State 7
+# (5, 2)
+IsTerminal() = False
+History() = [4, 1, 1, 1, 2]
+HistoryString() = "4, 1, 1, 1, 2"
+IsChanceNode() = False
+IsSimultaneousNode() = False
+CurrentPlayer() = 0
+InformationStateString(0) = "4, 1, 1, 1, 2"
+ObservationString(0) = "(5, 2)"
+PublicObservationString() = "(5, 2)"
+PrivateObservationString(0) = ""
+ObservationTensor(0).x: ◯◯◯◯◯◉◯◯◯◯
+ObservationTensor(0).t: ◯◯◯◯◯◯◯◯◯◯
+Rewards() = [3.3025850929940455]
+Returns() = [9.507755278982136]
+LegalActions() = [0, 1, 2]
+StringLegalActions() = ["-1", "0", "1"]
+
+# Apply action "1"
+action: 2
+
+# State 8
+# (6, 2)_a
+IsTerminal() = False
+History() = [4, 1, 1, 1, 2, 2]
+HistoryString() = "4, 1, 1, 1, 2, 2"
+IsChanceNode() = False
+IsSimultaneousNode() = False
+CurrentPlayer() = PlayerId.MEAN_FIELD
+InformationStateString(0) = "4, 1, 1, 1, 2, 2"
+ObservationString(0) = "(6, 2)_a"
+PublicObservationString() = "(6, 2)_a"
+PrivateObservationString(0) = ""
+ObservationTensor(0).x: ◯◯◯◯◯◯◉◯◯◯
+ObservationTensor(0).t: ◯◯◯◯◯◯◯◯◯◯
+Rewards() = [0.0]
+Returns() = [9.507755278982136]
+DistributionSupport() = ['(0, 2)', '(1, 2)', '(2, 2)', '(3, 2)', '(4, 2)', '(5, 2)', '(6, 2)', '(7, 2)', '(8, 2)', '(9, 2)']
+
+# Set mean field distribution to be uniform
+action: update_distribution
+
+# State 9
+# Apply action "1"
+action: 2
+
+# State 10
+# Apply action "0"
+action: 1
+
+# State 11
+# Set mean field distribution to be uniform
+action: update_distribution
+
+# State 12
+# Apply action "1"
+action: 2
+
+# State 13
+# Apply action "-1"
+action: 0
+
+# State 14
+# Set mean field distribution to be uniform
+action: update_distribution
+
+# State 15
+# Apply action "1"
+action: 2
+
+# State 16
+# Apply action "-1"
+action: 0
+
+# State 17
+# Set mean field distribution to be uniform
+action: update_distribution
+
+# State 18
+# Apply action "1"
+action: 2
+
+# State 19
+# Apply action "0"
+action: 1
+
+# State 20
+# Set mean field distribution to be uniform
+action: update_distribution
+
+# State 21
+# Apply action "0"
+action: 1
+
+# State 22
+# Apply action "-1"
+action: 0
+
+# State 23
+# Set mean field distribution to be uniform
+action: update_distribution
+
+# State 24
+# Apply action "0"
+action: 1
+
+# State 25
+# Apply action "1"
+action: 2
+
+# State 26
+# Set mean field distribution to be uniform
+action: update_distribution
+
+# State 27
+# Apply action "-1"
+action: 0
+
+# State 28
+# Apply action "1"
+action: 2
+
+# State 29
+# Set mean field distribution to be uniform
+action: update_distribution
+
+# State 30
+# Apply action "0"
+action: 1
+
+# State 31
+# (8, 10)
+IsTerminal() = True
+History() = [4, 1, 1, 1, 2, 2, 2, 1, 2, 0, 2, 0, 2, 1, 1, 0, 1, 2, 0, 2, 1]
+HistoryString() = "4, 1, 1, 1, 2, 2, 2, 1, 2, 0, 2, 0, 2, 1, 1, 0, 1, 2, 0, 2, 1"
+IsChanceNode() = False
+IsSimultaneousNode() = False
+CurrentPlayer() = PlayerId.TERMINAL
+InformationStateString(0) = "4, 1, 1, 1, 2, 2, 2, 1, 2, 0, 2, 0, 2, 1, 1, 0, 1, 2, 0, 2, 1"
+ObservationString(0) = "(8, 10)"
+PublicObservationString() = "(8, 10)"
+PrivateObservationString(0) = ""
+ObservationTensor(0).x: ◯◯◯◯◯◯◯◯◉◯
+ObservationTensor(0).t: ◯◯◯◯◯◯◯◯◯◯
+Rewards() = [2.6025850929940457]
+Returns() = [31.1284360229345]

--- a/open_spiel/python/algorithms/generate_playthrough.py
+++ b/open_spiel/python/algorithms/generate_playthrough.py
@@ -28,6 +28,7 @@ import numpy as np
 
 from open_spiel.python import games  # pylint: disable=unused-import
 from open_spiel.python.observation import make_observation
+from open_spiel.python.mfg import games  # pylint: disable=unused-import,reimported
 import pyspiel
 
 

--- a/open_spiel/python/mfg/__init__.py
+++ b/open_spiel/python/mfg/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/open_spiel/python/mfg/algorithms/__init__.py
+++ b/open_spiel/python/mfg/algorithms/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/open_spiel/python/mfg/games/__init__.py
+++ b/open_spiel/python/mfg/games/__init__.py
@@ -1,0 +1,29 @@
+# Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Mean Field Games implemented in Python.
+
+These games are registered as they are imported. It's perfectly possible to
+import just a single game if you prefer. There is no need to add new games here,
+so long as they register themselves and you import them when wanting to uise
+them. However, adding them here will make them available for playthroughs and
+for automated API testing.
+
+Registration looks like this:
+```
+pyspiel.register_game(_GAME_TYPE, MFGCrowdModellingGame)
+```
+"""
+
+from open_spiel.python.mfg.games import crowd_modelling

--- a/open_spiel/python/mfg/games/crowd_modelling.py
+++ b/open_spiel/python/mfg/games/crowd_modelling.py
@@ -278,7 +278,7 @@ class Observer:
     # convenient than with the 1-D tensor. Both are views onto the same memory.
     self.tensor.fill(0)
     self.dict["x"][state.x] = 1
-    self.dict["t"][state.t] = 1
+    # self.dict["t"][state.t] = 1
 
   def string_from(self, state, player):
     """Observation of `state` from the PoV of `player`, as a string."""

--- a/open_spiel/python/tests/pyspiel_test.py
+++ b/open_spiel/python/tests/pyspiel_test.py
@@ -23,6 +23,7 @@ from absl.testing import absltest
 
 from open_spiel.python import games  # pylint: disable=unused-import
 from open_spiel.python import policy
+from open_spiel.python.mfg import games  # pylint: disable=unused-import,reimported
 import pyspiel
 
 # Specify game names in alphabetical order, to make the test easier to read.
@@ -88,6 +89,7 @@ EXPECTED_GAMES = set([
     "pig",
     "python_iterated_prisoners_dilemma",
     "python_kuhn_poker",
+    "python_mfg_crowd_modelling",
     "python_tic_tac_toe",
     "quoridor",
     "repeated_game",


### PR DESCRIPTION
The tests for this PR will fail because I cannot generate a play-through for `python_mfg_crowd_modelling` (https://github.com/deepmind/open_spiel/issues/617). Therefore `integration_tests/playthrough_test.py` fails.
It would be great to enable generating playthrough for python mean field games as it should help for developers (like me) that would like to implement a mean field game in python.