### PR TITLE
Fix predator prey and update random sim test

### DIFF
--- a/open_spiel/integration_tests/playthroughs/python_mfg_predator_prey.txt
+++ b/open_spiel/integration_tests/playthroughs/python_mfg_predator_prey.txt
@@ -18,7 +18,7 @@ GameType.utility = Utility.GENERAL_SUM
 
 NumDistinctActions() = 5
 PolicyTensorShape() = [5]
-MaxChanceOutcomes() = 5
+MaxChanceOutcomes() = 25
 GetParameters() = {geometry=0,horizon=10,players=3,reward_matrix=0 -1 1 1 0 -1 -1 1 0,size=5}
 NumPlayers() = 3
 MinUtility() = -inf

--- a/open_spiel/python/mfg/games/predator_prey.py
+++ b/open_spiel/python/mfg/games/predator_prey.py
@@ -98,7 +98,7 @@ class MFGPredatorPreyGame(pyspiel.Game):
     self.geometry = get_param("geometry", params)
     game_info = pyspiel.GameInfo(
         num_distinct_actions=_NUM_ACTIONS,
-        max_chance_outcomes=max(self.size, _NUM_CHANCE),
+        max_chance_outcomes=max(self.size * self.size, _NUM_CHANCE),
         num_players=num_players,
         min_utility=-np.inf,
         max_utility=+np.inf,
@@ -115,6 +115,10 @@ class MFGPredatorPreyGame(pyspiel.Game):
     instantiated with new_initial_state_for_population().
     """
     return MFGPredatorPreyState(self)
+
+  def max_chance_nodes_in_history(self):
+    """Maximun chance nodes in game history."""
+    return self.horizon + 1
 
   def new_initial_state_for_population(self, population):
     """State corresponding to the start of a game for a given population."""

--- a/open_spiel/python/mfg/games/predator_prey_test.py
+++ b/open_spiel/python/mfg/games/predator_prey_test.py
@@ -76,39 +76,15 @@ class MFGPredatorPreyGameTest(parameterized.TestCase):
   )
   def test_random_game(self, population):
     """Tests basic API functions."""
-    np.random.seed(7)
     horizon = 10
     size = 20
     game = predator_prey.MFGPredatorPreyGame(params={
         'horizon': horizon,
         'size': size,
     })
-    state = game.new_initial_state_for_population(population)
-    t = 0
-    while not state.is_terminal():
-      if state.current_player() == pyspiel.PlayerId.CHANCE:
-        actions, probs = zip(*state.chance_outcomes())
-        action = np.random.choice(actions, p=probs)
-        self.check_cloning(state)
-        self.assertEqual(
-            len(state.legal_actions()), len(state.chance_outcomes()))
-        state.apply_action(action)
-      elif state.current_player() == pyspiel.PlayerId.MEAN_FIELD:
-        self.assertEqual(state.legal_actions(), [])
-        self.check_cloning(state)
-        num_states = len(state.distribution_support())
-        state.update_distribution([1 / num_states] * num_states)
-      else:
-        self.assertEqual(state.current_player(), population)
-        self.check_cloning(state)
-        state.observation_string()
-        state.information_state_string()
-        legal_actions = state.legal_actions()
-        action = np.random.choice(legal_actions)
-        state.apply_action(action)
-        t += 1
-
-    self.assertEqual(t, horizon)
+    pyspiel.random_sim_test(
+        game, num_sims=10, serialize=False, verbose=True,
+        mean_field_population=population)
 
   @parameterized.parameters(
       {

--- a/open_spiel/python/pybind11/pyspiel.cc
+++ b/open_spiel/python/pybind11/pyspiel.cc
@@ -584,6 +584,7 @@ PYBIND11_MODULE(pyspiel, m) {
         py::arg("mask_test") = true,
         py::arg("state_checker_fn") =
             py::cpp_function(&testing::DefaultStateChecker),
+        py::arg("mean_field_population") = -1,
         "Run the C++ tests on a game");
 
   // Set an error handler that will raise exceptions. These exceptions are for

--- a/open_spiel/tests/basic_tests.cc
+++ b/open_spiel/tests/basic_tests.cc
@@ -273,7 +273,8 @@ std::vector<double> RandomDistribution(int num_states, std::mt19937* rng) {
 void RandomSimulation(std::mt19937* rng, const Game& game, bool undo,
                       bool serialize, bool verbose, bool mask_test,
                       std::shared_ptr<Observer> observer,  // Can be nullptr
-                      std::function<void(const State&)> state_checker_fn
+                      std::function<void(const State&)> state_checker_fn,
+                      int mean_field_population = -1
                      ) {
   std::unique_ptr<Observation> observation =
       observer == nullptr ? nullptr
@@ -304,7 +305,12 @@ void RandomSimulation(std::mt19937* rng, const Game& game, bool undo,
 
     std::cout << "Starting new game.." << std::endl;
   }
-  std::unique_ptr<open_spiel::State> state = game.NewInitialState();
+  std::unique_ptr<open_spiel::State> state;
+  if (mean_field_population == -1) {
+    state = game.NewInitialState();
+  } else {
+    state = game.NewInitialStateForPopulation(mean_field_population);
+  }
 
   if (verbose) {
     std::cout << "Initial state:" << std::endl;
@@ -485,7 +491,8 @@ void RandomSimulation(std::mt19937* rng, const Game& game, bool undo,
 // Perform sims random simulations of the specified game.
 void RandomSimTest(const Game& game, int num_sims, bool serialize,
                    bool verbose, bool mask_test,
-                   const std::function<void(const State&)>& state_checker_fn) {
+                   const std::function<void(const State&)>& state_checker_fn,
+                   int mean_field_population) {
   std::mt19937 rng;
   if (verbose) {
     std::cout << "\nRandomSimTest, game = " << game.GetType().short_name
@@ -493,7 +500,8 @@ void RandomSimTest(const Game& game, int num_sims, bool serialize,
   }
   for (int sim = 0; sim < num_sims; ++sim) {
     RandomSimulation(&rng, game, /*undo=*/false, /*serialize=*/serialize,
-                     verbose, mask_test, nullptr, state_checker_fn);
+                     verbose, mask_test, nullptr, state_checker_fn,
+                     mean_field_population);
   }
 }
 

--- a/open_spiel/tests/basic_tests.h
+++ b/open_spiel/tests/basic_tests.h
@@ -47,7 +47,8 @@ void RandomSimTest(
     const Game& game, int num_sims,
     bool serialize = true, bool verbose = true, bool mask_test = true,
     const std::function<void(const State&)>& state_checker_fn
-        = &DefaultStateChecker);
+        = &DefaultStateChecker,
+    int mean_field_population = -1);
 
 // Perform num_sims random simulations of the specified game. Also tests the
 // Undo function. Note: for every step in the simulation, the entire simulation


### PR DESCRIPTION
This PR is based on https://github.com/deepmind/open_spiel/pull/660 but also modify random sim test to add mean field population.
The PR also fix max chance outcome of predator prey. Therefore the PR enables using random sim test for predator prey.