### PR TITLE
fix bug in policy aggregator

### DIFF
--- a/open_spiel/python/algorithms/policy_aggregator.py
+++ b/open_spiel/python/algorithms/policy_aggregator.py
@@ -21,6 +21,7 @@ policy by sweeping over the state space.
 import numpy as np
 from open_spiel.python import policy
 import pyspiel
+import copy
 
 
 class PolicyFunction(policy.Policy):
@@ -236,7 +237,7 @@ class PolicyAggregator(object):
       used_moves = np.unique(used_moves)
 
       for uid in used_moves:
-        new_reaches = np.copy(my_reaches)
+        new_reaches = copy.deepcopy(my_reaches)
         if pid == turn_player:
           for i in range(len(legal_policies)):
             # compute the new reach for each policy for this action

--- a/open_spiel/python/algorithms/policy_aggregator_joint.py
+++ b/open_spiel/python/algorithms/policy_aggregator_joint.py
@@ -22,6 +22,7 @@ policy.
 import numpy as np
 from open_spiel.python import policy
 import pyspiel
+import copy
 
 
 def _aggregate_at_state(joint_policies, state, player):
@@ -159,7 +160,7 @@ class JointPolicyAggregator(object):
     self._policy = {}
 
     state = self._game.new_initial_state()
-    self._rec_aggregate(pid, state, weights.copy())
+    self._rec_aggregate(pid, state, copy.deepcopy(weights))
 
     # Now normalize
     for key in self._policy:
@@ -215,7 +216,7 @@ class JointPolicyAggregator(object):
         self._policy[state_key] = {}
 
     for action in state.legal_actions():
-      new_reaches = np.copy(my_reaches)
+      new_reaches = copy.deepcopy(my_reaches)
       if pid == current_player:
         for idx, state_action_probs in enumerate(action_probabilities_list):
           # compute the new reach for each policy for this action

--- a/open_spiel/python/algorithms/policy_aggregator_test.py
+++ b/open_spiel/python/algorithms/policy_aggregator_test.py
@@ -22,6 +22,7 @@ import numpy as np
 from open_spiel.python import policy
 from open_spiel.python import rl_environment
 from open_spiel.python.algorithms import policy_aggregator
+import pyspiel
 
 
 class PolicyAggregatorTest(parameterized.TestCase):
@@ -83,6 +84,29 @@ class PolicyAggregatorTest(parameterized.TestCase):
       }
       for key in value_normal.keys():
         self.assertAlmostEqual(value[key], value_normal[key], 8)
+
+  @parameterized.named_parameters(
+      {
+          "testcase_name": "tic_tac_toe",
+          "game_name": "tic_tac_toe",
+      })
+  def test_policy_aggregation_variadic(self, game_name):
+    game = pyspiel.load_game(game_name)
+
+    uniform_policy = policy.UniformRandomPolicy(game)
+    first_action_policy = policy.FirstActionPolicy(game)
+
+    pol_ag = policy_aggregator.PolicyAggregator(game)
+
+    weights0 = [1.0, 0.0]
+    player0 = pol_ag.aggregate(list(range(game.num_players())), [[uniform_policy, first_action_policy]] + [
+                               [uniform_policy]] * (game.num_players()-1), [weights0] + [[1.0]] * (game.num_players()-1))
+    state = game.new_initial_state()
+    action_prob = player0.action_probabilities(state)
+    for action in action_prob:
+      if action_prob[action] > 0:
+        self.assertAlmostEqual(
+            action_prob[action], 1./len(state.legal_actions()))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hello. I think there is one issue in the original implementation of policy aggregator. If we use it in the following way:
```game = pyspiel.load_game("tic_tac_toe")
uniform_policy = UniformRandomPolicy(game)
first_action_policy = FirstActionPolicy(game)
weights = [1.0, 0.0]
aggregator = PolicyAggregator(game)
player0 = aggregator.aggregate([0, 1], [[uniform_policy, first_action_policy], [uniform_policy]], [copy.deepcopy(weights), [1.0]])
print(player0.action_probabilities(game.new_initial_state()))
```

Where here player0 should be a uniform policy (since it gets all the mass), and it should prints something like {0: 0.111, 1:0.111....}.
However it actually prints {0:1, 1:0, 2:0,...., 8:0}.

The reason is in this line: 
https://github.com/deepmind/open_spiel/blob/4924f3de48bf88421259eddc1454f7a1f37d0dc8/open_spiel/python/algorithms/policy_aggregator.py#L239

It uses np.copy to copy the weights. However np.copy is not a deepcopy for variadic weights. The return of np.copy([[1.0, 0.0], [1.0]]) is actually  `array([list([1.0, 0.0]), list([1.0])], dtype=object)`. So if you modify one list object in it, it will be propagated to any np.copy(). And as a consequence the reach probabilities will just be messed up due to the recursion implementation. I think the original implementation is correct only when the weights array is a complete matrix so every player is mixing the same number of policies.

The solution is simple: we just replace np.copy with copy.deepcopy().