### PR TITLE
Fix recent issues in tests

### DIFF
--- a/open_spiel/julia/wrapper/spieljl.cc
+++ b/open_spiel/julia/wrapper/spieljl.cc
@@ -375,7 +375,7 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod) {
       .method("min_utility", &open_spiel::Game::MinUtility)
       .method("max_utility", &open_spiel::Game::MaxUtility)
       .method("get_type", &open_spiel::Game::GetType)
-      .method("utility_sum", &open_spiel::Game::UtilitySum)
+      .method("utility_sum", &open_spiel::Game::UtilitySumValue)
       .method("information_state_tensor_shape",
               &open_spiel::Game::InformationStateTensorShape)
       .method("information_state_tensor_size",

--- a/open_spiel/python/pybind11/pyspiel.cc
+++ b/open_spiel/python/pybind11/pyspiel.cc
@@ -55,6 +55,11 @@
 #include "open_spiel/spiel_utils.h"
 #include "open_spiel/tests/basic_tests.h"
 
+// Several function return absl::optional or lists of absl::optional, so must
+// use pybind11_abseil here.
+#include "pybind11/include/pybind11/detail/common.h"
+#include "pybind11_abseil/absl_casters.h"
+
 // List of optional python submodules.
 #if OPEN_SPIEL_BUILD_WITH_GAMUT
 #include "open_spiel/games/gamut/gamut_pybind11.h"

--- a/open_spiel/spiel.h
+++ b/open_spiel/spiel.h
@@ -15,6 +15,7 @@
 #ifndef OPEN_SPIEL_SPIEL_H_
 #define OPEN_SPIEL_SPIEL_H_
 
+#include <cmath>
 #include <functional>
 #include <iostream>
 #include <map>
@@ -808,6 +809,17 @@ class Game : public std::enable_shared_from_this<Game> {
   // The total utility for all players, if this is a constant-sum-utility game.
   // Should return 0 if the game is zero-sum.
   virtual absl::optional<double> UtilitySum() const { return absl::nullopt; }
+
+  // Helper methods when absl::optional is not available
+  virtual bool HasUtilitySum() const { return UtilitySum().has_value(); }
+  virtual double UtilitySumValue() const {
+    absl::optional<double> maybe_sum = UtilitySum();
+    if (!maybe_sum.has_value()) {
+      return std::nan("");
+    } else {
+      return *maybe_sum;
+    }
+  }
 
   // Describes the structure of the information state representation in a
   // tensor-like format. This is especially useful for experiments involving


### PR DESCRIPTION
- Add missing include to use abseil_pybind11 types (absl::optional) in pyspiel.cc
- Add methods Game::HasUtilitySum and Game::UtilitySumValue for APIs that do not support optional types
- Change Julia API (spieljl.cc) to use Game::UtilitySumValue instead of Game::UtilitySum

Fixes: #1014, #1016.