### PR TITLE
add UtilitySum method to repeated games

### DIFF
--- a/open_spiel/game_transforms/repeated_game.h
+++ b/open_spiel/game_transforms/repeated_game.h
@@ -87,6 +87,9 @@ class RepeatedGame : public SimMoveGame {
   double MaxUtility() const override {
     return stage_game_->MaxUtility() * num_repetitions_;
   }
+  double UtilitySum() const override {
+    return stage_game_->UtilitySum() * num_repetitions_;
+  }
   std::vector<int> InformationStateTensorShape() const override;
   std::vector<int> ObservationTensorShape() const override;
 

--- a/open_spiel/game_transforms/repeated_game_test.cc
+++ b/open_spiel/game_transforms/repeated_game_test.cc
@@ -124,6 +124,8 @@ void RepeatedPrisonersDilemaTest() {
   SPIEL_CHECK_EQ(repeated_game->GetType().min_num_players, 2);
   SPIEL_CHECK_EQ(repeated_game->GetType().utility,
                  GameType::Utility::kGeneralSum);
+  // repeated_game->UtilitySum() should raise an error. This is checked in 
+  // game_transforms_test.py as it's simpler to catch the error from Python.
   SPIEL_CHECK_EQ(repeated_game->GetType().reward_model,
                  GameType::RewardModel::kRewards);
 

--- a/open_spiel/integration_tests/playthroughs/repeated_game(stage_game=matrix_rps(),num_repetitions=10).txt
+++ b/open_spiel/integration_tests/playthroughs/repeated_game(stage_game=matrix_rps(),num_repetitions=10).txt
@@ -23,7 +23,7 @@ GetParameters() = {num_repetitions=10,stage_game=matrix_rps()}
 NumPlayers() = 2
 MinUtility() = -10.0
 MaxUtility() = 10.0
-UtilitySum() = None
+UtilitySum() = 0.0
 ObservationTensorShape() = [6]
 ObservationTensorLayout() = TensorLayout.CHW
 ObservationTensorSize() = 6
@@ -49,17 +49,45 @@ LegalActions(1) = [0, 1, 2]
 StringLegalActions(0) = ["Rock", "Paper", "Scissors"]
 StringLegalActions(1) = ["Rock", "Paper", "Scissors"]
 
-# Apply joint action ["Rock", "Rock"]
-actions: [0, 0]
+# Apply joint action ["Scissors", "Paper"]
+actions: [2, 1]
 
 # State 1
 # Round 0:
+# Actions: Scissors Paper
+# Rewards: 1 -1
+# Total Returns: 1 -1
+IsTerminal() = False
+History() = [2, 1]
+HistoryString() = "2, 1"
+IsChanceNode() = False
+IsSimultaneousNode() = True
+CurrentPlayer() = -2
+ObservationString(0) = "Scissors Paper "
+ObservationString(1) = "Scissors Paper "
+ObservationTensor(0): ◯◯◉◯◉◯
+ObservationTensor(1): ◯◯◉◯◉◯
+Rewards() = [1, -1]
+Returns() = [1, -1]
+LegalActions(0) = [0, 1, 2]
+LegalActions(1) = [0, 1, 2]
+StringLegalActions(0) = ["Rock", "Paper", "Scissors"]
+StringLegalActions(1) = ["Rock", "Paper", "Scissors"]
+
+# Apply joint action ["Rock", "Rock"]
+actions: [0, 0]
+
+# State 2
+# Round 0:
+# Actions: Scissors Paper
+# Rewards: 1 -1
+# Round 1:
 # Actions: Rock Rock
 # Rewards: 0 0
-# Total Returns: 0 0
+# Total Returns: 1 -1
 IsTerminal() = False
-History() = [0, 0]
-HistoryString() = "0, 0"
+History() = [2, 1, 0, 0]
+HistoryString() = "2, 1, 0, 0"
 IsChanceNode() = False
 IsSimultaneousNode() = True
 CurrentPlayer() = -2
@@ -68,7 +96,7 @@ ObservationString(1) = "Rock Rock "
 ObservationTensor(0): ◉◯◯◉◯◯
 ObservationTensor(1): ◉◯◯◉◯◯
 Rewards() = [0, 0]
-Returns() = [0, 0]
+Returns() = [1, -1]
 LegalActions(0) = [0, 1, 2]
 LegalActions(1) = [0, 1, 2]
 StringLegalActions(0) = ["Rock", "Paper", "Scissors"]
@@ -77,103 +105,75 @@ StringLegalActions(1) = ["Rock", "Paper", "Scissors"]
 # Apply joint action ["Scissors", "Scissors"]
 actions: [2, 2]
 
-# State 2
-# Round 0:
-# Actions: Rock Rock
-# Rewards: 0 0
-# Round 1:
-# Actions: Scissors Scissors
-# Rewards: 0 0
-# Total Returns: 0 0
-IsTerminal() = False
-History() = [0, 0, 2, 2]
-HistoryString() = "0, 0, 2, 2"
-IsChanceNode() = False
-IsSimultaneousNode() = True
-CurrentPlayer() = -2
-ObservationString(0) = "Scissors Scissors "
-ObservationString(1) = "Scissors Scissors "
-ObservationTensor(0): ◯◯◉◯◯◉
-ObservationTensor(1): ◯◯◉◯◯◉
-Rewards() = [0, 0]
-Returns() = [0, 0]
-LegalActions(0) = [0, 1, 2]
-LegalActions(1) = [0, 1, 2]
-StringLegalActions(0) = ["Rock", "Paper", "Scissors"]
-StringLegalActions(1) = ["Rock", "Paper", "Scissors"]
-
-# Apply joint action ["Paper", "Rock"]
-actions: [1, 0]
-
 # State 3
-# Apply joint action ["Paper", "Paper"]
-actions: [1, 1]
+# Apply joint action ["Scissors", "Rock"]
+actions: [2, 0]
 
 # State 4
-# Apply joint action ["Paper", "Paper"]
-actions: [1, 1]
+# Apply joint action ["Paper", "Rock"]
+actions: [1, 0]
 
 # State 5
 # Apply joint action ["Rock", "Paper"]
 actions: [0, 1]
 
 # State 6
-# Apply joint action ["Rock", "Scissors"]
-actions: [0, 2]
+# Apply joint action ["Paper", "Scissors"]
+actions: [1, 2]
 
 # State 7
-# Apply joint action ["Rock", "Scissors"]
-actions: [0, 2]
+# Apply joint action ["Paper", "Paper"]
+actions: [1, 1]
 
 # State 8
-# Apply joint action ["Rock", "Rock"]
-actions: [0, 0]
+# Apply joint action ["Rock", "Paper"]
+actions: [0, 1]
 
 # State 9
-# Apply joint action ["Rock", "Scissors"]
-actions: [0, 2]
+# Apply joint action ["Scissors", "Rock"]
+actions: [2, 0]
 
 # State 10
 # Round 0:
+# Actions: Scissors Paper
+# Rewards: 1 -1
+# Round 1:
 # Actions: Rock Rock
 # Rewards: 0 0
-# Round 1:
+# Round 2:
 # Actions: Scissors Scissors
 # Rewards: 0 0
-# Round 2:
+# Round 3:
+# Actions: Scissors Rock
+# Rewards: -1 1
+# Round 4:
 # Actions: Paper Rock
 # Rewards: 1 -1
-# Round 3:
-# Actions: Paper Paper
-# Rewards: 0 0
-# Round 4:
-# Actions: Paper Paper
-# Rewards: 0 0
 # Round 5:
 # Actions: Rock Paper
 # Rewards: -1 1
 # Round 6:
-# Actions: Rock Scissors
-# Rewards: 1 -1
+# Actions: Paper Scissors
+# Rewards: -1 1
 # Round 7:
-# Actions: Rock Scissors
-# Rewards: 1 -1
-# Round 8:
-# Actions: Rock Rock
+# Actions: Paper Paper
 # Rewards: 0 0
+# Round 8:
+# Actions: Rock Paper
+# Rewards: -1 1
 # Round 9:
-# Actions: Rock Scissors
-# Rewards: 1 -1
-# Total Returns: 3 -3
+# Actions: Scissors Rock
+# Rewards: -1 1
+# Total Returns: -3 3
 IsTerminal() = True
-History() = [0, 0, 2, 2, 1, 0, 1, 1, 1, 1, 0, 1, 0, 2, 0, 2, 0, 0, 0, 2]
-HistoryString() = "0, 0, 2, 2, 1, 0, 1, 1, 1, 1, 0, 1, 0, 2, 0, 2, 0, 0, 0, 2"
+History() = [2, 1, 0, 0, 2, 2, 2, 0, 1, 0, 0, 1, 1, 2, 1, 1, 0, 1, 2, 0]
+HistoryString() = "2, 1, 0, 0, 2, 2, 2, 0, 1, 0, 0, 1, 1, 2, 1, 1, 0, 1, 2, 0"
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = -4
-ObservationString(0) = "Rock Scissors "
-ObservationString(1) = "Rock Scissors "
-ObservationTensor(0): ◉◯◯◯◯◉
-ObservationTensor(1): ◉◯◯◯◯◉
-Rewards() = [1, -1]
-Returns() = [3, -3]
+ObservationString(0) = "Scissors Rock "
+ObservationString(1) = "Scissors Rock "
+ObservationTensor(0): ◯◯◉◉◯◯
+ObservationTensor(1): ◯◯◉◉◯◯
+Rewards() = [-1, 1]
+Returns() = [-3, 3]

--- a/open_spiel/python/CMakeLists.txt
+++ b/open_spiel/python/CMakeLists.txt
@@ -212,6 +212,7 @@ set(PYTHON_TESTS ${PYTHON_TESTS}
   mfg/games/dynamic_routing_test.py
   tests/mfg_implementation_test/mfg_test.py
   tests/bot_test.py
+  tests/game_transforms_test.py
   tests/games_bridge_test.py
   tests/games_sim_test.py
   tests/policy_test.py

--- a/open_spiel/python/tests/game_transforms_test.py
+++ b/open_spiel/python/tests/game_transforms_test.py
@@ -29,6 +29,7 @@ class RepeatedGameTest(absltest.TestCase):
     """Test both create_repeated_game function signatures."""
     repeated_game = pyspiel.create_repeated_game("matrix_rps",
                                                  {"num_repetitions": 10})
+    assert repeated_game.utility_sum() == 0
     state = repeated_game.new_initial_state()
     for _ in range(10):
       state.apply_actions([0, 0])
@@ -41,6 +42,12 @@ class RepeatedGameTest(absltest.TestCase):
     for _ in range(5):
       state.apply_actions([0, 0])
     assert state.is_terminal()
+
+    stage_game = pyspiel.load_game("matrix_pd")
+    repeated_game = pyspiel.create_repeated_game(stage_game,
+                                                 {"num_repetitions": 5})
+    with self.assertRaises(pyspiel.SpielError):
+      repeated_game.utility_sum()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I noticed that python's `exploitability.exploitability()` was erroring because `utility_sum()` wasn't defined for repeated games.

In this PR, I add the `UtilitySum` method to repeated games. Also, I noticed that the `python/tests/game_transforms_test.py` file didn't seem like it was actually being run anywhere, so I added it to `PYTHON_TESTS` in `CMakeLists.txt`.