### PR TITLE
add Asymmetric-Q & refine Nash-Q

### DIFF
--- a/open_spiel/python/algorithms/tabular_multiagent_qlearner.py
+++ b/open_spiel/python/algorithms/tabular_multiagent_qlearner.py
@@ -17,18 +17,21 @@ Currently implementations include:
 Nash-Q: https://www.jmlr.org/papers/volume4/hu03a/hu03a.pdf
 Correlated-Q: https://www.aaai.org/Papers/ICML/2003/ICML03-034.pdf, where both
 CE-Q and CCE-Q are supported.
+Asymmetric-Q: https://ieeexplore.ieee.org/document/1241094
 """
 
 import abc
 import collections
 import itertools
+import nashpy as nash
 import numpy as np
 
 from open_spiel.python import rl_agent
 from open_spiel.python import rl_tools
 from open_spiel.python.algorithms.jpsro import _mgcce
 from open_spiel.python.algorithms.jpsro import _mgce
-from open_spiel.python.algorithms.matrix_nash import lemke_howson_solve
+from open_spiel.python.algorithms.stackelberg_lp import solve_stackelberg
+import pyspiel
 
 
 def valuedict():
@@ -62,11 +65,13 @@ class TwoPlayerNashSolver(JointActionSolver):
     row_payoffs, col_payoffs = payoffs_array[0], payoffs_array[1]
     a0, a1 = payoffs_array.shape[1:]
 
+    nashpy_game = nash.Game(row_payoffs, col_payoffs)
+
     best_value = float("-inf")
     res_mixtures, res_values = None, None
 
     for (row_mixture,
-         col_mixture) in lemke_howson_solve(row_payoffs, col_payoffs):
+         col_mixture) in nashpy_game.support_enumeration():
       # TO-DO: handle the case where the LH solver gave ineligible answer
       if np.sum(np.isnan(row_mixture)) or np.sum(np.isnan(col_mixture)):
         continue
@@ -116,6 +121,32 @@ class CorrelatedEqSolver(JointActionSolver):
     return mixtures, values
 
 
+class StackelbergEqSolver(JointActionSolver):
+  """A joint action solver solving for Stackelverg equilibrium.
+
+  Uses python.algorithms.stackelberg_lp.py.
+  """
+
+  def __init__(self, is_first_leader=True):
+    self._is_first_leader = is_first_leader
+
+  def __call__(self, payoffs_array):
+    assert len(payoffs_array) == 2
+    game = pyspiel.create_matrix_game(payoffs_array[0], payoffs_array[1])
+    try:
+      player0_strategy, player1_strategy, player0_value, player1_value = solve_stackelberg(
+          game, self._is_first_leader)
+      return [player0_strategy, player1_strategy], [player0_value, player1_value]
+    except:
+      # if the game matrix is degenerated and cannot solve for an SSE, return uniform strategy
+      num_player0_strategies, num_player1_strategies = payoffs_array[0].shape
+      player0_strategy, player1_strategy = np.ones(
+          num_player0_strategies)/num_player0_strategies, np.ones(num_player1_strategies)/num_player1_strategies
+      player0_value, player1_value = player0_strategy.reshape(1, -1).dot(payoffs_array[0]).dot(
+          player1_strategy.reshape(-1, 1)), player0_strategy.reshape(1, -1).dot(payoffs_array[1]).dot(player1_strategy.reshape(-1, 1))
+      return [player0_strategy, player1_strategy], [player0_value, player1_value]
+
+
 class MultiagentQLearner(rl_agent.AbstractAgent):
   """A multiagent joint action learner."""
 
@@ -154,13 +185,10 @@ class MultiagentQLearner(rl_agent.AbstractAgent):
     ]
     self._prev_info_state = None
 
-  def restart_episode(self):
-    self._prev_info_state = None
-
   def _get_payoffs_array(self, info_state):
     payoffs_array = np.zeros((self._num_players,) + tuple(self._num_actions))
     for joint_action in itertools.product(
-        *[range(dim) for dim in self._num_actions]):
+            *[range(dim) for dim in self._num_actions]):
       for n in range(self._num_players):
         payoffs_array[
             (n,) + joint_action] = self._q_values[n][info_state][joint_action]

--- a/open_spiel/python/algorithms/tabular_multiagent_qlearner_test.py
+++ b/open_spiel/python/algorithms/tabular_multiagent_qlearner_test.py
@@ -20,6 +20,7 @@ from open_spiel.python import rl_environment
 from open_spiel.python.algorithms.tabular_multiagent_qlearner import CorrelatedEqSolver
 from open_spiel.python.algorithms.tabular_multiagent_qlearner import MultiagentQLearner
 from open_spiel.python.algorithms.tabular_multiagent_qlearner import TwoPlayerNashSolver
+from open_spiel.python.algorithms.tabular_multiagent_qlearner import StackelbergEqSolver
 from open_spiel.python.algorithms.tabular_qlearner import QLearner
 from open_spiel.python.egt.utils import game_payoffs_array
 import pyspiel
@@ -50,7 +51,6 @@ class MultiagentQTest(absltest.TestCase):
         ]
         time_step = env.step(actions)
         step_cnt += 1
-
       self.assertLess(step_cnt, 500)
 
     with self.subTest("ce_q"):
@@ -93,6 +93,27 @@ class MultiagentQTest(absltest.TestCase):
 
       self.assertLess(step_cnt, 500)
 
+    with self.subTest("asym_q"):
+      qlearner = QLearner(0, env.game.num_distinct_actions())
+      asymqlearner = MultiagentQLearner(1, 2,
+                                       [env.game.num_distinct_actions()] * 2,
+                                       StackelbergEqSolver())
+
+      time_step = env.reset()
+      actions = [None, None]
+      step_cnt = 0
+
+      while not time_step.last():
+        actions = [
+            qlearner.step(time_step).action,
+            asymqlearner.step(time_step, actions).action
+        ]
+        time_step = env.step(actions)
+        step_cnt += 1
+
+      self.assertLess(step_cnt, 500)
+
+
   def test_rps_run(self):
     env = rl_environment.Environment("matrix_rps")
     nashqlearner0 = MultiagentQLearner(0, 2,
@@ -105,8 +126,6 @@ class MultiagentQTest(absltest.TestCase):
 
     for _ in range(1000):
       time_step = env.reset()
-      nashqlearner0.restart_episode()
-      nashqlearner1.restart_episode()
       actions = [None, None]
       actions = [
           nashqlearner0.step(time_step, actions).action,
@@ -118,8 +137,6 @@ class MultiagentQTest(absltest.TestCase):
 
     with self.subTest("correct_rps_strategy"):
       time_step = env.reset()
-      nashqlearner0.restart_episode()
-      nashqlearner1.restart_episode()
       actions = [None, None]
       learner0_strategy, learner1_strategy = nashqlearner0.step(
           time_step, actions).probs, nashqlearner1.step(time_step,


### PR DESCRIPTION
Hello, I would like to (1) add [Asymmetric-Q](https://ieeexplore.ieee.org/document/1241094) which uses Stackelberg equilibrium to solve these Q-matrix games (2) refine Nash-Q by using enumerate_support() method to compute a Nash, since the Lemke-Howson solver may not always returns a solution.