### PR TITLE
Update github actions CI platforms

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -11,8 +11,14 @@ jobs:
     strategy:
       matrix:
         include:
-        # Standard platforms with newest Python versions for the platform.
-        # Disabled until available on Github Actions CI.
+        # Standard (most current) platforms and versions.
+        - os: ubuntu-22.04
+          OS_PYTHON_VERSION: "3.10"
+          TRAVIS_USE_NOX: 0
+          DEFAULT_OPTIONAL_DEPENDENCY: "ON"
+          BUILD_SHARED_LIB: "OFF"
+          OPEN_SPIEL_BUILD_WITH_ORTOOLS: "OFF"
+          OPEN_SPIEL_BUILD_WITH_ORTOOLS_DOWNLOAD_URL: ""
         - os: ubuntu-22.04
           OS_PYTHON_VERSION: "3.10"
           TRAVIS_USE_NOX: 0

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -20,7 +20,7 @@ jobs:
         #  BUILD_SHARED_LIB: "OFF"
         #  OPEN_SPIEL_BUILD_WITH_ORTOOLS: "OFF"
         #  OPEN_SPIEL_BUILD_WITH_ORTOOLS_DOWNLOAD_URL: ""
-        - os: macos-10.15
+        - os: macos-12
           OS_PYTHON_VERSION: "3.9"
           TRAVIS_USE_NOX: 0
           DEFAULT_OPTIONAL_DEPENDENCY: "OFF"
@@ -28,7 +28,7 @@ jobs:
           OPEN_SPIEL_BUILD_WITH_ORTOOLS: "OFF"
           OPEN_SPIEL_BUILD_WITH_ORTOOLS_DOWNLOAD_URL: ""
         # Standard or older platforms with older Python versions.
-        - os: macos-10.15
+        - os: macos-11
           OS_PYTHON_VERSION: "3.8"
           TRAVIS_USE_NOX: 0
           DEFAULT_OPTIONAL_DEPENDENCY: "OFF"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,13 +13,13 @@ jobs:
         include:
         # Standard platforms with newest Python versions for the platform.
         # Disabled until available on Github Actions CI.
-        #- os: ubuntu-22.04
-        #  OS_PYTHON_VERSION: "3.10"
-        #  TRAVIS_USE_NOX: 0
-        #  DEFAULT_OPTIONAL_DEPENDENCY: "OFF"
-        #  BUILD_SHARED_LIB: "OFF"
-        #  OPEN_SPIEL_BUILD_WITH_ORTOOLS: "OFF"
-        #  OPEN_SPIEL_BUILD_WITH_ORTOOLS_DOWNLOAD_URL: ""
+        - os: ubuntu-22.04
+          OS_PYTHON_VERSION: "3.10"
+          TRAVIS_USE_NOX: 0
+          DEFAULT_OPTIONAL_DEPENDENCY: "OFF"
+          BUILD_SHARED_LIB: "OFF"
+          OPEN_SPIEL_BUILD_WITH_ORTOOLS: "OFF"
+          OPEN_SPIEL_BUILD_WITH_ORTOOLS_DOWNLOAD_URL: ""
         - os: macos-12
           OS_PYTHON_VERSION: "3.9"
           TRAVIS_USE_NOX: 0

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,7 +31,7 @@ jobs:
         - os: ubuntu-20.04
           CIBW_ENVIRONMENT: "CXX=$(which g++) OPEN_SPIEL_BUILDING_WHEEL='ON' OPEN_SPIEL_BUILD_WITH_ACPC='ON' OPEN_SPIEL_BUILD_WITH_HANABI='ON'"
           CIBW_BUILD: cp37-manylinux_x86_64 cp38-manylinux_x86_64 cp39-manylinux_x86_64 cp310-manylinux_x86_64
-        - os: macOS-10.15
+        - os: macOS-12
           CIBW_ENVIRONMENT: "OPEN_SPIEL_BUILDING_WHEEL='ON' OPEN_SPIEL_BUILD_WITH_ACPC='ON' OPEN_SPIEL_BUILD_WITH_HANABI='ON'"
           CIBW_BUILD: cp37-macosx_x86_64 cp38-macosx_x86_64 cp39-macosx_x86_64 cp310-macosx_x86_64
     env:
@@ -67,7 +67,7 @@ jobs:
           source ./open_spiel/scripts/python_extra_deps.sh
           python3 -m pip install --upgrade $OPEN_SPIEL_PYTHON_JAX_DEPS $OPEN_SPIEL_PYTHON_PYTORCH_DEPS $OPEN_SPIEL_PYTHON_TENSORFLOW_DEPS $OPEN_SPIEL_PYTHON_MISC_DEPS
           python3 -m pip install twine
-          python3 -m pip install cibuildwheel==2.0.1
+          python3 -m pip install cibuildwheel==2.5.0
       - name: Build sdist
         run: |
           pipx run build --sdist

--- a/open_spiel/algorithms/minimax.cc
+++ b/open_spiel/algorithms/minimax.cc
@@ -17,7 +17,6 @@
 #include <algorithm>  // std::max
 #include <limits>
 
-#include "open_spiel/games/tic_tac_toe.h"
 #include "open_spiel/spiel.h"
 #include "open_spiel/spiel_utils.h"
 

--- a/open_spiel/policy.cc
+++ b/open_spiel/policy.cc
@@ -204,6 +204,50 @@ const std::string TabularPolicy::ToStringSorted() const {
   return str;
 }
 
+PartialTabularPolicy::PartialTabularPolicy()
+    : TabularPolicy(),
+      fallback_policy_(std::make_shared<UniformPolicy>()) {}
+
+PartialTabularPolicy::PartialTabularPolicy(
+      const std::unordered_map<std::string, ActionsAndProbs>& table)
+    : TabularPolicy(table),
+      fallback_policy_(std::make_shared<UniformPolicy>()) {}
+
+PartialTabularPolicy::PartialTabularPolicy(
+      const std::unordered_map<std::string, ActionsAndProbs>& table,
+      std::shared_ptr<Policy> fallback_policy)
+    : TabularPolicy(table),
+      fallback_policy_(fallback_policy) {}
+
+ActionsAndProbs PartialTabularPolicy::GetStatePolicy(const State& state) const {
+  auto iter = policy_table_.find(state.InformationStateString());
+  if (iter == policy_table_.end()) {
+    return fallback_policy_->GetStatePolicy(state);
+  } else {
+    return iter->second;
+  }
+}
+
+ActionsAndProbs PartialTabularPolicy::GetStatePolicy(const State& state,
+                                                     Player player) const {
+  auto iter = policy_table_.find(state.InformationStateString(player));
+  if (iter == policy_table_.end()) {
+    return fallback_policy_->GetStatePolicy(state);
+  } else {
+    return iter->second;
+  }
+}
+
+ActionsAndProbs PartialTabularPolicy::GetStatePolicy(
+    const std::string& info_state) const {
+  auto iter = policy_table_.find(info_state);
+  if (iter == policy_table_.end()) {
+    return fallback_policy_->GetStatePolicy(info_state);
+  } else {
+    return iter->second;
+  }
+}
+
 TabularPolicy GetEmptyTabularPolicy(const Game& game,
                                     bool initialize_to_uniform) {
   std::unordered_map<std::string, ActionsAndProbs> policy;

--- a/open_spiel/policy.h
+++ b/open_spiel/policy.h
@@ -267,8 +267,40 @@ class TabularPolicy : public Policy {
   // A ToString where the keys are sorted.
   const std::string ToStringSorted() const;
 
- private:
+ protected:
   std::unordered_map<std::string, ActionsAndProbs> policy_table_;
+};
+
+// A partial tabular policy is one that is not entirely complete: only a subset
+// of the full table is included. When called on state that is not in the table,
+// a specific fallback policy is queried instead.
+class PartialTabularPolicy : public TabularPolicy {
+ public:
+  // Creates an empty partial tabular policy with a uniform fallback policy.
+  PartialTabularPolicy();
+
+  // Creates a partial tabular policy with the specified table with a uniform
+  // fallback policy.
+  PartialTabularPolicy(
+      const std::unordered_map<std::string, ActionsAndProbs>& table);
+
+  // Creates a partial tabular policy with the specified table with the
+  // specified fallback policy.
+  PartialTabularPolicy(
+      const std::unordered_map<std::string, ActionsAndProbs>& table,
+      std::shared_ptr<Policy> fallback_policy);
+
+  // These retrieval methods are all modified in the same way: they first check
+  // if the key is in the table. If so, they return the state policy from the
+  // table. Otherwise, they forward the call to the fallback policy.
+  ActionsAndProbs GetStatePolicy(const State& state) const override;
+  ActionsAndProbs GetStatePolicy(const State& state, Player player)
+      const override;
+  ActionsAndProbs GetStatePolicy(const std::string& info_state)
+      const override;
+
+ private:
+  std::shared_ptr<Policy> fallback_policy_;
 };
 
 std::unique_ptr<TabularPolicy> DeserializeTabularPolicy(

--- a/open_spiel/python/policy.py
+++ b/open_spiel/python/policy.py
@@ -328,6 +328,20 @@ class TabularPolicy(Policy):
     """
     return self.action_probability_array[self.state_lookup[key]]
 
+  def to_dict(self):
+    """Returns a single dictionary representing the tabular policy.
+
+    Returns:
+      A dictionary of string keys to lists of (action, prob) pairs.
+    """
+    policy_dict = {}
+    num_actions = self.action_probability_array.shape[1]
+    for infostate_key, index in self.state_lookup.items():
+      probs = self.action_probability_array[index]
+      actions_and_probs = [(a, probs[a]) for a in range(num_actions)]
+      policy_dict[infostate_key] = actions_and_probs
+    return policy_dict
+
   def __copy__(self, copy_action_probability_array=True):
     """Returns a shallow copy of self.
 

--- a/open_spiel/python/pybind11/policy.cc
+++ b/open_spiel/python/pybind11/policy.cc
@@ -30,10 +30,12 @@
 #include "open_spiel/policy.h"
 #include "open_spiel/python/pybind11/pybind11.h"
 #include "open_spiel/spiel.h"
+#include "pybind11/include/pybind11/detail/common.h"
 
 namespace open_spiel {
 namespace {
 
+using ::open_spiel::ActionsAndProbs;
 using ::open_spiel::algorithms::Exploitability;
 using ::open_spiel::algorithms::NashConv;
 using ::open_spiel::algorithms::TabularBestResponse;
@@ -90,6 +92,29 @@ void init_pyspiel_policy(py::module& m) {
       .def("get_state_policy", &open_spiel::TabularPolicy::GetStatePolicy)
       .def("policy_table",
            py::overload_cast<>(&open_spiel::TabularPolicy::PolicyTable));
+
+  py::class_<open_spiel::PartialTabularPolicy,
+             std::shared_ptr<open_spiel::PartialTabularPolicy>,
+             open_spiel::TabularPolicy>(
+      m, "PartialTabularPolicy")
+      .def(py::init<>())
+      .def(py::init<const std::unordered_map<std::string, ActionsAndProbs>&>())
+      .def(py::init<const std::unordered_map<std::string, ActionsAndProbs>&,
+                    std::shared_ptr<Policy>>())
+      .def("get_state_policy",
+          (ActionsAndProbs(open_spiel::Policy::*)(const State&) const)
+          &open_spiel::PartialTabularPolicy::GetStatePolicy)
+      .def("get_state_policy",
+          (ActionsAndProbs(open_spiel::Policy::*)(const State&, Player) const)
+          &open_spiel::PartialTabularPolicy::GetStatePolicy)
+      .def("get_state_policy",
+           (ActionsAndProbs(open_spiel::Policy::*)(const std::string&) const)
+          &open_spiel::PartialTabularPolicy::GetStatePolicy)
+      .def("set_prob", &open_spiel::PartialTabularPolicy::SetProb)
+      .def("set_state_policy",
+           &open_spiel::PartialTabularPolicy::SetStatePolicy)
+      .def("policy_table",
+           py::overload_cast<>(&open_spiel::PartialTabularPolicy::PolicyTable));
 
   m.def("UniformRandomPolicy", &open_spiel::GetUniformPolicy);
   py::class_<open_spiel::UniformPolicy,

--- a/open_spiel/scripts/ci_script.sh
+++ b/open_spiel/scripts/ci_script.sh
@@ -17,7 +17,7 @@
 set -e
 set -x
 
-# Python 3.9 not default on Ubuntu yet.
+# Python 3.9 not default on Ubuntu yet (Ubuntu 20.04).
 OS=`uname -a | awk '{print $1}'`
 if [[ "$OS" = "Linux" && "$OS_PYTHON_VERSION" = "3.9" ]]; then
   echo "Linux detected and Python 3.9 requested. Installing Python 3.9 and setting as default."
@@ -36,8 +36,13 @@ ${PYBIN} -m pip install --upgrade setuptools
 # ${PYBIN} -m pip install --force-reinstall virtualenv==20.0.23
 # ${PYBIN} -m pip install --upgrade virtualenv
 
-# virtualenv -p ${PYBIN} ./venv
-${PYBIN} -m venv ./venv
+if [[ "$OS" = "Linux" && "$OS_PYTHON_VERSION" = "3.10" ]]; then
+  # Ubuntu 22.04 must execute the virtual env this way:
+  ${PYBIN} -m venv ./venv
+else
+  # Ubuntu 20.04 and earlier
+  virtualenv -p ${PYBIN} ./venv
+fi
 source ./venv/bin/activate
 
 python3 --version

--- a/open_spiel/scripts/ci_script.sh
+++ b/open_spiel/scripts/ci_script.sh
@@ -33,7 +33,8 @@ source ./open_spiel/scripts/python_extra_deps.sh
 
 ${PYBIN} -m pip install --upgrade pip
 ${PYBIN} -m pip install --upgrade setuptools
-${PYBIN} -m pip install --force-reinstall virtualenv==20.0.23
+# ${PYBIN} -m pip install --force-reinstall virtualenv==20.0.23
+# ${PYBIN} -m pip install --upgrade virtualenv
 
 virtualenv -p ${PYBIN} ./venv
 source ./venv/bin/activate

--- a/open_spiel/scripts/ci_script.sh
+++ b/open_spiel/scripts/ci_script.sh
@@ -36,7 +36,8 @@ ${PYBIN} -m pip install --upgrade setuptools
 # ${PYBIN} -m pip install --force-reinstall virtualenv==20.0.23
 # ${PYBIN} -m pip install --upgrade virtualenv
 
-virtualenv -p ${PYBIN} ./venv
+# virtualenv -p ${PYBIN} ./venv
+${PYBIN} -m venv ./venv
 source ./venv/bin/activate
 
 python3 --version

--- a/open_spiel/scripts/ci_script.sh
+++ b/open_spiel/scripts/ci_script.sh
@@ -33,8 +33,6 @@ source ./open_spiel/scripts/python_extra_deps.sh
 
 ${PYBIN} -m pip install --upgrade pip
 ${PYBIN} -m pip install --upgrade setuptools
-# ${PYBIN} -m pip install --force-reinstall virtualenv==20.0.23
-# ${PYBIN} -m pip install --upgrade virtualenv
 
 if [[ "$OS" = "Linux" && "$OS_PYTHON_VERSION" = "3.10" ]]; then
   # Ubuntu 22.04 must execute the virtual env this way:

--- a/open_spiel/scripts/python_extra_deps.sh
+++ b/open_spiel/scripts/python_extra_deps.sh
@@ -27,4 +27,4 @@
 export OPEN_SPIEL_PYTHON_JAX_DEPS="jax==0.3.7 jaxlib==0.3.7 dm-haiku==0.0.6 optax==0.1.2 chex==0.1.3 rlax==0.1.2"
 export OPEN_SPIEL_PYTHON_PYTORCH_DEPS="torch==1.11.0"
 export OPEN_SPIEL_PYTHON_TENSORFLOW_DEPS="numpy==1.21.5 tensorflow==2.8.0 tensorflow-probability==0.16.0 tensorflow_datasets==4.5.2 keras==2.8.0"
-export OPEN_SPIEL_PYTHON_MISC_DEPS="IPython==5.8.0 cvxopt==1.2.7 networkx==2.4 matplotlib==3.3.2 mock==4.0.2 nashpy==0.0.19 scipy==1.7.3 testresources==2.0.1 cvxpy==1.1.17 ecos==2.0.7.post1 osqp==0.6.2.post0 clu==0.0.6"
+export OPEN_SPIEL_PYTHON_MISC_DEPS="IPython==5.8.0 cvxopt==1.3.0 networkx==2.4 matplotlib==3.3.2 mock==4.0.2 nashpy==0.0.19 scipy==1.7.3 testresources==2.0.1 cvxpy==1.1.17 ecos==2.0.7.post1 osqp==0.6.2.post0 clu==0.0.6"

--- a/open_spiel/scripts/python_extra_deps.sh
+++ b/open_spiel/scripts/python_extra_deps.sh
@@ -27,4 +27,4 @@
 export OPEN_SPIEL_PYTHON_JAX_DEPS="jax==0.3.7 jaxlib==0.3.7 dm-haiku==0.0.6 optax==0.1.2 chex==0.1.3 rlax==0.1.2"
 export OPEN_SPIEL_PYTHON_PYTORCH_DEPS="torch==1.11.0"
 export OPEN_SPIEL_PYTHON_TENSORFLOW_DEPS="numpy==1.21.5 tensorflow==2.8.0 tensorflow-probability==0.16.0 tensorflow_datasets==4.5.2 keras==2.8.0"
-export OPEN_SPIEL_PYTHON_MISC_DEPS="IPython==5.8.0 cvxopt==1.3.0 networkx==2.4 matplotlib==3.3.2 mock==4.0.2 nashpy==0.0.19 scipy==1.7.3 testresources==2.0.1 cvxpy==1.1.17 ecos==2.0.7.post1 osqp==0.6.2.post0 clu==0.0.6"
+export OPEN_SPIEL_PYTHON_MISC_DEPS="IPython==5.8.0 cvxopt==1.3.0 networkx==2.4 matplotlib==3.3.2 mock==4.0.2 nashpy==0.0.19 scipy==1.7.3 testresources==2.0.1 cvxpy==1.2.0 ecos==2.0.10 osqp==0.6.2.post5 clu==0.0.6"

--- a/open_spiel/scripts/test_wheel.sh
+++ b/open_spiel/scripts/test_wheel.sh
@@ -56,7 +56,7 @@ if [[ "$MODE" = "full" ]]; then
   if [[ "$OS" = "Linux" ]]; then
     ${PYBIN} -m pip install wheelhouse/open_spiel-*-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   else
-    ${PYBIN} -m pip install wheelhouse/open_spiel-*-cp39-cp39-macosx_10_9_x86_64.whl
+    ${PYBIN} -m pip install wheelhouse/open_spiel-*-cp310-cp310-macosx_10_9_x86_64.whl
   fi
 fi
 


### PR DESCRIPTION
- Most recent MacOS 10.15 -> MacOS-12
- Previous MacOS 10.15 -> MacOS-11
- Add Ubuntu 22.04 CI targets
- Update cibuildwheel version to 2.5.0 to build Python 3.10 wheels
- Remove pinning version of virtualenv in CI tests
- Add custom command for venv on Ubuntu 22.04
- Upgrade optimization package versions