### PR TITLE
Add `/open_spiel/pybind11_abseil/` to `.gitignore`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ open_spiel/libnop/libnop/
 open_spiel/games/bridge/double_dummy_solver/
 open_spiel/games/universal_poker/double_dummy_solver/
 open_spiel/games/hanabi/hanabi-learning-environment/
+/open_spiel/pybind11_abseil/
 pybind11/
 
 # Install artifacts


### PR DESCRIPTION
When running `install.sh`, another git respository is cloned into `open_spiel/pybind11_abseil`. However, this path is not covered by `.gitignore`, when I believe it should be.

Note that, deviating from the style of the remainder of `.gitignore`, I added the path with a leading slash `/` to make sure it matches only this particular directory.

Admittedly, chances are low someone will want to create *another* directory in the repository that contains `open_spiel/pybind11_abseil` somewhere in the path, e.g., `foo/open_spiel/pybind11_abseil`. Not adding the leading slash would cause `.gitignore` to match that hypothetical `foo/open_spiel/pybind11_abseil` too, though, which may be unsedired.

I'm happy to adapt the rest of `.gitignore` and add leading slashes where appropriate, if you agree and would like me to.