### PR TITLE
removing the game call to GoofSpiel

### DIFF
--- a/open_spiel/colabs/CFR_and_REINFORCE.ipynb
+++ b/open_spiel/colabs/CFR_and_REINFORCE.ipynb
@@ -150,8 +150,6 @@
       },
       "outputs": [],
       "source": [
-        "game = pyspiel.load_game('turn_based_simultaneous_game(game=goofspiel(imp_info=true,num_cards=4,players=2,points_order=descending))')\n",
-        "policy = policy_lib.TabularPolicy(game)\n",
         "initial_state = game.new_initial_state()\n",
         "curr_policy = policy.action_probability_array.copy()\n",
         "regrets = np.zeros_like(policy.action_probability_array)\n",


### PR DESCRIPTION
The call to game GoofSpiel breaks the tutorial. In cell "id": "orVhRjWBsBWx", it explicitly states about likelihood of betting with a a king, jack, or queen, which is clearly alluding to Kuhn Poker, not goofspiel. Removing the game change makes the tutorial run fine, and all outputs make sense