### PR TITLE
Add MaxChanceNodesInHistory in python game binding

### DIFF
--- a/open_spiel/python/pybind11/python_games.cc
+++ b/open_spiel/python/pybind11/python_games.cc
@@ -47,6 +47,12 @@ std::unique_ptr<State> PyGame::NewInitialStateForPopulation(
                               NewInitialStateForPopulation, population);
 }
 
+int PyGame::MaxChanceNodesInHistory() const {
+  PYBIND11_OVERLOAD_PURE_NAME(int, Game,
+                              "max_chance_nodes_in_history",
+                              MaxChanceNodesInHistory);
+}
+
 const Observer& PyGame::default_observer() const {
   if (!default_observer_) default_observer_ = MakeObserver(kDefaultObsType, {});
   return *default_observer_;

--- a/open_spiel/python/pybind11/python_games.h
+++ b/open_spiel/python/pybind11/python_games.h
@@ -35,6 +35,7 @@ class PyGame : public Game {
   std::unique_ptr<State> NewInitialState() const override;
   std::unique_ptr<State> NewInitialStateForPopulation(
       int population) const override;
+  int MaxChanceNodesInHistory() const override;
   int NumDistinctActions() const override { return info_.num_distinct_actions; }
   int NumPlayers() const override { return info_.num_players; }
   double MinUtility() const override { return info_.min_utility; }


### PR DESCRIPTION
This is done after working on #648.
This enables using random_sim in python mfgs tests. Because of other issues in python mfgs tests, I am only submitting this PR for python mfgs.

@lanctot let me know if you prefer keep one bigger PR (#648) instead of many small PRs.