### PR TITLE
pybind11 for win32

### DIFF
--- a/open_spiel/python/pybind11/bots.cc
+++ b/open_spiel/python/pybind11/bots.cc
@@ -289,9 +289,11 @@ void init_pyspiel_bots(py::module& m) {
       },
       "A bot that samples from a policy.");
 
+#ifndef _WIN32
   m.def("make_uci_bot", open_spiel::uci::MakeUCIBot, py::arg("bot_binary_path"),
       py::arg("move_time"), py::arg("ponder"), py::arg("options"),
       "Bot that can play chess using UCI chess engine.");
+#endif 
 
 
 #if OPEN_SPIEL_BUILD_WITH_ROSHAMBO


### PR DESCRIPTION
UCI bot is not supported in Windows. But the python bindings are still trying to include it.