### PR TITLE
Fix sudden failures when compiling + testing wheels

### DIFF
--- a/open_spiel/game_parameters.h
+++ b/open_spiel/game_parameters.h
@@ -15,6 +15,7 @@
 #ifndef OPEN_SPIEL_GAME_PARAMETERS_H_
 #define OPEN_SPIEL_GAME_PARAMETERS_H_
 
+#include <iostream>
 #include <map>
 #include <memory>
 #include <string>
@@ -157,6 +158,9 @@ class GameParameter {
       case Type::kUnset:
         return rhs.type_ == Type::kUnset;
     }
+    std::cerr << "Unrecognized parameter type in operator=="
+              << ", returning false." << std::endl;
+    return false;
   }
   bool operator!=(const GameParameter& rhs) const { return !(*this == rhs); }
 

--- a/open_spiel/games/amazons.cc
+++ b/open_spiel/games/amazons.cc
@@ -380,6 +380,10 @@ std::string AmazonsState::ActionToString(Player player, Action action) const {
       return absl::StrCat(StateToString(PlayerToState(player)),
                           " Shoot:  ", str);
   }
+    
+  std::cerr << "Unhandled case in AmazonState::ActionToString, "
+            << "returning empty string." << std::endl;
+  return "";
 }
 
 // Looks okay

--- a/open_spiel/python/egt/dynamics_test.py
+++ b/open_spiel/python/egt/dynamics_test.py
@@ -63,7 +63,7 @@ class _InternalTest(absltest.TestCase):
     expected_2 = np.asarray([expected_0, expected_1, expected_2])
     np.testing.assert_array_equal(expected, expected_2)
 
-    np.testing.assert_array_equal(expected, _sum_j_x_j_ln_x_j_over_x_i(x))
+    np.testing.assert_array_almost_equal(expected, _sum_j_x_j_ln_x_j_over_x_i(x))
 
 
 class DynamicsTest(parameterized.TestCase):


### PR DESCRIPTION
There seem to be some sudden build failures for the wheels: https://github.com/deepmind/open_spiel/actions/runs/2564940439, so this PR is an attempt to fix them.

- Fix returns from non-void functions
- Fix error in comparison of 16th decimal place in `dynamics_test`