### PR TITLE
Implemented Boltzmann Q-learning python

### DIFF
--- a/open_spiel/python/CMakeLists.txt
+++ b/open_spiel/python/CMakeLists.txt
@@ -169,6 +169,7 @@ set(PYTHON_TESTS ${PYTHON_TESTS}
   algorithms/action_value_test.py
   algorithms/action_value_vs_best_response_test.py
   algorithms/best_response_test.py
+  algorithms/boltzmann_tabular_qlearner_test.py
   algorithms/cfr_br_test.py
   algorithms/cfr_test.py
   algorithms/evaluate_bots_test.py
@@ -187,6 +188,7 @@ set(PYTHON_TESTS ${PYTHON_TESTS}
   algorithms/policy_aggregator_test.py
   algorithms/projected_replicator_dynamics_test.py
   algorithms/random_agent_test.py
+  algorithms/tabular_qlearner_test.py
   bots/bluechip_bridge_test.py
   bots/bluechip_bridge_uncontested_bidding_test.py
   bots/is_mcts_test.py

--- a/open_spiel/python/algorithms/boltzmann_tabular_qlearner.py
+++ b/open_spiel/python/algorithms/boltzmann_tabular_qlearner.py
@@ -26,7 +26,7 @@ from open_spiel.python import rl_tools
 from open_spiel.python.algorithms import tabular_qlearner
 
 
-class BoltzmannQLearner(tabular_qlearner.Qlearner):
+class BoltzmannQLearner(tabular_qlearner.QLearner):
     """Tabular Boltzmann Q-Learning agent.
 
     See open_spiel/python/examples/tic_tac_toe_qlearner.py for an usage example.
@@ -40,7 +40,7 @@ class BoltzmannQLearner(tabular_qlearner.Qlearner):
                  num_actions,
                  step_size=0.1,
                  discount_factor=1.0,
-                 temperature_schedule=rl_tools.ConstantSchedule(1.),
+                 temperature_schedule=rl_tools.ConstantSchedule(.5),
                  centralized=False):
         super().__init__(
             player_id,

--- a/open_spiel/python/algorithms/boltzmann_tabular_qlearner.py
+++ b/open_spiel/python/algorithms/boltzmann_tabular_qlearner.py
@@ -1,0 +1,94 @@
+
+# Copyright 2022 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Boltzmann Q learning agent.
+This algorithm is a variation of Q learning that uses action selection
+based on boltzmann probability interpretation of Q-values.
+
+For more details, see equation (2) page 2 in
+   https://arxiv.org/pdf/1109.1528.pdf
+"""
+
+import numpy as np
+
+from open_spiel.python import rl_tools
+from open_spiel.python.algorithms import tabular_qlearner
+
+
+class BoltzmannQLearner(tabular_qlearner.Qlearner):
+    """Tabular Boltzmann Q-Learning agent.
+
+    See open_spiel/python/examples/tic_tac_toe_qlearner.py for an usage example.
+
+    The tic_tac_toe example uses the standard Qlearner. Using the BoltzmannQlearner is
+    identical and only differs in the initialization of the agents.
+    """
+
+    def __init__(self,
+                 player_id,
+                 num_actions,
+                 step_size=0.1,
+                 discount_factor=1.0,
+                 temperature_schedule=rl_tools.ConstantSchedule(1.),
+                 centralized=False):
+        super().__init__(
+            player_id,
+            num_actions,
+            step_size=step_size,
+            discount_factor=discount_factor,
+            epsilon_schedule=temperature_schedule,
+            centralized=centralized
+        )
+
+    def _softmax(self, info_state, legal_actions):
+        """Action selection based on boltzmann probability interpretation of Q-values.
+
+        For more details, see equation (2) page 2 in
+        https://arxiv.org/pdf/1109.1528.pdf
+
+        Args:
+            info_state: hashable representation of the information state.
+            legal_actions: list of actions at `info_state`.
+            temperature: float, the higher the value, the higher the chance of taking an exploratory action.
+
+        Returns:
+            A valid soft-max selected action and valid action probabilities.
+        """
+        probs = np.zeros(self._num_actions)
+
+        # self._current_epsilon represents the current value of the temperature parameter
+        if self._current_epsilon != 0.0:
+            probs += [
+                np.exp((1 / self._current_epsilon) * self._q_values[info_state][i])
+                for i in range(self._num_actions)
+            ]
+            probs /= np.sum(
+                [np.exp((1 / self._current_epsilon) * self._q_values[info_state][i]) for i in range(self._num_actions)]
+            )
+        else:
+            # Temperature = 0 causes normal greedy action selection
+            greedy_q = max([self._q_values[info_state][a] for a in legal_actions])
+            greedy_actions = [
+                a for a in legal_actions if self._q_values[info_state][a] == greedy_q
+            ]
+
+            probs[greedy_actions] += 1 / len(greedy_actions)
+
+        action = np.random.choice(range(self._num_actions), p=probs)
+        return action, probs
+
+    def _get_action_probs(self, info_state, legal_actions):
+        """Returns a selected action and the probabilities of legal actions."""
+
+        return self._softmax(info_state, legal_actions)

--- a/open_spiel/python/algorithms/boltzmann_tabular_qlearner_test.py
+++ b/open_spiel/python/algorithms/boltzmann_tabular_qlearner_test.py
@@ -1,0 +1,46 @@
+"""Tests for open_spiel.python.algorithms.boltzmann_tabular_qlearner"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow.compat.v1 as tf
+
+from open_spiel.python import rl_environment
+from open_spiel.python.algorithms import boltzmann_tabular_qlearner
+import pyspiel
+
+# Temporarily disable TF2 behavior until code is updated.
+tf.disable_v2_behavior()
+
+# A simple two-action game encoded as an EFG game. Going left gets -1, going
+# right gets a +1.
+SIMPLE_EFG_DATA = """
+  EFG 2 R "Simple single-agent problem" { "Player 1" } ""
+  p "ROOT" 1 1 "ROOT" { "L" "R" } 0
+    t "L" 1 "Outcome L" { -1.0 }
+    t "R" 2 "Outcome R" { 1.0 }
+"""
+
+
+class BoltzmannQlearnerTest(tf.test.TestCase):
+
+    def test_simple_game(self):
+        game = pyspiel.load_efg_game(SIMPLE_EFG_DATA)
+        env = rl_environment.Environment(game=game)
+
+        agent = boltzmann_tabular_qlearner.BoltzmannQLearner(0, game.num_distinct_actions())
+        total_reward = 0
+
+        for _ in range(100):
+            time_step = env.reset()
+            while not time_step.last():
+                agent_output = agent.step(time_step)
+                time_step = env.step([agent_output.action])
+                total_reward += time_step.rewards[0]
+            agent.step(time_step)
+        self.assertGreaterEqual(total_reward, 75)
+
+
+if __name__ == "__main__":
+    tf.test.main()

--- a/open_spiel/python/algorithms/boltzmann_tabular_qlearner_test.py
+++ b/open_spiel/python/algorithms/boltzmann_tabular_qlearner_test.py
@@ -4,14 +4,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow.compat.v1 as tf
-
+from absl.testing import absltest
 from open_spiel.python import rl_environment
 from open_spiel.python.algorithms import boltzmann_tabular_qlearner
 import pyspiel
-
-# Temporarily disable TF2 behavior until code is updated.
-tf.disable_v2_behavior()
 
 # A simple two-action game encoded as an EFG game. Going left gets -1, going
 # right gets a +1.
@@ -23,7 +19,7 @@ SIMPLE_EFG_DATA = """
 """
 
 
-class BoltzmannQlearnerTest(tf.test.TestCase):
+class BoltzmannQlearnerTest(absltest.TestCase):
 
     def test_simple_game(self):
         game = pyspiel.load_efg_game(SIMPLE_EFG_DATA)
@@ -43,4 +39,4 @@ class BoltzmannQlearnerTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    absltest.main()

--- a/open_spiel/python/algorithms/tabular_qlearner.py
+++ b/open_spiel/python/algorithms/tabular_qlearner.py
@@ -53,8 +53,9 @@ class QLearner(rl_agent.AbstractAgent):
         self._q_values = collections.defaultdict(valuedict)
         self._prev_info_state = None
         self._last_loss_value = None
+        self._current_epsilon = None
 
-    def _epsilon_greedy(self, info_state, legal_actions, epsilon):
+    def _epsilon_greedy(self, info_state, legal_actions):
         """Returns a valid epsilon-greedy action and valid action probs.
 
     If the agent has not been to `info_state`, a valid random action is chosen.
@@ -72,10 +73,17 @@ class QLearner(rl_agent.AbstractAgent):
         greedy_actions = [
             a for a in legal_actions if self._q_values[info_state][a] == greedy_q
         ]
-        probs[legal_actions] = epsilon / len(legal_actions)
-        probs[greedy_actions] += (1 - epsilon) / len(greedy_actions)
+        probs[legal_actions] = self._current_epsilon / len(legal_actions)
+        probs[greedy_actions] += (1 - self._current_epsilon) / len(greedy_actions)
         action = np.random.choice(range(self._num_actions), p=probs)
         return action, probs
+
+    def _get_action_probs(self, info_state, legal_actions):
+        """Returns a selected action and the probabilities of legal actions.
+
+        To be overwritten by subclasses that implement other action selection methods.
+        """
+        return self._epsilon_greedy(info_state, legal_actions)
 
     def step(self, time_step, is_evaluation=False):
         """Returns the action to be taken and updates the Q-values if needed.
@@ -98,9 +106,9 @@ class QLearner(rl_agent.AbstractAgent):
 
         # Act step: don't act at terminal states.
         if not time_step.last():
-            epsilon = 0.0 if is_evaluation else self._epsilon
-            action, probs = self._epsilon_greedy(
-                info_state, legal_actions, epsilon=epsilon)
+            self._current_epsilon = 0.0 if is_evaluation else self._epsilon
+            action, probs = self._get_action_probs(
+                info_state, legal_actions)
 
         # Learn step: don't learn during evaluation or at first agent steps.
         if self._prev_info_state and not is_evaluation:
@@ -116,125 +124,6 @@ class QLearner(rl_agent.AbstractAgent):
 
             # Decay epsilon, if necessary.
             self._epsilon = self._epsilon_schedule.step()
-
-            if time_step.last():  # prepare for the next episode.
-                self._prev_info_state = None
-                return
-
-        # Don't mess up with the state during evaluation.
-        if not is_evaluation:
-            self._prev_info_state = info_state
-            self._prev_action = action
-        return rl_agent.StepOutput(action=action, probs=probs)
-
-    @property
-    def loss(self):
-        return self._last_loss_value
-
-
-class BoltzmannQLearner(rl_agent.AbstractAgent):
-    """Tabular Boltzmann Q-Learning agent.
-
-    See open_spiel/python/examples/tic_tac_toe_qlearner.py for an usage example.
-
-    The tic_tac_toe example uses the standard Qlearner. Using the BoltzmannQlearner is
-    identical and only differs in the initialization of the agents.
-    """
-
-    def __init__(self,
-                 player_id,
-                 num_actions,
-                 step_size=0.1,
-                 discount_factor=1.0,
-                 temperature_schedule=rl_tools.ConstantSchedule(1.),
-                 centralized=False):
-        """Initialize the Q-Learning agent."""
-        self._player_id = player_id
-        self._num_actions = num_actions
-        self._step_size = step_size
-        self._discount_factor = discount_factor
-        self._temperature_schedule = temperature_schedule
-        self._temperature = temperature_schedule.value
-        self._centralized = centralized
-        self._q_values = collections.defaultdict(valuedict)
-        self._prev_info_state = None
-        self._last_loss_value = None
-
-    def _boltzmann_selection(self, info_state, legal_actions, temperature):
-        """Action selection based on boltzmann probability interpretation of Q-values.
-
-        For more details, see equation (2) page 2 in
-        https://arxiv.org/pdf/1109.1528.pdf
-
-        Args:
-            info_state: hashable representation of the information state.
-            legal_actions: list of actions at `info_state`.
-            temperature: float, the higher the value, the higher the chance of taking an exploratory action.
-
-        Returns:
-            A valid Boltzmann selected action and valid action probabilities.
-        """
-        probs = np.zeros(self._num_actions)
-
-        if temperature != 0.0:
-            probs += [
-                np.exp((1 / temperature) * self._q_values[info_state][i])
-                for i in range(self._num_actions)
-            ]
-            probs /= np.sum(
-                [np.exp((1 / temperature) * self._q_values[info_state][i]) for i in range(self._num_actions)]
-            )
-        else:
-            # Temperature = 0 causes normal greedy action selection
-            greedy_q = max([self._q_values[info_state][a] for a in legal_actions])
-            greedy_actions = [
-                a for a in legal_actions if self._q_values[info_state][a] == greedy_q
-            ]
-
-            probs[greedy_actions] += 1 / len(greedy_actions)
-
-        action = np.random.choice(range(self._num_actions), p=probs)
-        return action, probs
-
-    def step(self, time_step, is_evaluation=False):
-        """Returns the action to be taken and updates the Q-values if needed.
-
-  Args:
-    time_step: an instance of rl_environment.TimeStep.
-    is_evaluation: bool, whether this is a training or evaluation call.
-
-  Returns:
-    A `rl_agent.StepOutput` containing the action probs and chosen action.
-  """
-        if self._centralized:
-            info_state = str(time_step.observations["info_state"])
-        else:
-            info_state = str(time_step.observations["info_state"][self._player_id])
-        legal_actions = time_step.observations["legal_actions"][self._player_id]
-
-        # Prevent undefined errors if this agent never plays until terminal step
-        action, probs = None, None
-
-        # Act step: don't act at terminal states.
-        if not time_step.last():
-            temperature = 0.0 if is_evaluation else self._temperature
-            action, probs = self._boltzmann_selection(
-                info_state, legal_actions, temperature=temperature)
-
-        # Learn step: don't learn during evaluation or at first agent steps.
-        if self._prev_info_state and not is_evaluation:
-            target = time_step.rewards[self._player_id]
-            if not time_step.last():  # Q values are zero for terminal.
-                target += self._discount_factor * max(
-                    [self._q_values[info_state][a] for a in legal_actions])
-
-            prev_q_value = self._q_values[self._prev_info_state][self._prev_action]
-            self._last_loss_value = target - prev_q_value
-            self._q_values[self._prev_info_state][self._prev_action] += (
-                    self._step_size * self._last_loss_value)
-
-            # Decay temperature, if necessary.
-            self._temperature = self._temperature_schedule.step()
 
             if time_step.last():  # prepare for the next episode.
                 self._prev_info_state = None

--- a/open_spiel/python/algorithms/tabular_qlearner.py
+++ b/open_spiel/python/algorithms/tabular_qlearner.py
@@ -26,36 +26,36 @@ from open_spiel.python import rl_tools
 
 
 def valuedict():
-  return collections.defaultdict(float)
+    return collections.defaultdict(float)
 
 
 class QLearner(rl_agent.AbstractAgent):
-  """Tabular Q-Learning agent.
+    """Tabular Q-Learning agent.
 
   See open_spiel/python/examples/tic_tac_toe_qlearner.py for an usage example.
   """
 
-  def __init__(self,
-               player_id,
-               num_actions,
-               step_size=0.1,
-               epsilon_schedule=rl_tools.ConstantSchedule(0.2),
-               discount_factor=1.0,
-               centralized=False):
-    """Initialize the Q-Learning agent."""
-    self._player_id = player_id
-    self._num_actions = num_actions
-    self._step_size = step_size
-    self._epsilon_schedule = epsilon_schedule
-    self._epsilon = epsilon_schedule.value
-    self._discount_factor = discount_factor
-    self._centralized = centralized
-    self._q_values = collections.defaultdict(valuedict)
-    self._prev_info_state = None
-    self._last_loss_value = None
+    def __init__(self,
+                 player_id,
+                 num_actions,
+                 step_size=0.1,
+                 epsilon_schedule=rl_tools.ConstantSchedule(0.2),
+                 discount_factor=1.0,
+                 centralized=False):
+        """Initialize the Q-Learning agent."""
+        self._player_id = player_id
+        self._num_actions = num_actions
+        self._step_size = step_size
+        self._epsilon_schedule = epsilon_schedule
+        self._epsilon = epsilon_schedule.value
+        self._discount_factor = discount_factor
+        self._centralized = centralized
+        self._q_values = collections.defaultdict(valuedict)
+        self._prev_info_state = None
+        self._last_loss_value = None
 
-  def _epsilon_greedy(self, info_state, legal_actions, epsilon):
-    """Returns a valid epsilon-greedy action and valid action probs.
+    def _epsilon_greedy(self, info_state, legal_actions, epsilon):
+        """Returns a valid epsilon-greedy action and valid action probs.
 
     If the agent has not been to `info_state`, a valid random action is chosen.
 
@@ -67,18 +67,18 @@ class QLearner(rl_agent.AbstractAgent):
     Returns:
       A valid epsilon-greedy action and valid action probabilities.
     """
-    probs = np.zeros(self._num_actions)
-    greedy_q = max([self._q_values[info_state][a] for a in legal_actions])
-    greedy_actions = [
-        a for a in legal_actions if self._q_values[info_state][a] == greedy_q
-    ]
-    probs[legal_actions] = epsilon / len(legal_actions)
-    probs[greedy_actions] += (1 - epsilon) / len(greedy_actions)
-    action = np.random.choice(range(self._num_actions), p=probs)
-    return action, probs
+        probs = np.zeros(self._num_actions)
+        greedy_q = max([self._q_values[info_state][a] for a in legal_actions])
+        greedy_actions = [
+            a for a in legal_actions if self._q_values[info_state][a] == greedy_q
+        ]
+        probs[legal_actions] = epsilon / len(legal_actions)
+        probs[greedy_actions] += (1 - epsilon) / len(greedy_actions)
+        action = np.random.choice(range(self._num_actions), p=probs)
+        return action, probs
 
-  def step(self, time_step, is_evaluation=False):
-    """Returns the action to be taken and updates the Q-values if needed.
+    def step(self, time_step, is_evaluation=False):
+        """Returns the action to be taken and updates the Q-values if needed.
 
     Args:
       time_step: an instance of rl_environment.TimeStep.
@@ -87,46 +87,133 @@ class QLearner(rl_agent.AbstractAgent):
     Returns:
       A `rl_agent.StepOutput` containing the action probs and chosen action.
     """
-    if self._centralized:
-      info_state = str(time_step.observations["info_state"])
-    else:
-      info_state = str(time_step.observations["info_state"][self._player_id])
-    legal_actions = time_step.observations["legal_actions"][self._player_id]
+        if self._centralized:
+            info_state = str(time_step.observations["info_state"])
+        else:
+            info_state = str(time_step.observations["info_state"][self._player_id])
+        legal_actions = time_step.observations["legal_actions"][self._player_id]
 
-    # Prevent undefined errors if this agent never plays until terminal step
-    action, probs = None, None
+        # Prevent undefined errors if this agent never plays until terminal step
+        action, probs = None, None
 
-    # Act step: don't act at terminal states.
-    if not time_step.last():
-      epsilon = 0.0 if is_evaluation else self._epsilon
-      action, probs = self._epsilon_greedy(
-          info_state, legal_actions, epsilon=epsilon)
+        # Act step: don't act at terminal states.
+        if not time_step.last():
+            epsilon = 0.0 if is_evaluation else self._epsilon
+            action, probs = self._epsilon_greedy(
+                info_state, legal_actions, epsilon=epsilon)
 
-    # Learn step: don't learn during evaluation or at first agent steps.
-    if self._prev_info_state and not is_evaluation:
-      target = time_step.rewards[self._player_id]
-      if not time_step.last():  # Q values are zero for terminal.
-        target += self._discount_factor * max(
-            [self._q_values[info_state][a] for a in legal_actions])
+        # Learn step: don't learn during evaluation or at first agent steps.
+        if self._prev_info_state and not is_evaluation:
+            target = time_step.rewards[self._player_id]
+            if not time_step.last():  # Q values are zero for terminal.
+                target += self._discount_factor * max(
+                    [self._q_values[info_state][a] for a in legal_actions])
 
-      prev_q_value = self._q_values[self._prev_info_state][self._prev_action]
-      self._last_loss_value = target - prev_q_value
-      self._q_values[self._prev_info_state][self._prev_action] += (
-          self._step_size * self._last_loss_value)
+            prev_q_value = self._q_values[self._prev_info_state][self._prev_action]
+            self._last_loss_value = target - prev_q_value
+            self._q_values[self._prev_info_state][self._prev_action] += (
+                    self._step_size * self._last_loss_value)
 
-      # Decay epsilon, if necessary.
-      self._epsilon = self._epsilon_schedule.step()
+            # Decay epsilon, if necessary.
+            self._epsilon = self._epsilon_schedule.step()
 
-      if time_step.last():  # prepare for the next episode.
+            if time_step.last():  # prepare for the next episode.
+                self._prev_info_state = None
+                return
+
+        # Don't mess up with the state during evaluation.
+        if not is_evaluation:
+            self._prev_info_state = info_state
+            self._prev_action = action
+        return rl_agent.StepOutput(action=action, probs=probs)
+
+    @property
+    def loss(self):
+        return self._last_loss_value
+
+
+class BoltzmannQLearner(rl_agent.AbstractAgent):
+    """Tabular Q-Learning agent.
+
+  See open_spiel/python/examples/tic_tac_toe_qlearner.py for an usage example.
+  """
+
+    def __init__(self,
+                 player_id,
+                 num_actions,
+                 step_size=0.001,
+                 discount_factor=1.0,
+                 temperature=0.2,
+                 centralized=False):
+        """Initialize the Q-Learning agent."""
+        self._player_id = player_id
+        self._num_actions = num_actions
+        self._step_size = step_size
+        self._discount_factor = discount_factor
+        self._temperature = temperature
+        self._centralized = centralized
+        self._q_values = collections.defaultdict(valuedict)
         self._prev_info_state = None
-        return
+        self._last_loss_value = None
 
-    # Don't mess up with the state during evaluation.
-    if not is_evaluation:
-      self._prev_info_state = info_state
-      self._prev_action = action
-    return rl_agent.StepOutput(action=action, probs=probs)
+    def _boltzmann_selection(self, info_state):
+        """Action selection based on boltzmann probability interpretation of Q-values.
+  """
+        probs = np.zeros(self._num_actions)
 
-  @property
-  def loss(self):
-    return self._last_loss_value
+        probs += [np.exp((1 / self._temperature) * self._q_values[info_state][i]) for i in range(self._num_actions)]
+        probs /= np.sum(
+            [np.exp((1 / self._temperature) * self._q_values[info_state][i]) for i in range(self._num_actions)])
+
+        action = np.random.choice(range(self._num_actions), p=probs)
+        return action, probs
+
+    def step(self, time_step, is_evaluation=False):
+        """Returns the action to be taken and updates the Q-values if needed.
+
+  Args:
+    time_step: an instance of rl_environment.TimeStep.
+    is_evaluation: bool, whether this is a training or evaluation call.
+
+  Returns:
+    A `rl_agent.StepOutput` containing the action probs and chosen action.
+  """
+        if self._centralized:
+            info_state = str(time_step.observations["info_state"])
+        else:
+            info_state = str(time_step.observations["info_state"][self._player_id])
+        legal_actions = time_step.observations["legal_actions"][self._player_id]
+
+        # Prevent undefined errors if this agent never plays until terminal step
+        action, probs = None, None
+
+        # Act step: don't act at terminal states.
+        if not time_step.last():
+            action, probs = self._boltzmann_selection(
+                info_state)
+
+        # Learn step: don't learn during evaluation or at first agent steps.
+        if self._prev_info_state and not is_evaluation:
+            target = time_step.rewards[self._player_id]
+            if not time_step.last():  # Q values are zero for terminal.
+                target += self._discount_factor * max(
+                    [self._q_values[info_state][a] for a in legal_actions])
+
+            prev_q_value = self._q_values[self._prev_info_state][self._prev_action]
+            self._last_loss_value = target - prev_q_value
+            self._q_values[self._prev_info_state][self._prev_action] += (
+                    self._step_size * self._last_loss_value)
+
+            if time_step.last():  # prepare for the next episode.
+                self._prev_info_state = None
+                return
+
+        # Don't mess up with the state during evaluation.
+        if not is_evaluation:
+            self._prev_info_state = info_state
+            self._prev_action = action
+        return rl_agent.StepOutput(action=action, probs=probs)
+
+    @property
+    def loss(self):
+        return self._last_loss_value

--- a/open_spiel/python/algorithms/tabular_qlearner_test.py
+++ b/open_spiel/python/algorithms/tabular_qlearner_test.py
@@ -4,14 +4,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow.compat.v1 as tf
-
+from absl.testing import absltest
 from open_spiel.python import rl_environment
 from open_spiel.python.algorithms import tabular_qlearner
 import pyspiel
-
-# Temporarily disable TF2 behavior until code is updated.
-tf.disable_v2_behavior()
 
 # A simple two-action game encoded as an EFG game. Going left gets -1, going
 # right gets a +1.
@@ -23,7 +19,7 @@ SIMPLE_EFG_DATA = """
 """
 
 
-class QlearnerTest(tf.test.TestCase):
+class QlearnerTest(absltest.TestCase):
 
     def test_simple_game(self):
         game = pyspiel.load_efg_game(SIMPLE_EFG_DATA)
@@ -43,4 +39,4 @@ class QlearnerTest(tf.test.TestCase):
 
 
 if __name__ == "__main__":
-    tf.test.main()
+    absltest.main()

--- a/open_spiel/python/algorithms/tabular_qlearner_test.py
+++ b/open_spiel/python/algorithms/tabular_qlearner_test.py
@@ -1,0 +1,46 @@
+"""Tests for open_spiel.python.algorithms.tabular_qlearner"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow.compat.v1 as tf
+
+from open_spiel.python import rl_environment
+from open_spiel.python.algorithms import tabular_qlearner
+import pyspiel
+
+# Temporarily disable TF2 behavior until code is updated.
+tf.disable_v2_behavior()
+
+# A simple two-action game encoded as an EFG game. Going left gets -1, going
+# right gets a +1.
+SIMPLE_EFG_DATA = """
+  EFG 2 R "Simple single-agent problem" { "Player 1" } ""
+  p "ROOT" 1 1 "ROOT" { "L" "R" } 0
+    t "L" 1 "Outcome L" { -1.0 }
+    t "R" 2 "Outcome R" { 1.0 }
+"""
+
+
+class QlearnerTest(tf.test.TestCase):
+
+    def test_simple_game(self):
+        game = pyspiel.load_efg_game(SIMPLE_EFG_DATA)
+        env = rl_environment.Environment(game=game)
+
+        agent = tabular_qlearner.QLearner(0, game.num_distinct_actions())
+        total_reward = 0
+
+        for _ in range(100):
+            time_step = env.reset()
+            while not time_step.last():
+                agent_output = agent.step(time_step)
+                time_step = env.step([agent_output.action])
+                total_reward += time_step.rewards[0]
+            agent.step(time_step)
+        self.assertGreaterEqual(total_reward, 75)
+
+
+if __name__ == "__main__":
+    tf.test.main()

--- a/open_spiel/python/algorithms/tabular_qlearner_test.py
+++ b/open_spiel/python/algorithms/tabular_qlearner_test.py
@@ -7,7 +7,11 @@ from __future__ import print_function
 from absl.testing import absltest
 from open_spiel.python import rl_environment
 from open_spiel.python.algorithms import tabular_qlearner
+import numpy as np
 import pyspiel
+
+# Fixed seed to make test non stochastic.
+SEED = 10000
 
 # A simple two-action game encoded as an EFG game. Going left gets -1, going
 # right gets a +1.
@@ -29,14 +33,24 @@ class QlearnerTest(absltest.TestCase):
         total_reward = 0
 
         for _ in range(100):
-            time_step = env.reset()
-            while not time_step.last():
-                agent_output = agent.step(time_step)
-                time_step = env.step([agent_output.action])
-                total_reward += time_step.rewards[0]
-            agent.step(time_step)
-        self.assertGreaterEqual(total_reward, 75)
+            total_eval_reward = 0
+            for _ in range(1000):
+                time_step = env.reset()
+                while not time_step.last():
+                    agent_output = agent.step(time_step)
+                    time_step = env.step([agent_output.action])
+                    total_reward += time_step.rewards[0]
+                agent.step(time_step)
+            self.assertGreaterEqual(total_reward, 75)
+            for _ in range(1000):
+                time_step = env.reset()
+                while not time_step.last():
+                    agent_output = agent.step(time_step, is_evaluation=True)
+                    time_step = env.step([agent_output.action])
+                    total_eval_reward += time_step.rewards[0]
+            self.assertGreaterEqual(total_eval_reward, 250)
 
 
 if __name__ == "__main__":
+    np.random.seed(SEED)
     absltest.main()


### PR DESCRIPTION
I have implemented a variation of the tabular Q learner in python that uses a Boltzmann probability interpretation of the Q-values for action selection instead of e-greedy (the already existing implementation). According to equation (2) page 2 here: [paper1](https://arxiv.org/pdf/1109.1528.pdf)

This action selection implementation corresponds with the selection mechanism that results in the 'boltzmannq' replicator dynamics that are implemented in python/egt/dynamics and thus seemed like a nice add-on to me for the algorithms.

I'm glad to hear about any changes that I should make to my code to make it more open_spiel friendly.

Other notes/questions:
- The already implemented Q learner had a reference to an example where it is used, should a similar example be provided for my implementation?
- When it comes to testing I have verified (by hand) that the learning trajectories of my implementation indeed correspond with the already implemented boltzmannq replicator dynamics for different matrix games and values of the temperature parameter. Do I need to provide other programmatic ways of testing the implementation?