### PR TITLE
Fix random bug in alpha_zero_torch (pun intended)

### DIFF
--- a/open_spiel/algorithms/alpha_zero_torch/alpha_zero.cc
+++ b/open_spiel/algorithms/alpha_zero_torch/alpha_zero.cc
@@ -185,7 +185,7 @@ void actor(const open_spiel::Game& game, const AlphaZeroConfig& config, int num,
   } else {
     logger.reset(new NoopLogger());
   }
-  std::mt19937 rng;
+  std::mt19937 rng(absl::ToUnixNanos(absl::Now()));
   absl::uniform_real_distribution<double> dist(0.0, 1.0);
   std::vector<std::unique_ptr<MCTSBot>> bots;
   bots.reserve(2);

--- a/open_spiel/examples/alpha_zero_torch_game_example.cc
+++ b/open_spiel/examples/alpha_zero_torch_game_example.cc
@@ -72,7 +72,7 @@ InitBot(std::string type, const open_spiel::Game &game,
         absl::GetFlag(FLAGS_max_simulations),
         absl::GetFlag(FLAGS_max_memory_mb), absl::GetFlag(FLAGS_solve), Seed(),
         absl::GetFlag(FLAGS_verbose),
-        open_spiel::algorithms::ChildSelectionPolicy::UCT, 0, 0,
+        open_spiel::algorithms::ChildSelectionPolicy::PUCT, 0, 0,
         /*dont_return_chance_node=*/true);
   }
   if (type == "human") {


### PR DESCRIPTION
Without a seed, `std::mt19937` constructs with a default constant, and so all actors were using the same random sequence, generating duplicate trajectories.

Also tweaked the child selection policy to PUCT for the AZ bot in `alpha_zero_torch_game_example.cc`.