### PR TITLE
Remove misleading comment in LibTorch AlphaZero

### DIFF
--- a/open_spiel/algorithms/alpha_zero_torch/alpha_zero.cc
+++ b/open_spiel/algorithms/alpha_zero_torch/alpha_zero.cc
@@ -424,7 +424,6 @@ void learner(const open_spiel::Game& game, const AlphaZeroConfig& config,
 
     DataLogger::Record record = {
         {"step", step},
-        // XXX: "total_states" is currently incorrect if resuming.
         {"total_states", replay_buffer.TotalAdded()},
         {"states_per_s", num_states / seconds},
         {"states_per_s_actor", num_states / (config.actors * seconds)},
@@ -542,8 +541,8 @@ bool AlphaZero(AlphaZeroConfig config, StopToken* stop, bool resuming) {
 
   StartInfo start_info = {/*start_time=*/absl::Now(),
                           /*start_step=*/1,
-                          /*model_checkpoint_step*/0,
-                          /*total_trajectories*/0};
+                          /*model_checkpoint_step=*/0,
+                          /*total_trajectories=*/0};
   if (resuming) {
     start_info = StartInfoFromLearnerJson(config.path);
   }


### PR DESCRIPTION
Sorry, I missed that I had left a comment in `alpha_zero.cc` that stated that some recorded data was wrong if the training was resumed. However, since the serializable buffer has been added, the data that is recorded is actually correct. Therefore, this comment isn't needed anymore.

These changes also include a minor modification to two other comments.