### PR TITLE
correct issues about symmetric games in psro_v2

### DIFF
--- a/open_spiel/python/algorithms/psro_v2/abstract_meta_trainer.py
+++ b/open_spiel/python/algorithms/psro_v2/abstract_meta_trainer.py
@@ -196,7 +196,8 @@ class AbstractMetaTrainer(object):
   def update_meta_strategies(self):
     self._meta_strategy_probabilities = self._meta_strategy_method(self)
     if self.symmetric_game:
-      self._meta_strategy_probabilities = [self._meta_strategy_probabilities[0]]
+      self._meta_strategy_probabilities = [
+          self._meta_strategy_probabilities[0]]
 
   def update_agents(self):
     return NotImplementedError("update_agents not implemented.")
@@ -233,14 +234,15 @@ class AbstractMetaTrainer(object):
   def get_meta_game(self):
     """Returns the meta game matrix."""
     meta_games = self._meta_games
-    if self.symmetric_game:
-      meta_games = self._game_num_players * meta_games
     return [np.copy(a) for a in meta_games]
 
   def get_policies(self):
     """Returns the players' policies."""
     policies = self._policies
     if self.symmetric_game:
+      # Notice that the following line returns N references to the same policy
+      # This might not be correct for certain applications.
+      # E.g., a DQN BR oracle with player_id information
       policies = self._game_num_players * policies
     return policies
 

--- a/open_spiel/python/algorithms/psro_v2/psro_v2.py
+++ b/open_spiel/python/algorithms/psro_v2/psro_v2.py
@@ -170,10 +170,18 @@ class PSROSolver(abstract_meta_trainer.AbstractMetaTrainer):
         **kwargs)
 
   def _initialize_policy(self, initial_policies):
-    self._policies = [[] for k in range(self._num_players)]
-    self._new_policies = [([initial_policies[k]] if initial_policies else
-                           [policy.UniformRandomPolicy(self._game)])
-                          for k in range(self._num_players)]
+    if self.symmetric_game:
+      self._policies = [[]]
+      # Notice that the following line returns N references to the same policy
+      # This might not be correct for certain applications.
+      # E.g., a DQN BR oracle with player_id information
+      self._new_policies = [([initial_policies[0]] if initial_policies else
+                            [policy.UniformRandomPolicy(self._game)])]
+    else:
+      self._policies = [[] for _ in range(self._num_players)]
+      self._new_policies = [([initial_policies[k]] if initial_policies else
+                            [policy.UniformRandomPolicy(self._game)])
+                            for k in range(self._num_players)]
 
   def _initialize_game_state(self):
     effective_payoff_size = self._game_num_players
@@ -211,6 +219,9 @@ class PSROSolver(abstract_meta_trainer.AbstractMetaTrainer):
     meta-probabilities.
     """
     if self.symmetric_game:
+      # Notice that the following line returns N references to the same policy
+      # This might not be correct for certain applications.
+      # E.g., a DQN BR oracle with player_id information
       self._policies = self._policies * self._game_num_players
 
     self._meta_strategy_probabilities, self._non_marginalized_probabilities = (
@@ -218,7 +229,8 @@ class PSROSolver(abstract_meta_trainer.AbstractMetaTrainer):
 
     if self.symmetric_game:
       self._policies = [self._policies[0]]
-      self._meta_strategy_probabilities = [self._meta_strategy_probabilities[0]]
+      self._meta_strategy_probabilities = [
+          self._meta_strategy_probabilities[0]]
 
   def get_policies_and_strategies(self):
     """Returns current policy sampler, policies and meta-strategies of the game.
@@ -330,6 +342,9 @@ class PSROSolver(abstract_meta_trainer.AbstractMetaTrainer):
         training_parameters[current_player].append(new_parameter)
 
     if self.symmetric_game:
+      # Notice that the following line returns N references to the same policy
+      # This might not be correct for certain applications.
+      # E.g., a DQN BR oracle with player_id information
       self._policies = self._game_num_players * self._policies
       self._num_players = self._game_num_players
       training_parameters = [training_parameters[0]]
@@ -366,6 +381,9 @@ class PSROSolver(abstract_meta_trainer.AbstractMetaTrainer):
       # Switch to considering the game as a symmetric game where players have
       # the same policies & new policies. This allows the empirical gamestate
       # update to function normally.
+      # Notice that the following line returns N references to the same policy
+      # This might not be correct for certain applications.
+      # E.g., a DQN BR oracle with player_id information
       self._policies = self._game_num_players * self._policies
       self._new_policies = self._game_num_players * self._new_policies
       self._num_players = self._game_num_players
@@ -428,6 +446,7 @@ class PSROSolver(abstract_meta_trainer.AbstractMetaTrainer):
             # TODO(author4): This update uses ~2**(n_players-1) * sims_per_entry
             # samples to estimate each payoff table entry. This should be
             # brought to sims_per_entry to coincide with expected behavior.
+
             utility_estimates = self.sample_episodes(estimated_policies,
                                                      self._sims_per_entry)
 
@@ -471,6 +490,9 @@ class PSROSolver(abstract_meta_trainer.AbstractMetaTrainer):
     policies = self._policies
     if self.symmetric_game:
       # For compatibility reasons, return list of expected length.
+      # Notice that the following line returns N references to the same policy
+      # This might not be correct for certain applications.
+      # E.g., a DQN BR oracle with player_id information
       policies = self._game_num_players * self._policies
     return policies
 


### PR DESCRIPTION
Hi, I think there are a few issues in the current psro_v2 with the symmetric game option so I submit a PR. They are:

(1) for `get_metagame()`. The original one returns `self._game_num_players * self._meta_games`. This is incorrect because `self._meta_games` is always a list of N [|S1|, |S2|,...,|SN|] tensors where each tensor contains the payoff values of a player. |Sn| is the number of strategies of player n. `self._game_num_players * meta_games `will result to N references of the same N tensors which are N^2 tensors. 

My guess is that originally it was thought that `self._meta_games` only contains the tensor of player 0. But I don't see anywhere in psro_v2 handling metagame for symmetric game specifically. And even if it is the case this is still incorrect. Because `get_metagame()` gives payoff tensors for each player, so `get_metagame()[0]` and `get_metagame()[1]` are still different despite that they obey some degree of symmetry.

(2) `_initialize_policy`. In psro_v2, when `symmetric_game=True`, `self._policies, self._new_policies` will represent a single population strategy set when they aren't getting updated. But in `_initialize_policy` it does not have a special handler for this case and initializes the policy sets as an N-player policy list.

(3) Also in multiple places when it switches between one-population strategy set representation and N-player strategy set representation it does something like `self._policies = self._game_num_players * self._policies`. This approach assumes it is safe to use N references of the same policy set object for other computational purposes. However this might not be always be safe. For example if we use `open_spiel.python.jax.dqn` as an oracle, then it will contain player_id information. And `self._policies = self._game_num_players * self._policies` may contain N DQN all with `player_id=0`, which could lead to bug. This part needs some ad-hoc treatment, including how you build the oracle object so I put some comments at anywhere it appears.