### PR TITLE
fix broken link in docs/install.md

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -118,7 +118,7 @@ In a nutshell:
     ```
 
     Additionally, if you intend to use one of the
-    [optional Python dependencies](open_spiel/scripts/python_extra_deps.sh), you
+    [optional Python dependencies](/open_spiel/scripts/python_extra_deps.sh), you
     must manually install and/or upgrade them, e.g.: `bash pip install --upgrade
     torch==x.xx.x jax==x.x.x` where `x.xx.x` should be the desired version
     numbers (which can be found at the link above).


### PR DESCRIPTION
This relative link in the installation docs was broken (my bad!) because it was relative to the `docs/` directory. It should instead be relative to the root directory*. Tested on https://github.com/VitamintK/open_spiel/blob/fix-link/docs/install.md and verified that it works.

* more info on relative links: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes#relative-links-and-image-paths-in-readme-files