### PR TITLE
Add scipy as a python dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ pip >= 20.0.2
 attrs >= 19.3.0
 absl-py >= 0.10.0
 numpy >= 1.16
+scipy >= 1.5.4


### PR DESCRIPTION
Required by new MFG Linear-Quadratic game, and used in several places.