### PR TITLE
Skat game fix PlayLegalActions bug for null game type

### DIFF
--- a/open_spiel/games/skat.cc
+++ b/open_spiel/games/skat.cc
@@ -598,7 +598,7 @@ std::vector<Action> SkatState::PlayLegalActions() const {
     int suit = CardSuit(first_card);
     if (game_type_ == kNullGame) {
       for (int rank = 0; rank < kNumRanks; ++rank) {
-        int card = rank * kNumSuits + static_cast<int>(suit);
+        int card = static_cast<int>(suit) * kNumRanks + rank;
         if (card_locations_[card] == PlayerToLocation(current_player_)) {
           legal_actions.push_back(card);
         }


### PR DESCRIPTION
This is a simple one line patch to fix a bug in the calculation of legal actions in the skat game for "null" the game type.

### Description

`PlayLegalActions` when `game_type_ == kNullGame` should return all cards in the current players hand that follow the suit of the first card played in the current trick. If either this is the first card of the trick, or the current player does not have a card that follows suit, any card in the hand is a legal move.

The current behavior does not adhere to the [Skat Rules](https://en.wikipedia.org/wiki/Skat_(card_game)) and I think it's a simple case of two variable names being accidentally swapped. 

Please let me know if any changes are needed and many thanks for this great project :)

### Examples

#### Current Results:
```In [2]: skat = pyspiel.load_game("skat")

In [2]: skat = pyspiel.load_game("skat")

In [3]: state = skat.new_initial_state()

In [4]: for i in range(32):
   ...:     state.apply_action(i) # deal cards
   ...: 

In [5]: state.apply_action(38) # select null game type

In [6]: for _ in range(2): # discard cards to start playing phase
   ...:     state.apply_action(state.legal_actions()[-1])
   ...: 

In [7]: state.apply_action(0)

In [8]: state
Out[8]: 
Phase: playing 
Current Player: 1
Deck:     
Player 0: 🃈 🃉 🂸 🂹 🂽 🂾 🂺 🂱 🂫 
Player 1: 🃍 🃎 🃊 🂻 🂧 🂨 🂩 🃙 🃝 🃞 
Player 2: 🃁 🃋 🂷 🂭 🂮 🂪 🂡 🃚 🃑 🃛 
Skat:     🃗 🃘 

Last trick won by player -1
Solo Player: 0
Points (Solo / Team): (0 / 0)
Current Trick: Leader: 0, 🃇 
Game Type: null

In [9]: state.legal_actions()
Out[9]: [4, 16, 28]

In [10]: # legal actions should be all diamonds in the hand of player 1 (ie. 3,4,5)
```

#### Expected Result / Result after the change:
```
In [2]: skat = pyspiel.load_game("skat")

In [3]: state = skat.new_initial_state()

In [4]: for i in range(32):
   ...:     state.apply_action(i) # deal cards
   ...: 

In [5]: state.apply_action(38) # select null game type

In [6]: for _ in range(2): # discard cards to start playing phase
   ...:     state.apply_action(state.legal_actions()[-1])
   ...: 

In [7]: state.apply_action(0)

In [8]: state
Out[8]: 
Phase: playing 
Current Player: 1
Deck:     
Player 0: 🃈 🃉 🂸 🂹 🂽 🂾 🂺 🂱 🂫 
Player 1: 🃍 🃎 🃊 🂻 🂧 🂨 🂩 🃙 🃝 🃞 
Player 2: 🃁 🃋 🂷 🂭 🂮 🂪 🂡 🃚 🃑 🃛 
Skat:     🃗 🃘 

Last trick won by player -1
Solo Player: 0
Points (Solo / Team): (0 / 0)
Current Trick: Leader: 0, 🃇 
Game Type: null

In [9]: state.legal_actions()
Out[9]: [3, 4, 5]

In [10]: # now the legal actions are correct (all diamonds in the hand)
```