### PR TITLE
add InformationStateString to repeated_games

### DIFF
--- a/open_spiel/game_transforms/repeated_game.h
+++ b/open_spiel/game_transforms/repeated_game.h
@@ -27,9 +27,9 @@
 //
 // Parameters:
 //   "enable_infostate"   bool     Enable the sequence of round outcomes as the
-//                                 information state tensor (default: false).
+//                                 information state tensor and string (default: false).
 //   "stage_game"         game     The game that will be repeated.
-//   "num_repititions"    int      Number of times that the game is repeated.
+//   "num_repetitions"    int      Number of times that the game is repeated.
 
 
 namespace open_spiel {
@@ -47,6 +47,7 @@ class RepeatedState : public SimMoveState {
   bool IsTerminal() const override;
   std::vector<double> Rewards() const override;
   std::vector<double> Returns() const override;
+  std::string InformationStateString(Player player) const override;
   std::string ObservationString(Player player) const override;
   void InformationStateTensor(Player player,
                               absl::Span<float> values) const override;

--- a/open_spiel/game_transforms/repeated_game_test.cc
+++ b/open_spiel/game_transforms/repeated_game_test.cc
@@ -104,12 +104,21 @@ void RepeatedRockPaperScissorsInfoStateEnabledTest() {
                  GameType::RewardModel::kRewards);
   SPIEL_CHECK_TRUE(repeated_game->GetType().provides_observation_tensor);
   SPIEL_CHECK_TRUE(repeated_game->GetType().provides_information_state_tensor);
+  SPIEL_CHECK_TRUE(repeated_game->GetType().provides_information_state_string);
 
   // One-hot encoding of each player's previous action.
   SPIEL_CHECK_EQ(repeated_game->ObservationTensorShape()[0], 6);
 
   // One-hot encoding of each player's previous action times num_repetitions.
   SPIEL_CHECK_EQ(repeated_game->InformationStateTensorShape()[0], 18);
+
+  //Check information_state_string
+  std::unique_ptr<State> state = repeated_game->NewInitialState();
+  SPIEL_CHECK_EQ(state->InformationStateString(), "");
+  state->ApplyActions({0,0});
+  SPIEL_CHECK_EQ(state->InformationStateString(), "Rock Rock ;");
+  state->ApplyActions({1,2});
+  SPIEL_CHECK_EQ(state->InformationStateString(), "Rock Rock ;Paper Scissors ;");
 
   RepeatedRockPaperScissorsTest(repeated_game);
 }


### PR DESCRIPTION
1. Add InformationStateString method to repeated games and add test
2. change the names of `kDefaultEnableInformationStateTensor` flag and `enable_info_state_tensor` to also control `provides_information_state_string` in addition to `provides_information_state_tensor`. Not sure if this is what we want?(not entirely clear on the purpose of the parameter)
3. fix typo in docstring: num_repititions -> num_repetitions