### PR TITLE
Fix incorrect policy indexing in PSRO update_agents

### DIFF
--- a/open_spiel/python/algorithms/psro_v2/psro_v2.py
+++ b/open_spiel/python/algorithms/psro_v2/psro_v2.py
@@ -324,14 +324,8 @@ class PSROSolver(abstract_meta_trainer.AbstractMetaTrainer):
     training_parameters = [[] for _ in range(self._num_players)]
 
     for current_player in range(self._num_players):
-      if self.sample_from_marginals:
-        currently_used_policies = used_policies[current_player]
-        current_indexes = used_indexes[current_player]
-      else:
-        currently_used_policies = [
-            joint_policy[current_player] for joint_policy in used_policies
-        ]
-        current_indexes = used_indexes[current_player]
+      currently_used_policies = used_policies[current_player]
+      current_indexes = used_indexes[current_player]
 
       for i in range(len(currently_used_policies)):
         pol = currently_used_policies[i]


### PR DESCRIPTION
Remove buggy if/else conditional that incorrectly built currently_used_policies as a joint policy list comprehension. The code now correctly indexes used_policies[current_player] directly, which works for all cases since used_policies is already structured as a list per player.