### PR TITLE
Ensure at least one parallel job in build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,10 @@ class BuildExt(build_ext):
         env=env)
 
     # Build only pyspiel (for pip package)
-    subprocess.check_call(["make", "pyspiel", f"-j{os.cpu_count()}"],
+    detected_jobs = os.cpu_count()
+    jobs = max(detected_jobs or 1, 1)
+    print(f"Building pyspiel with {jobs} parallel job(s)")
+    subprocess.check_call(["make", "pyspiel", f"-j{jobs}"],
                           cwd=self.build_temp,
                           env=env)
 


### PR DESCRIPTION
Replaces os.cpu_count() with a safe minimum of 1 when determining the number of parallel build jobs, and adds a log message showing how many jobs are used. This prevents build failures on platforms where os.cpu_count() returns None or 0, which would otherwise produce an invalid make -jNone flag and abort the build.