### PR TITLE
refactor(algorithms): add type hints to cfr.py

### DIFF
--- a/open_spiel/python/algorithms/cfr.py
+++ b/open_spiel/python/algorithms/cfr.py
@@ -22,6 +22,8 @@ One iteration of CFR consists of:
 The average policy is what converges to a Nash Equilibrium.
 """
 
+from typing import Any, Callable, Dict, List, Optional, Union
+
 import collections
 import attr
 import numpy as np
@@ -34,17 +36,17 @@ import pyspiel
 class _InfoStateNode(object):
   """An object wrapping values associated to an information state."""
   # The list of the legal actions.
-  legal_actions = attr.ib()
-  index_in_tabular_policy = attr.ib()
+  legal_actions: List[int] = attr.ib()
+  index_in_tabular_policy: int = attr.ib()
   # Map from information states string representations and actions to the
   # counterfactual regrets, accumulated over the policy iterations
-  cumulative_regret = attr.ib(factory=lambda: collections.defaultdict(float))
+  cumulative_regret: Dict[int, float] = attr.ib(factory=lambda: collections.defaultdict(float))
   # Same as above for the cumulative of the policy probabilities computed
   # during the policy iterations
-  cumulative_policy = attr.ib(factory=lambda: collections.defaultdict(float))
+  cumulative_policy: Dict[int, float] = attr.ib(factory=lambda: collections.defaultdict(float))
 
 
-def _apply_regret_matching_plus_reset(info_state_nodes):
+def _apply_regret_matching_plus_reset(info_state_nodes: Dict[str, _InfoStateNode]):
   """Resets negative cumulative regrets to 0.
 
   Regret Matching+ corresponds to the following cumulative regrets update:
@@ -67,7 +69,8 @@ def _apply_regret_matching_plus_reset(info_state_nodes):
         action_to_cum_regret[action] = 0
 
 
-def _update_current_policy(current_policy, info_state_nodes):
+def _update_current_policy(current_policy: policy.TabularPolicy,
+                           info_state_nodes: Dict[str, _InfoStateNode]):
   """Updates in place `current_policy` from the cumulative regrets.
 
   This function is a module level function to be reused by both CFRSolver and
@@ -86,7 +89,8 @@ def _update_current_policy(current_policy, info_state_nodes):
       state_policy[action] = value
 
 
-def _update_average_policy(average_policy, info_state_nodes):
+def _update_average_policy(average_policy: policy.TabularPolicy,
+                           info_state_nodes: Dict[str, _InfoStateNode]):
   """Updates in place `average_policy` to the average of all policies iterated.
 
   This function is a module level function to be reused by both CFRSolver and
@@ -127,8 +131,8 @@ class _CFRSolverBase(object):
   ```
   """
 
-  def __init__(self, game, alternating_updates, linear_averaging,
-               regret_matching_plus):
+  def __init__(self, game: pyspiel.Game, alternating_updates: bool,
+               linear_averaging: bool, regret_matching_plus: bool):
     # pyformat: disable
     """Initializer.
 
@@ -165,7 +169,7 @@ class _CFRSolverBase(object):
     self._current_policy = policy.TabularPolicy(game)
     self._average_policy = self._current_policy.__copy__()
 
-    self._info_state_nodes = {}
+    self._info_state_nodes: Dict[str, _InfoStateNode] = {}
     self._initialize_info_state_nodes(self._root_node)
 
     self._iteration = 0  # For possible linear-averaging.
@@ -173,7 +177,7 @@ class _CFRSolverBase(object):
     self._alternating_updates = alternating_updates
     self._regret_matching_plus = regret_matching_plus
 
-  def _initialize_info_state_nodes(self, state):
+  def _initialize_info_state_nodes(self, state: pyspiel.State):
     """Initializes info_state_nodes.
 
     Create one _InfoStateNode per infoset. We could also initialize the node
@@ -205,7 +209,7 @@ class _CFRSolverBase(object):
     for action in info_state_node.legal_actions:
       self._initialize_info_state_nodes(state.child(action))
 
-  def current_policy(self):
+  def current_policy(self) -> policy.TabularPolicy:
     """Returns the current policy as a TabularPolicy.
 
     WARNING: The same object, updated in-place will be returned! You can copy
@@ -216,7 +220,7 @@ class _CFRSolverBase(object):
     """
     return self._current_policy
 
-  def average_policy(self):
+  def average_policy(self) -> policy.TabularPolicy:
     """Returns the average of all policies iterated.
 
     WARNING: The same object, updated in-place will be returned! You can copy
@@ -236,8 +240,10 @@ class _CFRSolverBase(object):
     _update_average_policy(self._average_policy, self._info_state_nodes)
     return self._average_policy
 
-  def _compute_counterfactual_regret_for_player(self, state, policies,
-                                                reach_probabilities, player):
+  def _compute_counterfactual_regret_for_player(self, state: pyspiel.State,
+                                                policies: Optional[List[Callable[[str], Dict[int, float]]]],
+                                                reach_probabilities: np.ndarray,
+                                                player: Optional[int]):
     """Increments the cumulative regrets and policy for `player`.
 
     Args:
@@ -338,7 +344,7 @@ class _CFRSolverBase(object):
 
     return state_value
 
-  def _get_infostate_policy(self, info_state_str):
+  def _get_infostate_policy(self, info_state_str: str) -> Dict[int, float]:
     """Returns an {action: prob} dictionary for the policy on `info_state`."""
     info_state_node = self._info_state_nodes[info_state_str]
     prob_vec = self._current_policy.action_probability_array[
@@ -348,7 +354,8 @@ class _CFRSolverBase(object):
     }
 
 
-def _regret_matching(cumulative_regrets, legal_actions):
+def _regret_matching(cumulative_regrets: Dict[int, float],
+                     legal_actions: List[int]) -> Dict[int, float]:
   """Returns an info state policy by applying regret-matching.
 
   Args:


### PR DESCRIPTION
refactor(algorithms): add type hints to cfr.py

Added type hints to the `CFRSolver`, `_CFRSolverBase` classes and helper functions.
Cleaned up imports and improved docstrings.
Verified by running `cfr_test.py`.