### PR TITLE
Adding softmax policy class for mean field games

### DIFF
--- a/open_spiel/python/mfg/algorithms/softmax_policy.py
+++ b/open_spiel/python/mfg/algorithms/softmax_policy.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Computes a greedy policy from a value."""
+"""Computes a softmax policy from a value."""
 import numpy as np
 
 from open_spiel.python import policy as policy_std

--- a/open_spiel/python/mfg/algorithms/softmax_policy.py
+++ b/open_spiel/python/mfg/algorithms/softmax_policy.py
@@ -34,8 +34,7 @@ class SoftmaxPolicy(policy.Policy):
           be in the range 0..game.num_players()-1.
         temperature: float to scale the values (multiplied by 1/temperature).
         state_action_value: A state-action value function.
-        prior_policy: Optional argument. Prior policy to scale the softmax policy. The prior must have
-          strictly positive coefficients, ohterwise it won't be used in the method action_probabilities.
+        prior_policy: Optional argument. Prior policy to scale the softmax policy.
       """
       super(SoftmaxPolicy, self).__init__(game, player_ids)
       self._state_action_value = state_action_value
@@ -46,12 +45,11 @@ class SoftmaxPolicy(policy.Policy):
       legal_actions = state.legal_actions()
       max_q = np.max([self._state_action_value(state, action)
           for action in legal_actions])
-      if self._prior_policy is not None and 0 not in self._prior_policy.action_probabilities(state):
+      exp_q = [np.exp((self._state_action_value(state, action) - max_q) / self._temperature) for action
+               in legal_actions]
+      if self._prior_policy is not None:
         prior_probs = self._prior_policy.action_probabilities(state)
-        exp_q = [prior_probs.get(action, 0) * np.exp((self._state_action_value(state, action) - max_q)
-                                                     / self._temperature) for action in legal_actions]
-      else:
-        exp_q = [np.exp((self._state_action_value(state, action) - max_q) / self._temperature) for action
-                 in legal_actions]
-      smax_q = exp_q / sum(exp_q)
+        exp_q = [prior_probs.get(action, 0) * exp_q[i] for i, action in enumerate(legal_actions)]
+      denom = sum(exp_q)
+      smax_q = exp_q if denom == 0 else exp_q / denom
       return dict(zip(legal_actions, smax_q))

--- a/open_spiel/python/mfg/algorithms/softmax_policy.py
+++ b/open_spiel/python/mfg/algorithms/softmax_policy.py
@@ -1,0 +1,53 @@
+# Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Computes a greedy policy from a value."""
+import numpy as np
+
+from open_spiel.python import policy as policy_std
+from open_spiel.python.mfg import value
+
+
+class SoftmaxPolicy(policy_std.Policy):
+  """Computes the softmax policy of a value."""
+
+  def __init__(self, game, player_ids, temperature,
+               state_action_value: value.ValueFunction,
+               prior_policy: policy_std.Policy = None):
+      """Initializes the softmax policy.
+      Args:
+        game: The game to analyze.
+        player_ids: list of player ids for which this policy applies; each should
+          be in the range 0..game.num_players()-1.
+        temperature: float to scale the values (multiplied by 1/temperature).
+        state_action_value: A state-action value function.
+        prior_policy: Optional argument. Prior policy to scale the softmax policy.
+      """
+      super(SoftmaxPolicy, self).__init__(game, player_ids)
+      self._state_action_value = state_action_value
+      self._prior_policy = prior_policy
+      self._temperature = temperature
+
+  def action_probabilities(self, state, player_id=None):
+      max_q = np.max([self._state_action_value(state, action)
+          for action in state.legal_actions()])
+      if self._prior_policy is not None:
+        exp_q = [p * np.exp((self._state_action_value(state, action) - max_q) / self._temperature) for action, p
+                in self._prior_policy.action_probabilities(state).items()]
+      else:
+        exp_q = [np.exp((self._state_action_value(state, action) - max_q) / self._temperature) for action
+                 in state.legal_actions()]
+      norm_exp = sum(exp_q)
+      smax_q = exp_q / norm_exp
+      return dict(zip(state.legal_actions(), smax_q))

--- a/open_spiel/python/mfg/algorithms/softmax_policy_test.py
+++ b/open_spiel/python/mfg/algorithms/softmax_policy_test.py
@@ -21,7 +21,6 @@ from open_spiel.python import policy
 from open_spiel.python.mfg import value
 from open_spiel.python.mfg.algorithms import best_response_value
 from open_spiel.python.mfg.algorithms import distribution
-from open_spiel.python.mfg.algorithms import greedy_policy
 from open_spiel.python.mfg.algorithms import softmax_policy
 from open_spiel.python.mfg.algorithms import policy_value
 from open_spiel.python.mfg.games import crowd_modelling  # pylint: disable=unused-import

--- a/open_spiel/python/mfg/algorithms/softmax_policy_test.py
+++ b/open_spiel/python/mfg/algorithms/softmax_policy_test.py
@@ -1,0 +1,103 @@
+# Copyright 2019 DeepMind Technologies Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for softmax_policy."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+
+from open_spiel.python import policy
+from open_spiel.python.mfg import value
+from open_spiel.python.mfg.algorithms import best_response_value
+from open_spiel.python.mfg.algorithms import distribution
+from open_spiel.python.mfg.algorithms import greedy_policy
+from open_spiel.python.mfg.algorithms import softmax_policy
+from open_spiel.python.mfg.algorithms import policy_value
+from open_spiel.python.mfg.games import crowd_modelling  # pylint: disable=unused-import
+import pyspiel
+
+
+class SoftmaxPolicyTest(parameterized.TestCase):
+
+  @parameterized.named_parameters(('python', 'python_mfg_crowd_modelling'),
+                                  ('cpp', 'mfg_crowd_modelling'))
+  def test_softmax(self, name):
+    """Check if the softmax policy works as expected.
+
+    The test checks that:
+    - uniform prior policy gives the same results than no prior.
+    - very high temperature gives almost a uniform policy.
+    - very low temperature gives almost a deterministic policy for the best action.
+
+    Args:
+      name: Name of the game.
+    """
+
+    # Checks that a greedy policy with respect to an optimal value is an optimal policy.
+    game = pyspiel.load_game(name)
+    uniform_policy = policy.UniformRandomPolicy(game)
+    dist = distribution.DistributionPolicy(game, uniform_policy)
+    br_value = best_response_value.BestResponse(
+        game, dist, value.TabularValueFunction(game))
+    br_val = br_value(game.new_initial_state())
+
+    greedy_pi = greedy_policy.GreedyPolicy(game, None, br_value)
+    greedy_pi = greedy_pi.to_tabular()
+    pybr_value = policy_value.PolicyValue(game, dist, greedy_pi,
+                                          value.TabularValueFunction(game))
+    pybr_val = pybr_value(game.new_initial_state())
+    self.assertAlmostEqual(br_val, pybr_val)
+
+    # uniform prior policy gives the same results than no prior.
+    softmax_pi_uniform_prior = softmax_policy.SoftmaxPolicy(game, None, 1.0, br_value, uniform_policy).to_tabular()
+    softmax_pi_uniform_prior_value = policy_value.PolicyValue(game, dist, softmax_pi_uniform_prior,
+                                          value.TabularValueFunction(game))
+    softmax_pi_uniform_prior_val = softmax_pi_uniform_prior_value(game.new_initial_state())
+    softmax_pi_no_prior = softmax_policy.SoftmaxPolicy(game, None, 1.0, br_value, None)
+    softmax_pi_no_prior_value = policy_value.PolicyValue(game, dist, softmax_pi_no_prior,
+                                                            value.TabularValueFunction(game))
+    softmax_pi_no_prior_val = softmax_pi_no_prior_value(game.new_initial_state())
+
+    self.assertAlmostEqual(softmax_pi_uniform_prior_val, softmax_pi_no_prior_val)
+
+    # very high temperature gives almost a uniform policy.
+    uniform_policy = uniform_policy.to_tabular()
+    uniform_value = policy_value.PolicyValue(game, dist, uniform_policy,
+                                          value.TabularValueFunction(game))
+    uniform_val = uniform_value(game.new_initial_state())
+
+    softmax_pi_no_prior = softmax_policy.SoftmaxPolicy(game, None, 100000000, br_value, None)
+    softmax_pi_no_prior_value = policy_value.PolicyValue(game, dist, softmax_pi_no_prior,
+                                                         value.TabularValueFunction(game))
+    softmax_pi_no_prior_val = softmax_pi_no_prior_value(game.new_initial_state())
+
+    self.assertAlmostEqual(uniform_val, softmax_pi_no_prior_val)
+
+    # very low temperature gives almost a best response policy.
+    softmax_pi_no_prior = softmax_policy.SoftmaxPolicy(game, None, 0.0001, br_value, None)
+    softmax_pi_no_prior_value = policy_value.PolicyValue(game, dist, softmax_pi_no_prior,
+                                                         value.TabularValueFunction(game))
+    softmax_pi_no_prior_val = softmax_pi_no_prior_value(game.new_initial_state())
+
+    self.assertAlmostEqual(br_val, softmax_pi_no_prior_val)
+
+
+
+
+
+
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/open_spiel/python/mfg/algorithms/softmax_policy_test.py
+++ b/open_spiel/python/mfg/algorithms/softmax_policy_test.py
@@ -44,60 +44,45 @@ class SoftmaxPolicyTest(parameterized.TestCase):
       name: Name of the game.
     """
 
-    # Checks that a greedy policy with respect to an optimal value is an optimal policy.
     game = pyspiel.load_game(name)
     uniform_policy = policy.UniformRandomPolicy(game)
     dist = distribution.DistributionPolicy(game, uniform_policy)
     br_value = best_response_value.BestResponse(
         game, dist, value.TabularValueFunction(game))
-    br_val = br_value(game.new_initial_state())
-
-    greedy_pi = greedy_policy.GreedyPolicy(game, None, br_value)
-    greedy_pi = greedy_pi.to_tabular()
-    pybr_value = policy_value.PolicyValue(game, dist, greedy_pi,
-                                          value.TabularValueFunction(game))
-    pybr_val = pybr_value(game.new_initial_state())
-    self.assertAlmostEqual(br_val, pybr_val)
+    br_init_val = br_value(game.new_initial_state())
 
     # uniform prior policy gives the same results than no prior.
     softmax_pi_uniform_prior = softmax_policy.SoftmaxPolicy(game, None, 1.0, br_value, uniform_policy).to_tabular()
     softmax_pi_uniform_prior_value = policy_value.PolicyValue(game, dist, softmax_pi_uniform_prior,
                                           value.TabularValueFunction(game))
-    softmax_pi_uniform_prior_val = softmax_pi_uniform_prior_value(game.new_initial_state())
+    softmax_pi_uniform_prior_init_val = softmax_pi_uniform_prior_value(game.new_initial_state())
     softmax_pi_no_prior = softmax_policy.SoftmaxPolicy(game, None, 1.0, br_value, None)
     softmax_pi_no_prior_value = policy_value.PolicyValue(game, dist, softmax_pi_no_prior,
                                                             value.TabularValueFunction(game))
-    softmax_pi_no_prior_val = softmax_pi_no_prior_value(game.new_initial_state())
+    softmax_pi_no_prior_init_val = softmax_pi_no_prior_value(game.new_initial_state())
 
-    self.assertAlmostEqual(softmax_pi_uniform_prior_val, softmax_pi_no_prior_val)
+    self.assertAlmostEqual(softmax_pi_uniform_prior_init_val, softmax_pi_no_prior_init_val)
 
     # very high temperature gives almost a uniform policy.
     uniform_policy = uniform_policy.to_tabular()
     uniform_value = policy_value.PolicyValue(game, dist, uniform_policy,
                                           value.TabularValueFunction(game))
-    uniform_val = uniform_value(game.new_initial_state())
+    uniform_init_val = uniform_value(game.new_initial_state())
 
     softmax_pi_no_prior = softmax_policy.SoftmaxPolicy(game, None, 100000000, br_value, None)
     softmax_pi_no_prior_value = policy_value.PolicyValue(game, dist, softmax_pi_no_prior,
                                                          value.TabularValueFunction(game))
-    softmax_pi_no_prior_val = softmax_pi_no_prior_value(game.new_initial_state())
+    softmax_pi_no_prior_init_val = softmax_pi_no_prior_value(game.new_initial_state())
 
-    self.assertAlmostEqual(uniform_val, softmax_pi_no_prior_val)
+    self.assertAlmostEqual(uniform_init_val, softmax_pi_no_prior_init_val)
 
     # very low temperature gives almost a best response policy.
     softmax_pi_no_prior = softmax_policy.SoftmaxPolicy(game, None, 0.0001, br_value, None)
     softmax_pi_no_prior_value = policy_value.PolicyValue(game, dist, softmax_pi_no_prior,
                                                          value.TabularValueFunction(game))
-    softmax_pi_no_prior_val = softmax_pi_no_prior_value(game.new_initial_state())
+    softmax_pi_no_prior_init_val = softmax_pi_no_prior_value(game.new_initial_state())
 
-    self.assertAlmostEqual(br_val, softmax_pi_no_prior_val)
-
-
-
-
-
-
-
+    self.assertAlmostEqual(br_init_val, softmax_pi_no_prior_init_val)
 
 if __name__ == '__main__':
   absltest.main()

--- a/open_spiel/scripts/python_extra_deps.sh
+++ b/open_spiel/scripts/python_extra_deps.sh
@@ -24,7 +24,7 @@
 #
 # To enable specific tests, please use the environment variables found in
 # scripts/global_variables.sh
-export OPEN_SPIEL_PYTHON_JAX_DEPS="jax==0.2.17 jaxlib==0.1.69 dm-haiku==0.0.3 optax==0.0.8 chex==0.0.7 rlax==0.0.3"
+export OPEN_SPIEL_PYTHON_JAX_DEPS="jax==0.2.17 dm-haiku==0.0.3 optax==0.0.8 chex==0.0.7 rlax==0.0.3"
 export OPEN_SPIEL_PYTHON_PYTORCH_DEPS="torch==1.8.1"
 export OPEN_SPIEL_PYTHON_TENSORFLOW_DEPS="numpy==1.19.5 tensorflow==2.6.0 tensorflow-probability<0.8.0,>=0.7.0 tensorflow_datasets==4.3.0 keras==2.6.0"
 export OPEN_SPIEL_PYTHON_MISC_DEPS="IPython==5.8.0 cvxopt==1.2.5 networkx==2.4 matplotlib==3.3.2 mock==4.0.2 nashpy==0.0.19 scipy==1.5.4 testresources==2.0.1 cvxpy==1.1.13 osqp==0.6.2.post0 clu==0.0.6"


### PR DESCRIPTION
This PR adds a class that allows to compute the softmax policy corresponding to a value function, with a temperature parameter and an optional prior policy.