### PR TITLE
add tabular_average_policy() to CFRPlusSolver

### DIFF
--- a/open_spiel/python/pybind11/policy.cc
+++ b/open_spiel/python/pybind11/policy.cc
@@ -157,6 +157,8 @@ void init_pyspiel_policy(py::module& m) {
       .def("current_policy", &open_spiel::algorithms::CFRSolver::CurrentPolicy)
       .def("average_policy",
            &open_spiel::algorithms::CFRPlusSolver::AveragePolicy)
+      .def("tabular_average_policy",
+           &open_spiel::algorithms::CFRPlusSolver::TabularAveragePolicy)
       .def(py::pickle(
           [](const open_spiel::algorithms::CFRPlusSolver&
                  solver) {  // __getstate__


### PR DESCRIPTION
`TabularAveragePolicy()` was exposed to python for CFRSolver in https://github.com/deepmind/open_spiel/commit/0d4c3e9a56fbbc53b8a5e2fc746e308cf2fd2ff8 

Here I also add it for CFRPlusSolver