### PR TITLE
Fix #794

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -59,7 +59,8 @@ rest) from any location, you will need to add to your PYTHONPATH the root
 directory and the `open_spiel` directory. Open
 [Windows environment variables and add to the PYTHONPATH](https://stackoverflow.com/questions/3701646/how-to-add-to-the-pythonpath-in-windows-so-it-finds-my-modules-packages).
 Add the directories `C:\Users\MyUser\open_spiel\open_spiel\out\build\x64-Debug`
-and `C:\Users\MyUser\open_spiel\open_spiel\out\build\x64-Debug` to PYTHONPATH.
+and `C:\Users\MyUser\open_spiel\open_spiel\out\build\x64-Debug\python` to PYTHONPATH.
+If your PYTHONPATH does not exist, then create a new environment variable for it.
 To check that python is working, you can run the example in
 `open_spiel\python\examples`.
 

--- a/open_spiel/games/morpion_solitaire.cc
+++ b/open_spiel/games/morpion_solitaire.cc
@@ -62,36 +62,35 @@ Line::Line(Action action) {
   int base;
   Point point1;
   Point point2;
-  switch (action) {
+  if (action >= 0 && action <= 129) {
     // [0, 1]
-    case 0 ... 129:
-      row = action / 10;
-      point1 = Point(row, action - row * 10);
-      point2 = Point(row, (action - row * 10) + 3);
-      break;
+    row = action / 10;
+    point1 = Point(row, action - row * 10);
+    point2 = Point(row, (action - row * 10) + 3);
+  }
+  else if (action >= 130 && action <= 259) {
     // [1, 0]
-    case 130 ... 259:
-      base = action - 130;
-      row = (base) / 13;
-      point1 = Point(row, base - row * 13);
-      point2 = Point(row + 3, (base - row * 13));
-      break;
+    base = action - 130;
+    row = (base) / 13;
+    point1 = Point(row, base - row * 13);
+    point2 = Point(row + 3, (base - row * 13));
+  }
+  else if (action >= 260 && action <= 359) {
     // [1, -1]
-    case 260 ... 359:
-      base = action - 260;
-      row = (base) / 10;
-      point1 = Point(row, base - row * 10);
-      point2 = Point(row + 3, (base - row * 10) + 3);
-      break;
+    base = action - 260;
+    row = (base) / 10;
+    point1 = Point(row, base - row * 10);
+    point2 = Point(row + 3, (base - row * 10) + 3);
+  }
+  else if (action >= 360 && action <= 459) {
     // [1, 1]
-    case 360 ... 459:
-      base = action - 360;
-      row = (base) / 10;
-      point1 = Point(row + 3, base - row * 10);
-      point2 = Point(row, (base - row * 10) + 3);
-      break;
-    default:
-      SpielFatalError("action provided does not correspond with a move");
+    base = action - 360;
+    row = (base) / 10;
+    point1 = Point(row + 3, base - row * 10);
+    point2 = Point(row, (base - row * 10) + 3);
+  }
+  else {
+    SpielFatalError("action provided does not correspond with a move");
   }
   Init(point1, point2);
 }


### PR DESCRIPTION
`morpion_solitaire.cc` was using a [linux-only C++ extension](https://stackoverflow.com/questions/5924681/are-elipses-in-case-statements-standard-c-c) (ellipses in case statements). I've changed this to a if-else block to fix windows compatibility.

I've confirmed that windows building works for me after making this patch.

Also, the windows docs had a type regarding the directories that needed to be added to PYTHONPATH.