### PR TITLE
Add binding and test for one population mfg using random sim

### DIFF
--- a/open_spiel/python/mfg/games/crowd_modelling.py
+++ b/open_spiel/python/mfg/games/crowd_modelling.py
@@ -89,6 +89,10 @@ class MFGCrowdModellingGame(pyspiel.Game):
       return Observer(params, self)
     return IIGObserverForPublicInfoGame(iig_obs_type, params)
 
+  def max_chance_nodes_in_history(self):
+    """Maximun chance nodes in game history."""
+    return self.horizon + 1
+
 
 class MFGCrowdModellingState(pyspiel.State):
   """A Mean Field Crowd Modelling state."""

--- a/open_spiel/python/mfg/games/crowd_modelling_test.py
+++ b/open_spiel/python/mfg/games/crowd_modelling_test.py
@@ -59,39 +59,14 @@ class MFGCrowdModellingGameTest(absltest.TestCase):
 
   def test_random_game(self):
     """Tests basic API functions."""
-    np.random.seed(7)
     horizon = 20
     size = 50
     game = crowd_modelling.MFGCrowdModellingGame(params={
         "horizon": horizon,
         "size": size
     })
-    state = game.new_initial_state()
-    t = 0
-    while not state.is_terminal():
-      if state.current_player() == pyspiel.PlayerId.CHANCE:
-        actions, probs = zip(*state.chance_outcomes())
-        action = np.random.choice(actions, p=probs)
-        self.check_cloning(state)
-        self.assertEqual(len(state.legal_actions()),
-                         len(state.chance_outcomes()))
-        state.apply_action(action)
-      elif state.current_player() == pyspiel.PlayerId.MEAN_FIELD:
-        self.assertEqual(state.legal_actions(), [])
-        self.check_cloning(state)
-        num_states = len(state.distribution_support())
-        state.update_distribution([1 / num_states] * num_states)
-      else:
-        self.assertEqual(state.current_player(), 0)
-        self.check_cloning(state)
-        state.observation_string()
-        state.information_state_string()
-        legal_actions = state.legal_actions()
-        action = np.random.choice(legal_actions)
-        state.apply_action(action)
-        t += 1
-
-    self.assertEqual(t, horizon)
+    pyspiel.random_sim_test(
+        game, num_sims=10, serialize=False, verbose=True)
 
   def test_reward(self):
     game = crowd_modelling.MFGCrowdModellingGame()

--- a/open_spiel/python/pybind11/python_games.cc
+++ b/open_spiel/python/pybind11/python_games.cc
@@ -47,6 +47,12 @@ std::unique_ptr<State> PyGame::NewInitialStateForPopulation(
                               NewInitialStateForPopulation, population);
 }
 
+int PyGame::MaxChanceNodesInHistory() const {
+  PYBIND11_OVERLOAD_PURE_NAME(int, Game,
+                              "max_chance_nodes_in_history",
+                              MaxChanceNodesInHistory);
+}
+
 const Observer& PyGame::default_observer() const {
   if (!default_observer_) default_observer_ = MakeObserver(kDefaultObsType, {});
   return *default_observer_;
@@ -138,6 +144,15 @@ std::unique_ptr<State> PyState::Clone() const {
   state->move_number_ = move_number_;
 
   return rv;
+}
+
+std::vector<std::string> PyState::DistributionSupport() {
+  PYBIND11_OVERLOAD_PURE_NAME(std::vector<std::string>, State,
+                              "distribution_support", DistributionSupport);
+}
+void PyState::UpdateDistribution(const std::vector<double>& distribution) {
+  PYBIND11_OVERLOAD_PURE_NAME(void, State, "update_distribution",
+                              UpdateDistribution, distribution);
 }
 
 // Register a Python game.

--- a/open_spiel/python/pybind11/python_games.h
+++ b/open_spiel/python/pybind11/python_games.h
@@ -35,6 +35,7 @@ class PyGame : public Game {
   std::unique_ptr<State> NewInitialState() const override;
   std::unique_ptr<State> NewInitialStateForPopulation(
       int population) const override;
+  int MaxChanceNodesInHistory() const override;
   int NumDistinctActions() const override { return info_.num_distinct_actions; }
   int NumPlayers() const override { return info_.num_players; }
   double MinUtility() const override { return info_.min_utility; }
@@ -77,6 +78,8 @@ class PyState : public State, public py::trampoline_self_life_support {
   std::vector<double> Returns() const override;
   std::vector<double> Rewards() const override;
   std::unique_ptr<State> Clone() const override;
+  std::vector<std::string> DistributionSupport() override;
+  void UpdateDistribution(const std::vector<double>& distribution) override;
   void DoApplyAction(Action action_id) override;
   void DoApplyActions(const std::vector<Action>& actions) override;
   std::string InformationStateString(Player player) const override;

--- a/open_spiel/tests/basic_tests.cc
+++ b/open_spiel/tests/basic_tests.cc
@@ -328,8 +328,7 @@ void RandomSimulation(std::mt19937* rng, const Game& game, bool undo,
     SPIEL_CHECK_EQ(state->ToString(), state_copy->ToString());
     SPIEL_CHECK_EQ(state->History(), state_copy->History());
 
-
-    if (game.GetType().dynamics == GameType::Dynamics::kMeanField){
+    if (game.GetType().dynamics == GameType::Dynamics::kMeanField) {
       SPIEL_CHECK_LT(state->MoveNumber(), game.MaxMoveNumber());
       SPIEL_CHECK_EQ(state->MoveNumber(), num_moves);
     }

--- a/open_spiel/tests/basic_tests.cc
+++ b/open_spiel/tests/basic_tests.cc
@@ -255,6 +255,19 @@ void CheckObservables(const Game& game,
   }
 }
 
+std::vector<double> RandomDistribution(int num_states, std::mt19937& rng) {
+  std::uniform_real_distribution<double> rand(0, 1);
+  std::vector<double> distrib;
+  for (int i = 0; i < num_states; ++i) {
+    distrib.push_back(rand(rng));
+  }
+  double sum = std::accumulate(distrib.begin(), distrib.end(), 0.);
+  for (int i = 0; i < num_states; ++i) {
+    distrib[i] /= sum;
+  }
+  return distrib;
+}
+
 void RandomSimulation(std::mt19937* rng, const Game& game, bool undo,
                       bool serialize, bool verbose, bool mask_test,
                       std::shared_ptr<Observer> observer,  // Can be nullptr
@@ -296,6 +309,7 @@ void RandomSimulation(std::mt19937* rng, const Game& game, bool undo,
     std::cout << "State:" << std::endl << state->ToString() << std::endl;
   }
   int game_length = 0;
+  int num_moves = 0;
 
   while (!state->IsTerminal()) {
     state_checker_fn(*state);
@@ -311,6 +325,12 @@ void RandomSimulation(std::mt19937* rng, const Game& game, bool undo,
     std::unique_ptr<open_spiel::State> state_copy = state->Clone();
     SPIEL_CHECK_EQ(state->ToString(), state_copy->ToString());
     SPIEL_CHECK_EQ(state->History(), state_copy->History());
+
+
+    if (game.GetType().dynamics == GameType::Dynamics::kMeanField){
+      SPIEL_CHECK_LT(state->MoveNumber(), game.MaxMoveNumber());
+      SPIEL_CHECK_EQ(state->MoveNumber(), num_moves);
+    }
 
     if (serialize && (history.size() < 10 || IsPowerOfTwo(history.size()))) {
       TestSerializeDeserialize(game, state.get());
@@ -335,6 +355,7 @@ void RandomSimulation(std::mt19937* rng, const Game& game, bool undo,
       if (undo && (history.size() < 10 || IsPowerOfTwo(history.size()))) {
         TestUndo(state->Clone(), history);
       }
+      num_moves++;
     } else if (state->CurrentPlayer() == open_spiel::kSimultaneousPlayerId) {
       std::vector<double> rewards = state->Rewards();
       SPIEL_CHECK_EQ(rewards.size(), game.NumPlayers());
@@ -372,6 +393,9 @@ void RandomSimulation(std::mt19937* rng, const Game& game, bool undo,
 
       ApplyActionTestClone(game, state.get(), joint_action);
       game_length++;
+    } else if (state->CurrentPlayer() == open_spiel::kMeanFieldPlayerId) {
+      auto support = state->DistributionSupport();
+      state->UpdateDistribution(RandomDistribution(support.size(), *rng));
     } else {
       std::vector<double> rewards = state->Rewards();
       SPIEL_CHECK_EQ(rewards.size(), game.NumPlayers());
@@ -405,6 +429,7 @@ void RandomSimulation(std::mt19937* rng, const Game& game, bool undo,
       history.emplace_back(state->Clone(), player, action);
       ApplyActionTestClone(game, state.get(), action);
       game_length++;
+      num_moves++;
 
       if (undo && (history.size() < 10 || IsPowerOfTwo(history.size()))) {
         TestUndo(state->Clone(), history);


### PR DESCRIPTION
This PR already contains changed in https://github.com/deepmind/open_spiel/pull/659 and https://github.com/deepmind/open_spiel/pull/658.
It was originally based on https://github.com/deepmind/open_spiel/pull/648 but does not fix bugs for crowd modelling 2d C++ game neither for predator pray python game (only multipopulation mfg so far in open spiel).
