### PR TITLE
Assign probability 0 to states not seen in distribution support.

### DIFF
--- a/open_spiel/python/mfg/algorithms/policy_value.py
+++ b/open_spiel/python/mfg/algorithms/policy_value.py
@@ -68,7 +68,7 @@ class PolicyValue(value.ValueFunction):
     elif state.current_player() == pyspiel.PlayerId.MEAN_FIELD:
       dist_to_register = state.distribution_support()
       dist = [
-          self._distribution.value_str(str_state)
+          self._distribution.value_str(str_state, 0.)
           for str_state in dist_to_register
       ]
       new_state = state.clone()


### PR DESCRIPTION
Enable distribution_support to return state that have not been seen by the distribution.