### PR TITLE
add flax to python misc deps

### DIFF
--- a/open_spiel/scripts/python_extra_deps.sh
+++ b/open_spiel/scripts/python_extra_deps.sh
@@ -27,4 +27,4 @@
 export OPEN_SPIEL_PYTHON_JAX_DEPS="jax==0.3.14 jaxlib==0.3.14 dm-haiku==0.0.7 optax==0.1.3 chex==0.1.4 rlax==0.1.4"
 export OPEN_SPIEL_PYTHON_PYTORCH_DEPS="torch==1.11.0"
 export OPEN_SPIEL_PYTHON_TENSORFLOW_DEPS="numpy==1.21.6 tensorflow==2.9.0 tensorflow-probability==0.16.0 tensorflow_datasets==4.5.2 keras==2.9.0"
-export OPEN_SPIEL_PYTHON_MISC_DEPS="IPython==5.8.0 cvxopt==1.3.0 networkx==2.4 matplotlib==3.5.2 mock==4.0.2 nashpy==0.0.19 scipy==1.7.3 testresources==2.0.1 cvxpy==1.2.0 ecos==2.0.10 osqp==0.6.2.post5 clu==0.0.6"
+export OPEN_SPIEL_PYTHON_MISC_DEPS="IPython==5.8.0 cvxopt==1.3.0 networkx==2.4 matplotlib==3.5.2 mock==4.0.2 nashpy==0.0.19 scipy==1.7.3 testresources==2.0.1 cvxpy==1.2.0 ecos==2.0.10 osqp==0.6.2.post5 clu==0.0.6 flax==0.5.3"


### PR DESCRIPTION
Pinning to flax-0.5.3 may help alleviate how often the jax/jaxlib deps versions need to be updated?


clu-0.0.6 requires flax (https://github.com/google/CommonLoopUtils/blob/v0.0.6/setup.py#L49)

current version of flax = 0.6.0
flax-0.6.0 requires jax>=0.3.16 (https://github.com/google/flax/blob/v0.6.0/setup.py#L29)
flax-0.5.3 requires jax>=0.3.2 (https://github.com/google/flax/blob/v0.5.3/setup.py#L29)