### PR TITLE
fixed random seed in nfsp_jax_test (Issue #602)

### DIFF
--- a/open_spiel/python/CMakeLists.txt
+++ b/open_spiel/python/CMakeLists.txt
@@ -192,9 +192,7 @@ if (OPEN_SPIEL_ENABLE_JAX)
   # Only current JAX test is the bridge supervised learning example below.
   set (PYTHON_TESTS ${PYTHON_TESTS}
     jax/dqn_jax_test.py
-    # This test is flaky. TODO(perolat): fix this.
-    # See https://github.com/deepmind/open_spiel/issues/602
-    # jax/nfsp_jax_test.py
+    jax/nfsp_jax_test.py
   )
 endif()
 

--- a/open_spiel/python/jax/nfsp_jax_test.py
+++ b/open_spiel/python/jax/nfsp_jax_test.py
@@ -22,6 +22,7 @@ import collections
 
 from absl.testing import absltest
 from scipy import stats
+import numpy as np
 
 from open_spiel.python import rl_environment
 from open_spiel.python.jax import nfsp
@@ -78,6 +79,7 @@ class ReservoirBufferTest(absltest.TestCase):
     self.assertEqual(len(reservoir_buffer), 2)
 
   def test_reservoir_uniform(self):
+    np.random.seed(42)
     size = 10
     max_value = 100
     num_trials = 1000


### PR DESCRIPTION
added fixed np-seed to reservoir buffer sampling in nfsp_jax_test to avoid occasional unlucky sampling as seen in #602 