### PR TITLE
Fix cargo bindgen install command

### DIFF
--- a/open_spiel/scripts/install.sh
+++ b/open_spiel/scripts/install.sh
@@ -258,7 +258,7 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
     sudo apt-get -y install $EXT_DEPS
   fi
   if [[ ${OPEN_SPIEL_BUILD_WITH_RUST:-"OFF"} == "ON" ]]; then
-    cargo add bindgen
+    cargo install bindgen-cli
   fi
 
   if [[ "$TRAVIS" ]]; then
@@ -286,7 +286,7 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then  # Mac OSX
   fi
   if [[ ${OPEN_SPIEL_BUILD_WITH_RUST:-"OFF"} == "ON" ]]; then
     [[ -x `which rustc` ]] || brew install rust || echo "** Warning: failed 'brew install rust' -- continuing"
-    cargo install bindgen
+    cargo install bindgen-cli
   fi
 
   curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py

--- a/open_spiel/scripts/install.sh
+++ b/open_spiel/scripts/install.sh
@@ -258,7 +258,9 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
     sudo apt-get -y install $EXT_DEPS
   fi
   if [[ ${OPEN_SPIEL_BUILD_WITH_RUST:-"OFF"} == "ON" ]]; then
-    cargo install bindgen-cli
+    if [[ ! -f $HOME/.cargo/bin/bindgen ]]; then
+      cargo install bindgen-cli
+    fi
   fi
 
   if [[ "$TRAVIS" ]]; then
@@ -286,7 +288,9 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then  # Mac OSX
   fi
   if [[ ${OPEN_SPIEL_BUILD_WITH_RUST:-"OFF"} == "ON" ]]; then
     [[ -x `which rustc` ]] || brew install rust || echo "** Warning: failed 'brew install rust' -- continuing"
-    cargo install bindgen-cli
+    if [[ ! -f $HOME/.cargo/bin/bindgen ]]; then
+      cargo install bindgen-cli
+    fi
   fi
 
   curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py

--- a/open_spiel/scripts/install.sh
+++ b/open_spiel/scripts/install.sh
@@ -258,7 +258,7 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
     sudo apt-get -y install $EXT_DEPS
   fi
   if [[ ${OPEN_SPIEL_BUILD_WITH_RUST:-"OFF"} == "ON" ]]; then
-    cargo install bindgen
+    cargo add bindgen
   fi
 
   if [[ "$TRAVIS" ]]; then


### PR DESCRIPTION
The github actions tests broke this morning: https://github.com/deepmind/open_spiel/actions/runs/3271752787.

```
++ cargo install bindgen
    Updating crates.io index
 Downloading crates ...
  Downloaded bindgen v0.61.0
error: there is nothing to install in `bindgen v0.61.0`, because it has no binaries
`cargo install` is only for installing programs, and can't be used with libraries.
To use a library crate, add it as a dependency in a Cargo project instead.
Error: Process completed with exit code 101.
```

This is an attempt to fix the problem.

From the bindgen user guide, the bindgen binary is available in `bindgen-cli`. But if you try to install it when it's already there, the install fails with:

```
++ cargo install bindgen-cli
    Updating crates.io index
 Downloading crates ...
  Downloaded bindgen-cli v0.61.0
error: binary `bindgen` already exists in destination as part of `bindgen v0.60.1`
Add --force to overwrite
Error: Process completed with exit code 101.
```