### PR TITLE
remove unused ILLEGAL_ACTION_LOGITS_PENALTY constants

### DIFF
--- a/open_spiel/python/algorithms/nfsp.py
+++ b/open_spiel/python/algorithms/nfsp.py
@@ -36,8 +36,6 @@ tf.disable_v2_behavior()
 Transition = collections.namedtuple(
     "Transition", "info_state action_probs legal_actions_mask")
 
-ILLEGAL_ACTION_LOGITS_PENALTY = -1e9
-
 MODE = enum.Enum("mode", "best_response average_policy")
 
 

--- a/open_spiel/python/jax/nfsp.py
+++ b/open_spiel/python/jax/nfsp.py
@@ -38,8 +38,6 @@ from open_spiel.python.utils.reservoir_buffer import ReservoirBuffer
 Transition = collections.namedtuple(
     "Transition", "info_state action_probs legal_actions_mask")
 
-ILLEGAL_ACTION_LOGITS_PENALTY = -1e9
-
 MODE = enum.Enum("mode", "best_response average_policy")
 
 

--- a/open_spiel/python/pytorch/nfsp.py
+++ b/open_spiel/python/pytorch/nfsp.py
@@ -35,8 +35,6 @@ from open_spiel.python.pytorch import dqn
 Transition = collections.namedtuple(
     "Transition", "info_state action_probs legal_actions_mask")
 
-ILLEGAL_ACTION_LOGITS_PENALTY = -1e9
-
 MODE = enum.Enum("mode", "best_response average_policy")
 
 


### PR DESCRIPTION
I noticed these `ILLEGAL_ACTION_LOGITS_PENALTY` constants aren't used anywhere at the moment, so here's a pull request to delete them.

(There are `ILLEGAL_ACTION_LOGITS_PENALTY` constants that *are* used, defined in https://github.com/deepmind/open_spiel/blob/master/open_spiel/python/algorithms/dqn.py and https://github.com/deepmind/open_spiel/blob/master/open_spiel/python/jax/dqn.py and https://github.com/deepmind/open_spiel/blob/master/open_spiel/python/pytorch/dqn.py )

