### PR TITLE
Upgrade versions of actions triggers from Node.js 12 deprecation warnings

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -82,7 +82,7 @@ jobs:
       OPEN_SPIEL_BUILD_WITH_ORTOOLS_DOWNLOAD_URL:  ${{ matrix.OPEN_SPIEL_BUILD_WITH_ORTOOLS_DOWNLOAD_URL }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: julia-actions/setup-julia@v1
       with:
         version: 1.8

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -55,7 +55,7 @@ jobs:
       CIBW_ENVIRONMENT: ${{ matrix.CIBW_ENVIRONMENT }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install
         run: |
@@ -99,7 +99,7 @@ jobs:
       - name: Install bdist_wheel and full tests
         run: ./open_spiel/scripts/test_wheel.sh full `pwd` ${CI_PYBIN}
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: |
             dist/*.tar.gz


### PR DESCRIPTION
When building the wheels for the new release, Github Actions gave the following warnings:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

Following the advice on [this link](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions), this PR updates the versions of `actions/checkout` and `actions/upload-artifact`.