### PR TITLE
Removing jaxlib from python_extra_deps

### DIFF
--- a/open_spiel/scripts/python_extra_deps.sh
+++ b/open_spiel/scripts/python_extra_deps.sh
@@ -24,7 +24,7 @@
 #
 # To enable specific tests, please use the environment variables found in
 # scripts/global_variables.sh
-export OPEN_SPIEL_PYTHON_JAX_DEPS="jax==0.2.17 jaxlib==0.1.69 dm-haiku==0.0.3 optax==0.0.8 chex==0.0.7 rlax==0.0.3"
+export OPEN_SPIEL_PYTHON_JAX_DEPS="jax==0.2.17 dm-haiku==0.0.3 optax==0.0.8 chex==0.0.7 rlax==0.0.3"
 export OPEN_SPIEL_PYTHON_PYTORCH_DEPS="torch==1.8.1"
 export OPEN_SPIEL_PYTHON_TENSORFLOW_DEPS="numpy==1.19.5 tensorflow==2.6.0 tensorflow-probability<0.8.0,>=0.7.0 tensorflow_datasets==4.3.0 keras==2.6.0"
 export OPEN_SPIEL_PYTHON_MISC_DEPS="IPython==5.8.0 cvxopt==1.2.5 networkx==2.4 matplotlib==3.3.2 mock==4.0.2 nashpy==0.0.19 scipy==1.5.4 testresources==2.0.1 cvxpy==1.1.13 osqp==0.6.2.post0 clu==0.0.6"


### PR DESCRIPTION
Reason: the proper one required by the specified Jax version should be installed alongside Jax.

The specific version seems to be causing problems in testing on Github actions: https://github.com/deepmind/open_spiel/runs/4471352897?check_suite_focus=true