### PR TITLE
Update liar's dice to use `LegalChanceOutcomes()`

### DIFF
--- a/open_spiel/games/liars_dice.cc
+++ b/open_spiel/games/liars_dice.cc
@@ -239,11 +239,7 @@ std::vector<Action> LiarsDiceState::LegalActions() const {
   if (IsTerminal()) return {};
   // A chance node is a single die roll.
   if (IsChanceNode()) {
-    std::vector<Action> outcomes(dice_sides());
-    for (int i = 0; i < dice_sides(); i++) {
-      outcomes[i] = i;
-    }
-    return outcomes;
+    return LegalChanceOutcomes();
   }
 
   std::vector<Action> actions;


### PR DESCRIPTION
Updates liar's poker to use the best practice approach for returning legal chance outcomes from `LegalActions()`. Closes:https://github.com/deepmind/open_spiel/issues/992