### PR TITLE
Implement the dice game Yacht

### DIFF
--- a/open_spiel/games/yacht/yacht.cc
+++ b/open_spiel/games/yacht/yacht.cc
@@ -215,7 +215,10 @@ Player YachtState::CurrentPlayer() const {
 // Helper to check if dice form a straight
 bool YachtState::IsStraight(const std::vector<int>& dice,
   int bottom, int top) const {
-  std::vector<bool> present(dice_sides_, false);
+  if (top > dice_sides_) {
+    return false;
+  }
+  std::vector<bool> present(dice_sides_ + 1, false);
   for (int die : dice) {
     present[die] = true;
   }


### PR DESCRIPTION
## Description
Implements Yacht (dice game similar to Yahtzee) for OpenSpiel.

Addresses #843 (Yacht from the list of requested games)

## Implementation Details
- Supports 1-10 players


## Testing
- All existing tests pass
- Added yacht_test.cc with coverage of game mechanics
- Verified with cpplint and build_and_run_tests.sh