### PR TITLE
add simultaneous node support in policy_aggregator.py and exploitability.py

### DIFF
--- a/open_spiel/python/algorithms/exploitability.py
+++ b/open_spiel/python/algorithms/exploitability.py
@@ -39,6 +39,7 @@ import collections
 import numpy as np
 
 from open_spiel.python.algorithms import best_response as pyspiel_best_response
+from open_spiel.python import policy as policy_lib
 import pyspiel
 
 
@@ -47,10 +48,15 @@ def _state_values(state, num_players, policy):
   if state.is_terminal():
     return np.array(state.returns())
   else:
-    p_action = (
-        state.chance_outcomes() if state.is_chance_node() else
-        policy.action_probabilities(state).items())
-    return sum(prob * _state_values(state.child(action), num_players, policy)
+    if state.is_simultaneous_node():
+      p_action = tuple(
+          policy_lib.joint_action_probabilities(state, policy))
+
+    else:
+      p_action = (
+          state.chance_outcomes() if state.is_chance_node() else
+          policy.action_probabilities(state).items())
+    return sum(prob * _state_values(policy_lib.child(state, action), num_players, policy)
                for action, prob in p_action)
 
 

--- a/open_spiel/python/algorithms/policy_aggregator.py
+++ b/open_spiel/python/algorithms/policy_aggregator.py
@@ -190,10 +190,7 @@ class PolicyAggregator(object):
       policies = self._policy_pool(state, pid)
       state_key = self._state_key(state, pid)
       self._policy[state_key] = {}
-      used_moves = []
-      for k in range(len(policies)):
-        used_moves += [a[0] for a in policies[k].items()]
-      used_moves = np.unique(used_moves)
+      used_moves = state.legal_actions(pid)
 
 
       for uid in used_moves:
@@ -252,10 +249,7 @@ class PolicyAggregator(object):
         if state_key not in self._policy:
           self._policy[state_key] = {}
 
-      used_moves = []
-      for k in range(len(legal_policies)):
-        used_moves += [a[0] for a in legal_policies[k].items()]
-      used_moves = np.unique(used_moves)
+      used_moves = state.legal_actions(turn_player)
 
       for uid in used_moves:
         new_reaches = copy.deepcopy(my_reaches)

--- a/open_spiel/python/algorithms/policy_aggregator.py
+++ b/open_spiel/python/algorithms/policy_aggregator.py
@@ -186,6 +186,7 @@ class PolicyAggregator(object):
     if state.is_terminal():
       return
     elif state.is_simultaneous_node():
+      
 
       policies = self._policy_pool(state, pid)
       state_key = self._state_key(state, pid)
@@ -221,9 +222,8 @@ class PolicyAggregator(object):
           for i in range(len(policies)):
             # compute the new reach for each policy for this action
             new_reaches[pid][i] *= policies[i].get(uid, 0)
-            # add reach * prob(a) for this policy to the computed policy
           
-          joint_action = list(other_joint_action[:pid] + (uid,)+other_joint_action[pid:])
+          joint_action = list(other_joint_action[:pid] + (uid,) + other_joint_action[pid:])
           new_state = state.clone()
           new_state.apply_actions(joint_action)
           self._rec_aggregate(pid, new_state, new_reaches)

--- a/open_spiel/python/algorithms/policy_aggregator.py
+++ b/open_spiel/python/algorithms/policy_aggregator.py
@@ -21,6 +21,7 @@ policy by sweeping over the state space.
 import copy
 import numpy as np
 from open_spiel.python import policy
+import itertools
 import pyspiel
 
 
@@ -74,12 +75,9 @@ class PolicyFunction(policy.Policy):
     """
     state_key = self._state_key(state, player_id=player_id)
     if state.is_simultaneous_node():
-      # Policy aggregator doesn't yet support simultaneous moves nodes.
-      # The below lines are one step towards that direction.
-      result = []
-      for player_pol in self._policies:
-        result.append(player_pol[state_key])
-      return result
+      # for simultaneous node, assume player id must be provided
+      assert player_id >= 0
+      return self._policies[player_id][state_key]
     if player_id is None:
       player_id = state.current_player()
     return self._policies[player_id][state_key]
@@ -188,29 +186,52 @@ class PolicyAggregator(object):
     if state.is_terminal():
       return
     elif state.is_simultaneous_node():
-      # TODO(author10): this is assuming that if there is a sim.-move state, it is
-      #               the only state, i.e., the game is a normal-form game
-      def assert_type(cond, msg):
-        assert cond, msg
-      assert_type(self._game_type.dynamics ==
-                  pyspiel.GameType.Dynamics.SIMULTANEOUS,
-                  "Game must be simultaneous-move")
-      assert_type(self._game_type.chance_mode ==
-                  pyspiel.GameType.ChanceMode.DETERMINISTIC,
-                  "Chance nodes not supported")
-      assert_type(self._game_type.information ==
-                  pyspiel.GameType.Information.ONE_SHOT,
-                  "Only one-shot NFGs supported")
+
       policies = self._policy_pool(state, pid)
       state_key = self._state_key(state, pid)
       self._policy[state_key] = {}
-      for player_policy, weight in zip(policies, my_reaches[pid]):
-        for action in player_policy.keys():
-          if action in self._policy[state_key]:
-            self._policy[state_key][action] += weight * player_policy[action]
+      used_moves = []
+      for k in range(len(policies)):
+        used_moves += [a[0] for a in policies[k].items()]
+      used_moves = np.unique(used_moves)
+
+
+      for uid in used_moves:
+        new_reaches = copy.deepcopy(my_reaches)
+        for i in range(len(policies)):
+          # compute the new reach for each policy for this action
+          new_reaches[pid][i] *= policies[i].get(uid, 0)
+          # add reach * prob(a) for this policy to the computed policy
+          if uid in self._policy[state_key].keys():
+            self._policy[state_key][uid] += new_reaches[pid][i]
           else:
-            self._policy[state_key][action] = weight * player_policy[action]
+            self._policy[state_key][uid] = new_reaches[pid][i]
+
+
+      num_players = self._game.num_players()
+      all_other_used_moves = []
+      for player in range(num_players):
+        if player != pid:
+          all_other_used_moves.append(state.legal_actions(player))
+        
+
+      other_joint_actions = itertools.product(*all_other_used_moves)
+
+      # enumerate every possible other-agent actions for next-state
+      for other_joint_action in other_joint_actions:
+        for uid in used_moves:
+          new_reaches = copy.deepcopy(my_reaches)
+          for i in range(len(policies)):
+            # compute the new reach for each policy for this action
+            new_reaches[pid][i] *= policies[i].get(uid, 0)
+            # add reach * prob(a) for this policy to the computed policy
+          
+          joint_action = list(other_joint_action[:pid] + (uid,)+other_joint_action[pid:])
+          new_state = state.clone()
+          new_state.apply_actions(joint_action)
+          self._rec_aggregate(pid, new_state, new_reaches)
       return
+
     elif state.is_chance_node():
       # do not factor in opponent reaches
       outcomes, _ = zip(*state.chance_outcomes())
@@ -228,7 +249,7 @@ class PolicyAggregator(object):
       if pid == turn_player:
         # update the current node
         # will need the observation to query the policies
-        if state not in self._policy:
+        if state_key not in self._policy:
           self._policy[state_key] = {}
 
       used_moves = []

--- a/open_spiel/python/algorithms/policy_aggregator_joint.py
+++ b/open_spiel/python/algorithms/policy_aggregator_joint.py
@@ -213,7 +213,6 @@ class JointPolicyAggregator(object):
           for i in range(len(policies)):
             # compute the new reach for each policy for this action
             new_reaches[i] *= policies[i].get(uid, 0)
-            # add reach * prob(a) for this policy to the computed policy
           
           joint_action = list(other_joint_action[:pid] + (uid,)+other_joint_action[pid:])
           new_state = state.clone()

--- a/open_spiel/python/algorithms/policy_aggregator_joint.py
+++ b/open_spiel/python/algorithms/policy_aggregator_joint.py
@@ -238,7 +238,7 @@ class JointPolicyAggregator(object):
     if pid == current_player:
       # update the current node
       # will need the observation to query the policies
-      if state not in self._policy:
+      if state_key not in self._policy:
         self._policy[state_key] = {}
 
     for action in state.legal_actions():

--- a/open_spiel/python/algorithms/policy_aggregator_joint.py
+++ b/open_spiel/python/algorithms/policy_aggregator_joint.py
@@ -178,12 +178,7 @@ class JointPolicyAggregator(object):
       return
 
     if state.is_simultaneous_node():
-      # assert (self._game_type.dynamics == pyspiel.GameType.Dynamics.SIMULTANEOUS
-      #        ), "Game must be simultaneous-move"
-      # assert (self._game_type.chance_mode == pyspiel.GameType.ChanceMode
-      #         .DETERMINISTIC), "Chance nodes not supported"
-      # assert (self._game_type.information == pyspiel.GameType.Information
-      #         .ONE_SHOT), "Only one-shot NFGs supported"
+
       policies = _aggregate_at_state(self._joint_policies, state, pid)
       state_key = self._state_key(state, pid)
 
@@ -230,17 +225,6 @@ class JointPolicyAggregator(object):
           self._rec_aggregate(pid, new_state, new_reaches)
       return
 
-
-
-      # for player_policies, weight in zip(policies, my_reaches):
-      #   player_policy = player_policies[pid]
-      #   for action in player_policy.keys():
-      #     if action in self._policy[state_key]:
-      #       self._policy[state_key][action] += weight * player_policy[action]
-      #     else:
-      #       self._policy[state_key][action] = weight * player_policy[action]
-      # # No recursion because we only support one shot simultaneous games.
-      # return
 
     if state.is_chance_node():
       for action in state.legal_actions():

--- a/open_spiel/python/algorithms/policy_aggregator_joint.py
+++ b/open_spiel/python/algorithms/policy_aggregator_joint.py
@@ -22,8 +22,8 @@ policy.
 import copy
 from open_spiel.python import policy
 import pyspiel
-import itertools
 import numpy as np
+import itertools
 
 
 def _aggregate_at_state(joint_policies, state, player):
@@ -178,7 +178,6 @@ class JointPolicyAggregator(object):
       return
 
     if state.is_simultaneous_node():
-
       policies = _aggregate_at_state(self._joint_policies, state, pid)
       state_key = self._state_key(state, pid)
 
@@ -225,7 +224,6 @@ class JointPolicyAggregator(object):
           self._rec_aggregate(pid, new_state, new_reaches)
       return
 
-
     if state.is_chance_node():
       for action in state.legal_actions():
         new_state = state.child(action)
@@ -240,7 +238,7 @@ class JointPolicyAggregator(object):
     if pid == current_player:
       # update the current node
       # will need the observation to query the policies
-      if state_key not in self._policy:
+      if state not in self._policy:
         self._policy[state_key] = {}
 
     for action in state.legal_actions():

--- a/open_spiel/python/algorithms/policy_aggregator_joint.py
+++ b/open_spiel/python/algorithms/policy_aggregator_joint.py
@@ -182,10 +182,7 @@ class JointPolicyAggregator(object):
       state_key = self._state_key(state, pid)
 
       self._policy[state_key] = {}
-      used_moves = []
-      for k in range(len(policies)):
-        used_moves += [a[0] for a in policies[k].items()]
-      used_moves = np.unique(used_moves)
+      used_moves = state.legal_actions(pid)
 
 
       for uid in used_moves:

--- a/open_spiel/python/algorithms/policy_aggregator_joint.py
+++ b/open_spiel/python/algorithms/policy_aggregator_joint.py
@@ -22,6 +22,8 @@ policy.
 import copy
 from open_spiel.python import policy
 import pyspiel
+import itertools
+import numpy as np
 
 
 def _aggregate_at_state(joint_policies, state, player):
@@ -176,26 +178,69 @@ class JointPolicyAggregator(object):
       return
 
     if state.is_simultaneous_node():
-      assert (self._game_type.dynamics == pyspiel.GameType.Dynamics.SIMULTANEOUS
-             ), "Game must be simultaneous-move"
-      assert (self._game_type.chance_mode == pyspiel.GameType.ChanceMode
-              .DETERMINISTIC), "Chance nodes not supported"
-      assert (self._game_type.information == pyspiel.GameType.Information
-              .ONE_SHOT), "Only one-shot NFGs supported"
+      # assert (self._game_type.dynamics == pyspiel.GameType.Dynamics.SIMULTANEOUS
+      #        ), "Game must be simultaneous-move"
+      # assert (self._game_type.chance_mode == pyspiel.GameType.ChanceMode
+      #         .DETERMINISTIC), "Chance nodes not supported"
+      # assert (self._game_type.information == pyspiel.GameType.Information
+      #         .ONE_SHOT), "Only one-shot NFGs supported"
       policies = _aggregate_at_state(self._joint_policies, state, pid)
       state_key = self._state_key(state, pid)
 
       self._policy[state_key] = {}
+      used_moves = []
+      for k in range(len(policies)):
+        used_moves += [a[0] for a in policies[k].items()]
+      used_moves = np.unique(used_moves)
 
-      for player_policies, weight in zip(policies, my_reaches):
-        player_policy = player_policies[pid]
-        for action in player_policy.keys():
-          if action in self._policy[state_key]:
-            self._policy[state_key][action] += weight * player_policy[action]
+
+      for uid in used_moves:
+        new_reaches = copy.deepcopy(my_reaches)
+        for i in range(len(policies)):
+          # compute the new reach for each policy for this action
+          new_reaches[i] *= policies[i].get(uid, 0)
+          # add reach * prob(a) for this policy to the computed policy
+          if uid in self._policy[state_key].keys():
+            self._policy[state_key][uid] += new_reaches[i]
           else:
-            self._policy[state_key][action] = weight * player_policy[action]
-      # No recursion because we only support one shot simultaneous games.
+            self._policy[state_key][uid] = new_reaches[i]
+
+
+      num_players = self._game.num_players()
+      all_other_used_moves = []
+      for player in range(num_players):
+        if player != pid:
+          all_other_used_moves.append(state.legal_actions(player))
+        
+
+      other_joint_actions = itertools.product(*all_other_used_moves)
+
+      # enumerate every possible other-agent actions for next-state
+      for other_joint_action in other_joint_actions:
+        for uid in used_moves:
+          new_reaches = copy.deepcopy(my_reaches)
+          for i in range(len(policies)):
+            # compute the new reach for each policy for this action
+            new_reaches[i] *= policies[i].get(uid, 0)
+            # add reach * prob(a) for this policy to the computed policy
+          
+          joint_action = list(other_joint_action[:pid] + (uid,)+other_joint_action[pid:])
+          new_state = state.clone()
+          new_state.apply_actions(joint_action)
+          self._rec_aggregate(pid, new_state, new_reaches)
       return
+
+
+
+      # for player_policies, weight in zip(policies, my_reaches):
+      #   player_policy = player_policies[pid]
+      #   for action in player_policy.keys():
+      #     if action in self._policy[state_key]:
+      #       self._policy[state_key][action] += weight * player_policy[action]
+      #     else:
+      #       self._policy[state_key][action] = weight * player_policy[action]
+      # # No recursion because we only support one shot simultaneous games.
+      # return
 
     if state.is_chance_node():
       for action in state.legal_actions():
@@ -211,7 +256,7 @@ class JointPolicyAggregator(object):
     if pid == current_player:
       # update the current node
       # will need the observation to query the policies
-      if state not in self._policy:
+      if state_key not in self._policy:
         self._policy[state_key] = {}
 
     for action in state.legal_actions():

--- a/open_spiel/python/algorithms/policy_aggregator_joint_test.py
+++ b/open_spiel/python/algorithms/policy_aggregator_joint_test.py
@@ -56,7 +56,7 @@ class JointPolicyAggregatorTest(parameterized.TestCase):
         probs = list(state_action_probs.values())
         expected_prob = 1. / len(probs)
         for prob in probs:
-          self.assertAlmostEqual(expected_prob, prob, place=10)
+          self.assertAlmostEqual(expected_prob, prob, places=10)
 
 
 if __name__ == "__main__":

--- a/open_spiel/python/algorithms/policy_aggregator_joint_test.py
+++ b/open_spiel/python/algorithms/policy_aggregator_joint_test.py
@@ -56,7 +56,7 @@ class JointPolicyAggregatorTest(parameterized.TestCase):
         probs = list(state_action_probs.values())
         expected_prob = 1. / len(probs)
         for prob in probs:
-          self.assertEqual(expected_prob, prob)
+          self.assertAlmostEqual(expected_prob, prob, place=10)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi, I found several algorithms like the ones in policy_aggregator.py and exploitability.py didn't handle cases for simultaneous nodes. So this PR is to address this issue.