### PR TITLE
MCTS: Sample from prior

### DIFF
--- a/open_spiel/algorithms/mcts.cc
+++ b/open_spiel/algorithms/mcts.cc
@@ -174,6 +174,13 @@ std::string SearchNode::ToString(const State& state) const {
       children.size());
 }
 
+Action SearchNode::SampleFromPrior(const State& state, std::shared_ptr<Evaluator> evaluator, std::mt19937* rng) const {
+  std::unique_ptr<State> working_state = state.Clone();
+  ActionsAndProbs prior = evaluator->Prior(*working_state);
+  Action chosen_action = SampleAction(prior, *rng).first;
+  return chosen_action;
+}
+
 std::vector<double> dirichlet_noise(int count, double alpha,
                                     std::mt19937* rng) {
   std::vector<double> noise;
@@ -219,32 +226,38 @@ MCTSBot::MCTSBot(const Game& game, std::shared_ptr<Evaluator> evaluator,
 Action MCTSBot::Step(const State& state) {
   absl::Time start = absl::Now();
   std::unique_ptr<SearchNode> root = MCTSearch(state);
-  SPIEL_CHECK_GT(root->children.size(), 0);
+  // SPIEL_CHECK_GT(root->children.size(), 0);
 
-  const SearchNode& best = root->BestChild();
+  if ((max_simulations_ == 1) || (max_simulations_ == 0))  {
+    // sample from prior
+    Action sample = root->SampleFromPrior(state, evaluator_, &rng_);
+    return sample;
+  } else {
+    // return best action
+    const SearchNode& best = root->BestChild();
 
-  if (verbose_) {
-    double seconds = absl::ToDoubleSeconds(absl::Now() - start);
-    std::cerr
-        << absl::StrFormat(
-               ("Finished %d sims in %.3f secs, %.1f sims/s, "
-                "tree size: %d nodes / %d mb."),
-               root->explore_count, seconds, (root->explore_count / seconds),
-               nodes_, MemoryUsedMb(nodes_))
-        << std::endl;
-    std::cerr << "Root:" << std::endl;
-    std::cerr << root->ToString(state) << std::endl;
-    std::cerr << "Children:" << std::endl;
-    std::cerr << root->ChildrenStr(state) << std::endl;
-    if (!best.children.empty()) {
-      std::unique_ptr<State> chosen_state = state.Clone();
-      chosen_state->ApplyAction(best.action);
-      std::cerr << "Children of chosen:" << std::endl;
-      std::cerr << best.ChildrenStr(*chosen_state) << std::endl;
-    }
+    if (verbose_) {
+      double seconds = absl::ToDoubleSeconds(absl::Now() - start);
+      std::cerr
+          << absl::StrFormat(
+                 ("Finished %d sims in %.3f secs, %.1f sims/s, "
+                  "tree size: %d nodes / %d mb."),
+                 root->explore_count, seconds, (root->explore_count / seconds),
+                 nodes_, MemoryUsedMb(nodes_))
+          << std::endl;
+      std::cerr << "Root:" << std::endl;
+      std::cerr << root->ToString(state) << std::endl;
+      std::cerr << "Children:" << std::endl;
+      std::cerr << root->ChildrenStr(state) << std::endl;
+      if (!best.children.empty()) {
+        std::unique_ptr<State> chosen_state = state.Clone();
+        chosen_state->ApplyAction(best.action);
+        std::cerr << "Children of chosen:" << std::endl;
+        std::cerr << best.ChildrenStr(*chosen_state) << std::endl;
+      }
+    } 
+    return best.action;
   }
-
-  return best.action;
 }
 
 std::pair<ActionsAndProbs, Action> MCTSBot::StepWithPolicy(const State& state) {
@@ -281,41 +294,48 @@ std::unique_ptr<State> MCTSBot::ApplyTreePolicy(
       nodes_ += current_node->children.capacity();
     }
 
-    SearchNode* chosen_child = nullptr;
-    if (working_state->IsChanceNode()) {
-      // For chance nodes, rollout according to chance node's probability
-      // distribution
-      Action chosen_action =
-          SampleAction(working_state->ChanceOutcomes(), rng_).first;
-
-      for (SearchNode& child : current_node->children) {
-        if (child.action == chosen_action) {
-          chosen_child = &child;
-          break;
-        }
-      }
+    Action selected_action;
+    if (current_node->children.size() == 0) {
+      // no children, sample from prior
+      selected_action = current_node->SampleFromPrior(state, evaluator_, &rng_);
     } else {
-      // Otherwise choose node with largest UCT value.
-      double max_value = -std::numeric_limits<double>::infinity();
-      for (SearchNode& child : current_node->children) {
-        double val;
-        switch (child_selection_policy_) {
-          case ChildSelectionPolicy::UCT:
-            val = child.UCTValue(current_node->explore_count, uct_c_);
+      // look at children
+      SearchNode* chosen_child = nullptr;
+      if (working_state->IsChanceNode()) {
+        // For chance nodes, rollout according to chance node's probability
+        // distribution
+        Action chosen_action = SampleAction(working_state->ChanceOutcomes(), rng_).first;
+
+        for (SearchNode& child : current_node->children) {
+          if (child.action == chosen_action) {
+            chosen_child = &child;
             break;
-          case ChildSelectionPolicy::PUCT:
-            val = child.PUCTValue(current_node->explore_count, uct_c_);
-            break;
+          }
         }
-        if (val > max_value) {
-          max_value = val;
-          chosen_child = &child;
+      } else {
+        // Otherwise choose node with largest UCT value.
+        double max_value = -std::numeric_limits<double>::infinity();
+        for (SearchNode& child : current_node->children) {
+          double val;
+          switch (child_selection_policy_) {
+            case ChildSelectionPolicy::UCT:
+              val = child.UCTValue(current_node->explore_count, uct_c_);
+              break;
+            case ChildSelectionPolicy::PUCT:
+              val = child.PUCTValue(current_node->explore_count, uct_c_);
+              break;
+          }
+          if (val > max_value) {
+            max_value = val;
+            chosen_child = &child;
+          }
         }
       }
+      selected_action = chosen_child->action;
+      current_node = chosen_child;
     }
 
-    working_state->ApplyAction(chosen_child->action);
-    current_node = chosen_child;
+    working_state->ApplyAction(selected_action);
     visit_path->push_back(current_node);
   }
 

--- a/open_spiel/algorithms/mcts.h
+++ b/open_spiel/algorithms/mcts.h
@@ -139,6 +139,8 @@ struct SearchNode {
   // The state is needed to convert the action to a string.
   std::string ToString(const State& state) const;
   std::string ChildrenStr(const State& state) const;
+
+  Action SampleFromPrior(const State& state, std::shared_ptr<Evaluator> evaluator, std::mt19937* rng) const;
 };
 
 // A SpielBot that uses the MCTS algorithm as its policy.

--- a/open_spiel/scripts/global_variables.sh
+++ b/open_spiel/scripts/global_variables.sh
@@ -43,7 +43,7 @@ export OPEN_SPIEL_BUILD_WITH_GO=${OPEN_SPIEL_BUILD_WITH_GO:-$DEFAULT_OPTIONAL_DE
 
 # Download the header-only library, libnop (https://github.com/google/libnop),
 # to support the serialization and deserialization of C++ data types.
-export OPEN_SPIEL_BUILD_WITH_LIBNOP="${OPEN_SPIEL_BUILD_WITH_LIBNOP:-"ON"}"
+export OPEN_SPIEL_BUILD_WITH_LIBNOP="${OPEN_SPIEL_BUILD_WITH_LIBNOP:-"OFF"}"
 
 # Download precompiled binaries for libtorch (PyTorch C++ API).
 # See https://pytorch.org/cppdocs/ for C++ documentation.
@@ -59,7 +59,7 @@ export OPEN_SPIEL_BUILD_WITH_LIBNOP="${OPEN_SPIEL_BUILD_WITH_LIBNOP:-"ON"}"
 # > as its Python counterpart.
 #
 # You can find an example usage in open_spiel/libtorch/torch_integration_test.cc
-export OPEN_SPIEL_BUILD_WITH_LIBTORCH="${OPEN_SPIEL_BUILD_WITH_LIBTORCH:-"ON"}"
+export OPEN_SPIEL_BUILD_WITH_LIBTORCH="${OPEN_SPIEL_BUILD_WITH_LIBTORCH:-"OFF"}"
 
 # You may want to replace this URL according to your system.
 # You can find all of these (and more) URLs at https://pytorch.org/
@@ -80,7 +80,7 @@ export OPEN_SPIEL_BUILD_WITH_LIBTORCH="${OPEN_SPIEL_BUILD_WITH_LIBTORCH:-"ON"}"
 #
 # For C++ Libtorch AlphaZero on macOS we recommend this URL:
 # https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.8.0.zip
-export OPEN_SPIEL_BUILD_WITH_LIBTORCH_DOWNLOAD_URL="${OPEN_SPIEL_BUILD_WITH_LIBTORCH_DOWNLOAD_URL:-"https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.8.0.zip"}"
+export OPEN_SPIEL_BUILD_WITH_LIBTORCH_DOWNLOAD_URL="${OPEN_SPIEL_BUILD_WITH_LIBTORCH_DOWNLOAD_URL:-"https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.5.1%2Bcpu.zip"}"
 
 # TensorflowCC is a CMake interface to the Tensorflow C++ API. It is used in
 # C++ AlphaZero. See: https://github.com/deepmind/open_spiel/blob/master/docs/alpha_zero.md

--- a/open_spiel/scripts/global_variables.sh
+++ b/open_spiel/scripts/global_variables.sh
@@ -43,7 +43,7 @@ export OPEN_SPIEL_BUILD_WITH_GO=${OPEN_SPIEL_BUILD_WITH_GO:-$DEFAULT_OPTIONAL_DE
 
 # Download the header-only library, libnop (https://github.com/google/libnop),
 # to support the serialization and deserialization of C++ data types.
-export OPEN_SPIEL_BUILD_WITH_LIBNOP="${OPEN_SPIEL_BUILD_WITH_LIBNOP:-"OFF"}"
+export OPEN_SPIEL_BUILD_WITH_LIBNOP="${OPEN_SPIEL_BUILD_WITH_LIBNOP:-"ON"}"
 
 # Download precompiled binaries for libtorch (PyTorch C++ API).
 # See https://pytorch.org/cppdocs/ for C++ documentation.
@@ -59,7 +59,7 @@ export OPEN_SPIEL_BUILD_WITH_LIBNOP="${OPEN_SPIEL_BUILD_WITH_LIBNOP:-"OFF"}"
 # > as its Python counterpart.
 #
 # You can find an example usage in open_spiel/libtorch/torch_integration_test.cc
-export OPEN_SPIEL_BUILD_WITH_LIBTORCH="${OPEN_SPIEL_BUILD_WITH_LIBTORCH:-"OFF"}"
+export OPEN_SPIEL_BUILD_WITH_LIBTORCH="${OPEN_SPIEL_BUILD_WITH_LIBTORCH:-"ON"}"
 
 # You may want to replace this URL according to your system.
 # You can find all of these (and more) URLs at https://pytorch.org/
@@ -80,7 +80,7 @@ export OPEN_SPIEL_BUILD_WITH_LIBTORCH="${OPEN_SPIEL_BUILD_WITH_LIBTORCH:-"OFF"}"
 #
 # For C++ Libtorch AlphaZero on macOS we recommend this URL:
 # https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.8.0.zip
-export OPEN_SPIEL_BUILD_WITH_LIBTORCH_DOWNLOAD_URL="${OPEN_SPIEL_BUILD_WITH_LIBTORCH_DOWNLOAD_URL:-"https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.5.1%2Bcpu.zip"}"
+export OPEN_SPIEL_BUILD_WITH_LIBTORCH_DOWNLOAD_URL="${OPEN_SPIEL_BUILD_WITH_LIBTORCH_DOWNLOAD_URL:-"https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.8.0.zip"}"
 
 # TensorflowCC is a CMake interface to the Tensorflow C++ API. It is used in
 # C++ AlphaZero. See: https://github.com/deepmind/open_spiel/blob/master/docs/alpha_zero.md


### PR DESCRIPTION
Fixes #753.

Modifies MCTS to handle max_simulations = 0 and max_simulations = 1 by sampling from prior, rather than erroring out.

Main Changes:
- Add SampleFromPrior() to SearchNode --> samples action using evaluator over legal actions.
- Step() --> Replaces check for children.size() = 0 with check for max_simulations = 0 or max_simulations = 1 and calls SampleFromPrior() in this case. Otherwise, proceeds as normal.
- ApplyTreePolicy() --> checks for current_node->children.size() = 0 and calls SampleFromPrior() in this case. Otherwise, selects actions as normal.