### PR TITLE
Update install.sh to avoid CI failure

### DIFF
--- a/open_spiel/scripts/install.sh
+++ b/open_spiel/scripts/install.sh
@@ -269,11 +269,12 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then  # Mac OSX
   [[ -x `which realpath` ]] || brew install coreutils || echo "** Warning: failed 'brew install coreutils' -- continuing"
   [[ -x `which cmake` ]] || brew install cmake || echo "** Warning: failed 'brew install cmake' -- continuing"
   [[ -x `which python3` ]] || brew install python3 || echo "** Warning: failed 'brew install python3' -- continuing"
-  # On Github Actions, macOS 10.15 comes with Python 3.9.
+  # On Github Actions, macOS comes with Python 3.9.
   # We want to test multiple Python versions determined by OS_PYTHON_VERSION.
   if [[ "$CI" && "${OS_PYTHON_VERSION}" != "3.9" ]]; then
     brew install "python@${OS_PYTHON_VERSION}"
-    brew unlink python@3.9
+    # Uninstall Python 3.9 if we need to.
+    brew list python@3.9 ]] && brew unlink python@3.9
     brew link --force --overwrite "python@${OS_PYTHON_VERSION}"
   fi
   `python3 -c "import tkinter" > /dev/null 2>&1` || brew install tcl-tk || echo "** Warning: failed 'brew install tcl-tk' -- continuing"

--- a/open_spiel/scripts/install.sh
+++ b/open_spiel/scripts/install.sh
@@ -274,7 +274,7 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then  # Mac OSX
   if [[ "$CI" && "${OS_PYTHON_VERSION}" != "3.9" ]]; then
     brew install "python@${OS_PYTHON_VERSION}"
     # Uninstall Python 3.9 if we need to.
-    brew list python@3.9 ]] && brew unlink python@3.9
+    brew list python@3.9 && brew unlink python@3.9
     brew link --force --overwrite "python@${OS_PYTHON_VERSION}"
   fi
   `python3 -c "import tkinter" > /dev/null 2>&1` || brew install tcl-tk || echo "** Warning: failed 'brew install tcl-tk' -- continuing"

--- a/open_spiel/scripts/python_extra_deps.sh
+++ b/open_spiel/scripts/python_extra_deps.sh
@@ -24,7 +24,7 @@
 #
 # To enable specific tests, please use the environment variables found in
 # scripts/global_variables.sh
-export OPEN_SPIEL_PYTHON_JAX_DEPS="jax==0.3.7 jaxlib==0.3.7 dm-haiku==0.0.6 optax==0.1.2 chex==0.1.3 rlax==0.1.2"
+export OPEN_SPIEL_PYTHON_JAX_DEPS="jax==0.3.16 jaxlib==0.3.16 dm-haiku==0.0.7 optax==0.1.3 chex==0.1.4 rlax==0.1.4"
 export OPEN_SPIEL_PYTHON_PYTORCH_DEPS="torch==1.11.0"
 export OPEN_SPIEL_PYTHON_TENSORFLOW_DEPS="numpy==1.21.6 tensorflow==2.9.0 tensorflow-probability==0.16.0 tensorflow_datasets==4.5.2 keras==2.9.0"
 export OPEN_SPIEL_PYTHON_MISC_DEPS="IPython==5.8.0 cvxopt==1.3.0 networkx==2.4 matplotlib==3.5.2 mock==4.0.2 nashpy==0.0.19 scipy==1.7.3 testresources==2.0.1 cvxpy==1.2.0 ecos==2.0.10 osqp==0.6.2.post5 clu==0.0.6"

--- a/open_spiel/scripts/python_extra_deps.sh
+++ b/open_spiel/scripts/python_extra_deps.sh
@@ -24,7 +24,7 @@
 #
 # To enable specific tests, please use the environment variables found in
 # scripts/global_variables.sh
-export OPEN_SPIEL_PYTHON_JAX_DEPS="jax==0.3.16 jaxlib==0.3.16 dm-haiku==0.0.7 optax==0.1.3 chex==0.1.4 rlax==0.1.4"
+export OPEN_SPIEL_PYTHON_JAX_DEPS="jax==0.3.14 jaxlib==0.3.14 dm-haiku==0.0.7 optax==0.1.3 chex==0.1.4 rlax==0.1.4"
 export OPEN_SPIEL_PYTHON_PYTORCH_DEPS="torch==1.11.0"
 export OPEN_SPIEL_PYTHON_TENSORFLOW_DEPS="numpy==1.21.6 tensorflow==2.9.0 tensorflow-probability==0.16.0 tensorflow_datasets==4.5.2 keras==2.9.0"
 export OPEN_SPIEL_PYTHON_MISC_DEPS="IPython==5.8.0 cvxopt==1.3.0 networkx==2.4 matplotlib==3.5.2 mock==4.0.2 nashpy==0.0.19 scipy==1.7.3 testresources==2.0.1 cvxpy==1.2.0 ecos==2.0.10 osqp==0.6.2.post5 clu==0.0.6"


### PR DESCRIPTION
1. The `brew unlink` command appears to be failing now, so MacOS versions of Python on GitHub actions may have changed. Example of failed runs: https://github.com/deepmind/open_spiel/actions/runs/2873127141  (from commits in #894)

2. There seems to be issues with the Jax versions, so upgrading them while we're here.