### PR TITLE
Do not appen state with 0.0 probability in FP

### DIFF
--- a/open_spiel/python/mfg/algorithms/fictitious_play.py
+++ b/open_spiel/python/mfg/algorithms/fictitious_play.py
@@ -58,7 +58,8 @@ class MergedPolicy(policy_std.Policy):
       for p, d, w in zip(self._policies, self._distributions, self._weights):
         merged_pi += w * d(state) * p(state)[a]
         norm_merged_pi += w * d(state)
-      action_prob.append((a, merged_pi/norm_merged_pi))
+      if norm_merged_pi:
+        action_prob.append((a, merged_pi/norm_merged_pi))
     return dict(action_prob)
 
 


### PR DESCRIPTION
Due to the fact that floating points can not represent value very small, probability of a state can be 0.0. In this case a DivideByZero error will happen. To prevent that we should check that the probability of a state is not 0.

For example if you want to model radioactive decay law (with mean field), at one point the quantity of atoms will be so small that floating point that represents it will be 0.0.