### PR TITLE
Allow for environment variables to not be set in `noxfile.py`.

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -32,13 +32,13 @@ def tests(session):
   session.install("-r", "requirements.txt")
   child_env = os.environ.copy()
   child_env["OPEN_SPIEL_BUILD_ALL"] = "ON"
-  if child_env["OPEN_SPIEL_ENABLE_JAX"] == "ON":
+  if child_env.get("OPEN_SPIEL_ENABLE_JAX") == "ON":
     session.install(*child_env["OPEN_SPIEL_PYTHON_JAX_DEPS"].split())
-  if child_env["OPEN_SPIEL_ENABLE_PYTORCH"] == "ON":
+  if child_env.get("OPEN_SPIEL_ENABLE_PYTORCH") == "ON":
     session.install(*child_env["OPEN_SPIEL_PYTHON_PYTORCH_DEPS"].split())
-  if child_env["OPEN_SPIEL_ENABLE_TENSORFLOW"] == "ON":
+  if child_env.get("OPEN_SPIEL_ENABLE_TENSORFLOW") == "ON":
     session.install(*child_env["OPEN_SPIEL_PYTHON_TENSORFLOW_DEPS"].split())
-  if child_env["OPEN_SPIEL_ENABLE_PYTHON_MISC"] == "ON":
+  if child_env.get("OPEN_SPIEL_ENABLE_PYTHON_MISC") == "ON":
     session.install(*child_env["OPEN_SPIEL_PYTHON_MISC_DEPS"].split())
   session.run("python3", "setup.py", "build", env=child_env)
   session.run("python3", "setup.py", "install", env=child_env)


### PR DESCRIPTION
`noxfile.py` used to assume that the following environment variables are set (either to `"ON"`, or some other value such as, presumably, `"OFF"`):

- OPEN_SPIEL_ENABLE_JAX
- OPEN_SPIEL_ENABLE_PYTORCH
- OPEN_SPIEL_ENABLE_TENSORFLOW
- OPEN_SPIEL_ENABLE_PYTHON_MISC

If this was not the case, i.e. the values were not set at all, an error would be produced.

This PR avoids the error, and treats environment variables that are not set as it would non-`"ON"` values.

If indeed the only allowed values are `"ON"` and `"OFF"`, I'd be happy to add code that checks for this and produces diagnostic messages if an unexpected value is encountered. Otherwise, users may set the `OPEN_SPIEL_ENABLE_JAX` variable to, say, `"on"`, and be surprised because their intent is silently ignored and likely to cause issues down the road.