### PR TITLE
Distinguish old and new states in distribution and add assertions

### DIFF
--- a/open_spiel/python/mfg/algorithms/best_response_value.py
+++ b/open_spiel/python/mfg/algorithms/best_response_value.py
@@ -75,13 +75,8 @@ class BestResponse(value.ValueFunction):
       return self._state_value[state_str]
     elif state.current_player() == pyspiel.PlayerId.MEAN_FIELD:
       dist_to_register = state.distribution_support()
-      def get_state_probability(str_state):
-        try:
-          return self._distribution.value_str(str_state)
-        except ValueError:
-          return 0
       dist = [
-          get_state_probability(str_state)
+          self._distribution.value_str(str_state, 0.)
           for str_state in dist_to_register
       ]
       assert abs(sum(dist) - self.game.num_players()) < 1e-4, (

--- a/open_spiel/python/mfg/algorithms/best_response_value.py
+++ b/open_spiel/python/mfg/algorithms/best_response_value.py
@@ -75,10 +75,18 @@ class BestResponse(value.ValueFunction):
       return self._state_value[state_str]
     elif state.current_player() == pyspiel.PlayerId.MEAN_FIELD:
       dist_to_register = state.distribution_support()
+      def get_state_probability(str_state):
+        try:
+          return self._distribution.value_str(str_state)
+        except ValueError:
+          return 0
       dist = [
-          self._distribution.value_str(str_state)
+          get_state_probability(str_state)
           for str_state in dist_to_register
       ]
+      assert abs(sum(dist) - self.game.num_players()) < 1e-4, (
+            "Sum of probabilities of all possible states should be the number "
+            f"of population, it is {sum(dist)}.")
       new_state = state.clone()
       new_state.update_distribution(dist)
       self._state_value[state_str] = (

--- a/open_spiel/python/mfg/algorithms/distribution.py
+++ b/open_spiel/python/mfg/algorithms/distribution.py
@@ -133,10 +133,25 @@ class DistributionPolicy(distribution.Distribution):
         mfg_state.observation_string(pyspiel.PlayerId.DEFAULT_PLAYER_ID))
 
   def value_str(self, mfg_state_str, default_value = None):
+    """Return probability of the state encoded by mfg_state_str.
+
+    Args:
+      mfg_state_str: string description of the state. This should be created
+        using observation_string.
+      default_value: in case the state has not been seen by the distribution, to
+        avoid raising a value error the default value is returned if it is not
+        None.
+    Returns:
+      state_probability: probability to be in the state descripbed by
+        mfg_state_str.
+    Raises:
+      ValueError: if the state has not been seen by the distribution and no
+        default value has been passed to the method.
+    """
     if default_value is None:
       try:
         return self.distribution[mfg_state_str]
       except KeyError as e:
         raise ValueError(
           f'Distribution not computed for state {mfg_state_str}') from e
-    return self.distribution.get(mfg_state_str, 0.)
+    return self.distribution.get(mfg_state_str, default_value)

--- a/open_spiel/python/mfg/algorithms/distribution.py
+++ b/open_spiel/python/mfg/algorithms/distribution.py
@@ -33,7 +33,6 @@ class DistributionPolicy(distribution.Distribution):
     """
     super(DistributionPolicy, self).__init__(game)
     self._policy = policy
-    self.game = game
     if root_state is None:
       self._root_states = game.new_initial_states()
     else:
@@ -88,13 +87,8 @@ class DistributionPolicy(distribution.Distribution):
             pyspiel.StateType.MEAN_FIELD):
         for mfg_state in listing_states:
           dist_to_register = mfg_state.distribution_support()
-          def get_probability_for_state(str_state):
-            try:
-              return self.value_str(str_state)
-            except ValueError:
-              return 0
           dist = [
-            get_probability_for_state(str_state)
+            self.distribution.get(str_state, 0.)
             for str_state in dist_to_register
           ]
           assert abs(sum(dist) - self.game.num_players()) < 1e-4, (
@@ -142,6 +136,5 @@ class DistributionPolicy(distribution.Distribution):
     try:
       return self.distribution[mfg_state_str]
     except KeyError as e:
-      # Check this because self.distribution is a default dict.
       raise ValueError(
         f'Distribution not computed for state {mfg_state_str}') from e

--- a/open_spiel/python/mfg/algorithms/distribution.py
+++ b/open_spiel/python/mfg/algorithms/distribution.py
@@ -88,7 +88,7 @@ class DistributionPolicy(distribution.Distribution):
         for mfg_state in listing_states:
           dist_to_register = mfg_state.distribution_support()
           dist = [
-            self.distribution.get(str_state, 0.)
+            self.value_str(str_state, 0.)
             for str_state in dist_to_register
           ]
           assert abs(sum(dist) - self.game.num_players()) < 1e-4, (
@@ -132,9 +132,11 @@ class DistributionPolicy(distribution.Distribution):
     return self.value_str(
         mfg_state.observation_string(pyspiel.PlayerId.DEFAULT_PLAYER_ID))
 
-  def value_str(self, mfg_state_str):
-    try:
-      return self.distribution[mfg_state_str]
-    except KeyError as e:
-      raise ValueError(
-        f'Distribution not computed for state {mfg_state_str}') from e
+  def value_str(self, mfg_state_str, default_value = None):
+    if default_value is None:
+      try:
+        return self.distribution[mfg_state_str]
+      except KeyError as e:
+        raise ValueError(
+          f'Distribution not computed for state {mfg_state_str}') from e
+    return self.distribution.get(mfg_state_str, 0.)

--- a/open_spiel/python/mfg/algorithms/distribution.py
+++ b/open_spiel/python/mfg/algorithms/distribution.py
@@ -97,7 +97,7 @@ class DistributionPolicy(distribution.Distribution):
             get_probability_for_state(str_state)
             for str_state in dist_to_register
           ]
-          assert (sum(dist) - self.game.num_players()) < 1e-4, (
+          assert abs(sum(dist) - self.game.num_players()) < 1e-4, (
             "Sum of probabilities of all possible states should be the number "
             f"of population, it is {sum(dist)}.")
           new_mfg_state = mfg_state.clone()

--- a/open_spiel/spiel.h
+++ b/open_spiel/spiel.h
@@ -215,9 +215,7 @@ class State {
 
   // Change the state of the game by applying the specified action in turn-based
   // games or in non-simultaneous nodes of simultaneous move games.
-  // This function encodes the logic of the game rules. Returns true
-  // on success. In simultaneous games, returns false (ApplyActions should be
-  // used in that case.)
+  // This function encodes the logic of the game rules.
   //
   // In the case of chance nodes, the behavior of this function depends on
   // GameType::chance_mode. If kExplicit, then the outcome should be


### PR DESCRIPTION
Assert that the sum over the distribution is always equal to the number of players/populations.

I figure out that they are no tests for multipopulation MFG in python.