### PR TITLE
Add Hugging Face Gemma fine-tuning Colab aligned with Kauldron example

### DIFF
--- a/open_spiel/colabs/open_spiel_hf_llm.ipynb
+++ b/open_spiel/colabs/open_spiel_hf_llm.ipynb
@@ -1,0 +1,2360 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "gpuType": "T4"
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "accelerator": "GPU",
+    "widgets": {
+      "application/vnd.jupyter.widget-state+json": {
+        "13b603301def44529a99abedacbcd4db": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_95485ddd849d40b9b1418799b6f6214f",
+              "IPY_MODEL_becbb781afe049e9880002285e940430",
+              "IPY_MODEL_6c3325a78e64418c85b679c764a5f869"
+            ],
+            "layout": "IPY_MODEL_06932deaace042839a7b10727c506995"
+          }
+        },
+        "95485ddd849d40b9b1418799b6f6214f": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_c6525034f5934ac69870acc368edb4fd",
+            "placeholder": "​",
+            "style": "IPY_MODEL_bb84453c45d148db90ecd85e73631fba",
+            "value": "Map: 100%"
+          }
+        },
+        "becbb781afe049e9880002285e940430": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_7c168c1b0b244cf486f1d608560404a5",
+            "max": 8419,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_4113b9aee42449998cfd1b25110499f9",
+            "value": 8419
+          }
+        },
+        "6c3325a78e64418c85b679c764a5f869": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_b78ae0df68e3476590995f05c48c8604",
+            "placeholder": "​",
+            "style": "IPY_MODEL_26a86ffd041d464ebdceceb8158f9043",
+            "value": " 8419/8419 [00:00&lt;00:00, 11568.59 examples/s]"
+          }
+        },
+        "06932deaace042839a7b10727c506995": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "c6525034f5934ac69870acc368edb4fd": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "bb84453c45d148db90ecd85e73631fba": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "7c168c1b0b244cf486f1d608560404a5": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "4113b9aee42449998cfd1b25110499f9": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "b78ae0df68e3476590995f05c48c8604": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "26a86ffd041d464ebdceceb8158f9043": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "4737b67c3838465ca9ab2e9dcc3cc683": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_42f226bc5f174b6f8e317e02e9fa496b",
+              "IPY_MODEL_0f33bb0195be415dbea1e6c5c16ab748",
+              "IPY_MODEL_bcb4bd99536a4c0083907089f91c1f5a"
+            ],
+            "layout": "IPY_MODEL_dfed03a84c9d47e7bde8a25a8caf862b"
+          }
+        },
+        "42f226bc5f174b6f8e317e02e9fa496b": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_bf08f2e1720c45b582cc6b5a8eb84b86",
+            "placeholder": "​",
+            "style": "IPY_MODEL_ec71e6a70a584a3a94f07e006a9b8608",
+            "value": "Map: 100%"
+          }
+        },
+        "0f33bb0195be415dbea1e6c5c16ab748": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_17e5c77f7328430588ef6fe0ab61d40e",
+            "max": 6735,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_8e4741fef1e54978a1faa91e1ccae393",
+            "value": 6735
+          }
+        },
+        "bcb4bd99536a4c0083907089f91c1f5a": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_8913b81e72c94c448d3cbb5bfd070f9f",
+            "placeholder": "​",
+            "style": "IPY_MODEL_56944532f4b84f7a80a9f5a001fd26fe",
+            "value": " 6735/6735 [00:02&lt;00:00, 2674.17 examples/s]"
+          }
+        },
+        "dfed03a84c9d47e7bde8a25a8caf862b": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "bf08f2e1720c45b582cc6b5a8eb84b86": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "ec71e6a70a584a3a94f07e006a9b8608": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "17e5c77f7328430588ef6fe0ab61d40e": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "8e4741fef1e54978a1faa91e1ccae393": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "8913b81e72c94c448d3cbb5bfd070f9f": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "56944532f4b84f7a80a9f5a001fd26fe": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "55251819f23548bbb442acabd0c505eb": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_1bfa6b1a940c4a4c8196304d2879b285",
+              "IPY_MODEL_b42e2751d207436d8417fa0d04990d7e",
+              "IPY_MODEL_6308c6cd48d3482c8a0fddae0e80a530"
+            ],
+            "layout": "IPY_MODEL_c2248ff4957a4a38b120bddd0d9d9d7a"
+          }
+        },
+        "1bfa6b1a940c4a4c8196304d2879b285": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_6c47173b965b4a748a1fba194ab96bdf",
+            "placeholder": "​",
+            "style": "IPY_MODEL_4eb0fbd3e3dd444fb94cee139f139d33",
+            "value": "Map: 100%"
+          }
+        },
+        "b42e2751d207436d8417fa0d04990d7e": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_9b0a7d8afc7346db9c2180b26fb44ee3",
+            "max": 1684,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_16093d3521a243e5933029ac35320aba",
+            "value": 1684
+          }
+        },
+        "6308c6cd48d3482c8a0fddae0e80a530": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_e88776fcd4304de79d31709a587e65ea",
+            "placeholder": "​",
+            "style": "IPY_MODEL_5e69fb4a7a5e45758a845002e063ef4d",
+            "value": " 1684/1684 [00:00&lt;00:00, 2720.02 examples/s]"
+          }
+        },
+        "c2248ff4957a4a38b120bddd0d9d9d7a": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "6c47173b965b4a748a1fba194ab96bdf": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "4eb0fbd3e3dd444fb94cee139f139d33": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "9b0a7d8afc7346db9c2180b26fb44ee3": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "16093d3521a243e5933029ac35320aba": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "e88776fcd4304de79d31709a587e65ea": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "5e69fb4a7a5e45758a845002e063ef4d": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "cc3effb0e1c54e3883dbdd40cbf6da37": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_3c89e08097004bbf88ce5b0eac4aa7a6",
+              "IPY_MODEL_1e655a5897704f47a0b55f999db4e501",
+              "IPY_MODEL_f7b88122c0ac4fe5ad23013bd0cc83f3"
+            ],
+            "layout": "IPY_MODEL_ec30d6ac80f546cb863b5cd7c0e821c7"
+          }
+        },
+        "3c89e08097004bbf88ce5b0eac4aa7a6": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_2f22eed3d62d4f0ea9a764ebe4d924f2",
+            "placeholder": "​",
+            "style": "IPY_MODEL_6e1ed631f95f485bbc6cc1d761b4ee9e",
+            "value": "Loading checkpoint shards: 100%"
+          }
+        },
+        "1e655a5897704f47a0b55f999db4e501": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_f88e7421f4994f31a8270737728bd622",
+            "max": 2,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_9d9fbecd82df4bf2bc171e519059e431",
+            "value": 2
+          }
+        },
+        "f7b88122c0ac4fe5ad23013bd0cc83f3": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_dfc7a09070144b74b311c0e605006a1d",
+            "placeholder": "​",
+            "style": "IPY_MODEL_05548f2ba6f94315b4b2b75c2ff8cfad",
+            "value": " 2/2 [00:22&lt;00:00, 22.71s/it]"
+          }
+        },
+        "ec30d6ac80f546cb863b5cd7c0e821c7": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "2f22eed3d62d4f0ea9a764ebe4d924f2": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "6e1ed631f95f485bbc6cc1d761b4ee9e": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "f88e7421f4994f31a8270737728bd622": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "9d9fbecd82df4bf2bc171e519059e431": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "dfc7a09070144b74b311c0e605006a1d": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "05548f2ba6f94315b4b2b75c2ff8cfad": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        }
+      }
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Fine-tuning a Gemma model with Hugging Face\n",
+        "\n",
+        "*   This Colab gets you started with fine-tuning language models for game-playing via Hugging Face.\n",
+        "*   we generate a dataset of actions recommended by an MCTS bot via self-play.\n",
+        "*   MCTS is short for [Monte Carlo tree search](https://en.wikipedia.org/wiki/Monte_Carlo_tree_search).\n",
+        "*   OpenSpiel is a framework for reinforcement learning in games.\n",
+        "*   Gemma is an open language model.\n",
+        "*   Hugging Face provides an open training and model ecosystem that enables flexible model loading and fine-tuning.\n",
+        "\n",
+        "\n",
+        "\n",
+        "\n",
+        "\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "yLtS3If3qsaX"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Install\n",
+        "**Install core dependencies**: Hugging Face ecosystem libraries, Accelerate, and OpenSpiel.\n",
+        "\n",
+        "*Optional*: bitsandbytes and peft enable parameter-efficient fine-tuning of quantized models (e.g., QLoRA) to reduce memory footprint and support training under practical GPU constraints."
+      ],
+      "metadata": {
+        "id": "uq0uW_oAp0QK"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip -q install -U open_spiel \"transformers>=4.44\" \"accelerate>=0.33\" \"huggingface_hub>=0.24\" bitsandbytes peft"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "E8irXXyW036u",
+        "outputId": "e3f20904-fddd-4552-f8d3-f0280f301357"
+      },
+      "execution_count": 4,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m7.1/7.1 MB\u001b[0m \u001b[31m48.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m76.7/76.7 kB\u001b[0m \u001b[31m8.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25h"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import torch\n",
+        "print(\"cuda:\", torch.cuda.is_available())\n",
+        "\n",
+        "import bitsandbytes as bnb\n",
+        "print(\"bnb version:\", bnb.__version__)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "pFdB0uHCCIsI",
+        "outputId": "80df87a8-02c5-4976-9b22-4abe718c563d"
+      },
+      "execution_count": 3,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "cuda: True\n",
+            "bnb version: 0.49.0\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!nvidia-smi"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "F__18wLC5Rd7",
+        "outputId": "3310fedd-7d07-44ef-9fcb-5e33884ad683"
+      },
+      "execution_count": 25,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Fri Dec 26 13:42:59 2025       \n",
+            "+-----------------------------------------------------------------------------------------+\n",
+            "| NVIDIA-SMI 550.54.15              Driver Version: 550.54.15      CUDA Version: 12.4     |\n",
+            "|-----------------------------------------+------------------------+----------------------+\n",
+            "| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |\n",
+            "| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |\n",
+            "|                                         |                        |               MIG M. |\n",
+            "|=========================================+========================+======================|\n",
+            "|   0  Tesla T4                       Off |   00000000:00:04.0 Off |                    0 |\n",
+            "| N/A   49C    P0             26W /   70W |    2550MiB /  15360MiB |      3%      Default |\n",
+            "|                                         |                        |                  N/A |\n",
+            "+-----------------------------------------+------------------------+----------------------+\n",
+            "                                                                                         \n",
+            "+-----------------------------------------------------------------------------------------+\n",
+            "| Processes:                                                                              |\n",
+            "|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |\n",
+            "|        ID   ID                                                               Usage      |\n",
+            "|=========================================================================================|\n",
+            "+-----------------------------------------------------------------------------------------+\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import math\n",
+        "import random\n",
+        "import numpy as np\n",
+        "import pyspiel\n",
+        "import tqdm\n",
+        "import torch\n",
+        "from open_spiel.python.algorithms import mcts\n",
+        "from typing import Dict, List, Any, Optional\n",
+        "\n",
+        "# Hugging Face imports\n",
+        "from datasets import Dataset\n",
+        "from transformers import (\n",
+        "    AutoTokenizer,\n",
+        "    AutoModelForCausalLM,\n",
+        "    BitsAndBytesConfig,\n",
+        "    TrainingArguments,\n",
+        "    Trainer,\n",
+        "    default_data_collator,\n",
+        ")\n",
+        "\n",
+        "from peft import (\n",
+        "    LoraConfig,\n",
+        "    get_peft_model,\n",
+        "    prepare_model_for_kbit_training,\n",
+        ")\n"
+      ],
+      "metadata": {
+        "id": "JnIvSi4MwZJX"
+      },
+      "execution_count": 42,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Create the fine-tuning dataset via self-play MCTS"
+      ],
+      "metadata": {
+        "id": "jr-WV3lWvs19"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def set_seeds(seed: int) -> None:\n",
+        "    random.seed(seed)\n",
+        "    np.random.seed(seed)\n",
+        "\n",
+        "def player_mark(player: int) -> str:\n",
+        "    return \"x\" if player == 0 else \"o\"\n",
+        "\n",
+        "\n",
+        "def expand_state_str(state_str: str) -> str:\n",
+        "    \"\"\"Insert spaces so tokens like 'x', 'o', '.' are less likely to merge.\"\"\"\n",
+        "    return (state_str\n",
+        "            .replace(\"x\", \" x\")\n",
+        "            .replace(\"o\", \" o\")\n",
+        "            .replace(\".\", \" .\"))\n",
+        "\n",
+        "def make_mcts_bot(game, uct_c, max_simulations, seed):\n",
+        "    rng = random.Random(seed)\n",
+        "    evaluator = mcts.RandomRolloutEvaluator(random_state=rng)\n",
+        "    bot = mcts.MCTSBot(\n",
+        "        game=game,\n",
+        "        uct_c=uct_c,\n",
+        "        max_simulations=max_simulations,\n",
+        "        evaluator=evaluator,\n",
+        "        random_state=rng\n",
+        "    )\n",
+        "    return bot\n",
+        "\n",
+        "def epsilon_greedy_action(\n",
+        "    legal_actions: List[int],\n",
+        "    greedy_action: int,\n",
+        "    num_distinct_actions: int,\n",
+        "    epsilon: float,\n",
+        "    all_actions: np.ndarray,\n",
+        ") -> int:\n",
+        "    \"\"\"\n",
+        "    epsilon-greedy\n",
+        "    \"\"\"\n",
+        "    greedy_policy = np.zeros(num_distinct_actions, dtype=float)\n",
+        "    uniform_policy = np.zeros(num_distinct_actions, dtype=float)\n",
+        "\n",
+        "    uniform_policy[legal_actions] = 1.0\n",
+        "    uniform_policy /= len(legal_actions)\n",
+        "\n",
+        "    greedy_policy[greedy_action] = 1.0\n",
+        "    epsilon_greedy_policy = epsilon * uniform_policy + (1.0 - epsilon) * greedy_policy\n",
+        "\n",
+        "    action_to_take = int(np.random.choice(all_actions, p=epsilon_greedy_policy))\n",
+        "    assert action_to_take in legal_actions\n",
+        "    return action_to_take\n",
+        "\n",
+        "def generate_mcts_imitation_dataset(game_name: str,\n",
+        "                                    uct_c: float,\n",
+        "                                    mcts_sims_per_decision: int,\n",
+        "                                    epsilon: float,\n",
+        "                                    num_episodes: int,\n",
+        "                                    seed: int) -> List[Dict[str, Any]]:\n",
+        "    \"\"\"\n",
+        "    Generates a dataset via MCTS self-play.\n",
+        "    \"\"\"\n",
+        "    set_seeds(seed)\n",
+        "\n",
+        "    game = pyspiel.load_game(game_name)\n",
+        "    bot = make_mcts_bot(\n",
+        "        game=game,\n",
+        "        uct_c=uct_c,\n",
+        "        max_simulations=mcts_sims_per_decision,\n",
+        "        seed=seed,\n",
+        "    )\n",
+        "\n",
+        "    num_distinct_actions = game.num_distinct_actions()\n",
+        "    all_actions = np.arange(num_distinct_actions)\n",
+        "\n",
+        "    records: List[Dict[str, Any]] = []\n",
+        "\n",
+        "    print(\n",
+        "        f\"Generating data using {num_episodes} episodes of self-play MCTS...\\n\"\n",
+        "        f\"game={game_name}, sims/decision={mcts_sims_per_decision}, \"\n",
+        "        f\"epsilon={epsilon}, uct_c={uct_c:.4f}, seed={seed}\"\n",
+        "    )\n",
+        "\n",
+        "    for _ in tqdm.tqdm(range(num_episodes)):\n",
+        "        state = game.new_initial_state()\n",
+        "\n",
+        "        while not state.is_terminal():\n",
+        "            player = state.current_player()\n",
+        "            legal_actions = state.legal_actions()\n",
+        "\n",
+        "            # Teacher action (label): greedy MCTS action\n",
+        "            greedy_action = int(bot.step(state))\n",
+        "\n",
+        "            # Record training example (label = greedy_action)\n",
+        "            records.append({\n",
+        "                \"state_str\": expand_state_str(str(state)),\n",
+        "                \"action\": greedy_action,\n",
+        "                \"action_str\": state.action_to_string(greedy_action),\n",
+        "                \"player_mark\": player_mark(player),\n",
+        "                \"legal_actions\": legal_actions,\n",
+        "            })\n",
+        "\n",
+        "            # Behavior action (for exploration): epsilon-greedy\n",
+        "            action_to_take = epsilon_greedy_action(\n",
+        "                legal_actions=legal_actions,\n",
+        "                greedy_action=greedy_action,\n",
+        "                num_distinct_actions=num_distinct_actions,\n",
+        "                epsilon=epsilon,\n",
+        "                all_actions=all_actions,\n",
+        "            )\n",
+        "            state.apply_action(action_to_take)\n",
+        "\n",
+        "    return records, num_distinct_actions"
+      ],
+      "metadata": {
+        "id": "BnwInLa8xaF8"
+      },
+      "execution_count": 20,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "NUM_EPISODES = 1000\n",
+        "MCTS_SIMS_PER_DECISION = 1000\n",
+        "records, num_labels = generate_mcts_imitation_dataset(game_name='tic_tac_toe',\n",
+        "                                                      uct_c=(2.0 * math.sqrt(2)),\n",
+        "                                                      mcts_sims_per_decision=MCTS_SIMS_PER_DECISION,\n",
+        "                                                      epsilon=0.1,\n",
+        "                                                      num_episodes=NUM_EPISODES,\n",
+        "                                                      seed=42)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "_wqrgnWhyffH",
+        "outputId": "815919e8-3ebc-4448-ab11-1b45053ec243"
+      },
+      "execution_count": 21,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Generating data using 1000 episodes of self-play MCTS...\n",
+            "game=tic_tac_toe, sims/decision=1000, epsilon=0.1, uct_c=2.8284, seed=42\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "100%|██████████| 1000/1000 [02:41<00:00,  6.19it/s]\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Convert records to HuggingFace Dataset and format prompt"
+      ],
+      "metadata": {
+        "id": "EAB_xEx2227A"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "ds = Dataset.from_list(records)\n",
+        "\n",
+        "PROMPT_TEMPLATE = \"\"\"\\\n",
+        "You are playing a game of Tic-Tac-Toe. The current state is:\n",
+        "\n",
+        "{state_str}\n",
+        "\n",
+        "You need to give your move in the following format: mark(row,col)\n",
+        "Where mark is either \"x\" or \"o\" and row and col coordinates are 0-indexed.\n",
+        "\n",
+        "You are playing as player {player_mark!r}.\n",
+        "What is your next move?\n",
+        "Respond with: YOUR_MOVE\n",
+        "\"\"\"\n",
+        "\n",
+        "def add_prompt_response(ex):\n",
+        "    ex[\"prompt\"] = PROMPT_TEMPLATE.format(\n",
+        "        state_str=ex[\"state_str\"],\n",
+        "        player_mark=ex[\"player_mark\"],\n",
+        "    )\n",
+        "    # Directly use OpenSpiel's string form, e.g., \"o(0,2)\"\n",
+        "    ex[\"response\"] = ex[\"action_str\"]\n",
+        "    return ex\n",
+        "\n",
+        "ds2 = ds.map(add_prompt_response)\n",
+        "print(ds2[0][\"prompt\"])\n",
+        "print(\"response:\", ds2[0][\"response\"])\n",
+        "\n",
+        "# train/test split\n",
+        "ds_split = ds2.train_test_split(test_size=0.2, seed=0)\n",
+        "train_ds = ds_split[\"train\"]\n",
+        "eval_ds  = ds_split[\"test\"]\n",
+        "\n",
+        "print(len(train_ds), len(eval_ds))"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 309,
+          "referenced_widgets": [
+            "13b603301def44529a99abedacbcd4db",
+            "95485ddd849d40b9b1418799b6f6214f",
+            "becbb781afe049e9880002285e940430",
+            "6c3325a78e64418c85b679c764a5f869",
+            "06932deaace042839a7b10727c506995",
+            "c6525034f5934ac69870acc368edb4fd",
+            "bb84453c45d148db90ecd85e73631fba",
+            "7c168c1b0b244cf486f1d608560404a5",
+            "4113b9aee42449998cfd1b25110499f9",
+            "b78ae0df68e3476590995f05c48c8604",
+            "26a86ffd041d464ebdceceb8158f9043"
+          ]
+        },
+        "id": "Cvp7TvZv2sPV",
+        "outputId": "96617fbd-240e-43d2-c89d-b66ba11ac180"
+      },
+      "execution_count": 51,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "Map:   0%|          | 0/8419 [00:00<?, ? examples/s]"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "13b603301def44529a99abedacbcd4db"
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "You are playing a game of Tic-Tac-Toe. The current state is:\n",
+            "\n",
+            " . . .\n",
+            " . . .\n",
+            " . . .\n",
+            "\n",
+            "You need to give your move in the following format: mark(row,col)\n",
+            "Where mark is either \"x\" or \"o\" and row and col coordinates are 0-indexed.\n",
+            "\n",
+            "You are playing as player 'x'.\n",
+            "What is your next move?\n",
+            "Respond with: YOUR_MOVE\n",
+            "\n",
+            "response: x(1,1)\n",
+            "6735 1684\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Drop-in Gemma model via Hugging Face"
+      ],
+      "metadata": {
+        "id": "THb92kKD65l4"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!huggingface-cli login"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "JzXRk4Cj7uoR",
+        "outputId": "6ef0f26c-e4a1-495c-c6c9-297ab262d9ee"
+      },
+      "execution_count": 23,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\u001b[33m⚠️  Warning: 'huggingface-cli login' is deprecated. Use 'hf auth login' instead.\u001b[0m\n",
+            "\n",
+            "    _|    _|  _|    _|    _|_|_|    _|_|_|  _|_|_|  _|      _|    _|_|_|      _|_|_|_|    _|_|      _|_|_|  _|_|_|_|\n",
+            "    _|    _|  _|    _|  _|        _|          _|    _|_|    _|  _|            _|        _|    _|  _|        _|\n",
+            "    _|_|_|_|  _|    _|  _|  _|_|  _|  _|_|    _|    _|  _|  _|  _|  _|_|      _|_|_|    _|_|_|_|  _|        _|_|_|\n",
+            "    _|    _|  _|    _|  _|    _|  _|    _|    _|    _|    _|_|  _|    _|      _|        _|    _|  _|        _|\n",
+            "    _|    _|    _|_|      _|_|_|    _|_|_|  _|_|_|  _|      _|    _|_|_|      _|        _|    _|    _|_|_|  _|_|_|_|\n",
+            "\n",
+            "    To log in, `huggingface_hub` requires a token generated from https://huggingface.co/settings/tokens .\n",
+            "Enter your token (input will not be visible): \n",
+            "Add token as git credential? (Y/n) Y\n",
+            "Token is valid (permission: read).\n",
+            "The token `read-only` has been saved to /root/.cache/huggingface/stored_tokens\n",
+            "\u001b[1m\u001b[31mCannot authenticate through git-credential as no helper is defined on your machine.\n",
+            "You might have to re-authenticate when pushing to the Hugging Face Hub.\n",
+            "Run the following command in your terminal in case you want to set the 'store' credential helper as default.\n",
+            "\n",
+            "git config --global credential.helper store\n",
+            "\n",
+            "Read https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage for more details.\u001b[0m\n",
+            "Token has not been saved to git credential helper.\n",
+            "Your token has been saved to /root/.cache/huggingface/token\n",
+            "Login successful.\n",
+            "The current active token is: `read-only`\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Specify LM\n",
+        "\n",
+        "MODEL_ID = \"google/gemma-2b\"\n",
+        "SEED = 42\n",
+        "MAX_LENGTH = 256   # to align with Kauldron, use max_length=512（token）\n",
+        "BATCH_SIZE = 8     # to align with Kauldron, use batch_size=64\n",
+        "TRAINING_STEPS = 50  # to align with Kauldron, use 500 steps\n"
+      ],
+      "metadata": {
+        "id": "tBJrdKgK7kRZ"
+      },
+      "execution_count": 63,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "tokenizer = AutoTokenizer.from_pretrained(MODEL_ID, use_fast=True)\n",
+        "if tokenizer.pad_token is None:\n",
+        "    tokenizer.pad_token = tokenizer.eos_token\n",
+        "\n",
+        "print(\"pad_token:\", tokenizer.pad_token, \"pad_token_id:\", tokenizer.pad_token_id)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "mnsUEYBn7s8P",
+        "outputId": "913e40f4-a4ae-44fb-f040-3a8b0fd463b4"
+      },
+      "execution_count": 64,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "pad_token: <pad> pad_token_id: 0\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Tokenize + labels mask\n",
+        "\n",
+        "def tokenize_seq2seq_style(batch):\n",
+        "    prompts = batch[\"prompt\"]\n",
+        "    responses = batch[\"response\"]\n",
+        "\n",
+        "    input_ids_list, attention_mask_list, labels_list = [], [], []\n",
+        "\n",
+        "    for p, r in zip(prompts, responses):\n",
+        "        # input data: [prompt] + \"\\n\" + [response]\n",
+        "        p_text = p + \"\\n\"\n",
+        "        r_text = r\n",
+        "\n",
+        "        p_ids = tokenizer(p_text, add_special_tokens=False).input_ids\n",
+        "        r_ids = tokenizer(r_text, add_special_tokens=False).input_ids\n",
+        "\n",
+        "        input_ids = (p_ids + r_ids)[:MAX_LENGTH]\n",
+        "        labels = ([-100] * len(p_ids) + r_ids)[:MAX_LENGTH]\n",
+        "        attention_mask = [1] * len(input_ids)\n",
+        "\n",
+        "        # pad\n",
+        "        pad_len = MAX_LENGTH - len(input_ids)\n",
+        "        input_ids += [tokenizer.pad_token_id] * pad_len\n",
+        "        attention_mask += [0] * pad_len\n",
+        "        labels += [-100] * pad_len\n",
+        "\n",
+        "        input_ids_list.append(input_ids)\n",
+        "        attention_mask_list.append(attention_mask)\n",
+        "        labels_list.append(labels)\n",
+        "\n",
+        "    return {\n",
+        "        \"input_ids\": input_ids_list,\n",
+        "        \"attention_mask\": attention_mask_list,\n",
+        "        \"labels\": labels_list,\n",
+        "    }\n",
+        "\n",
+        "train_tok = train_ds.map(tokenize_seq2seq_style, batched=True, remove_columns=train_ds.column_names)\n",
+        "eval_tok  = eval_ds.map(tokenize_seq2seq_style, batched=True, remove_columns=eval_ds.column_names)\n",
+        "\n",
+        "train_tok.set_format(type=\"torch\", columns=[\"input_ids\", \"attention_mask\", \"labels\"])\n",
+        "eval_tok.set_format(type=\"torch\", columns=[\"input_ids\", \"attention_mask\", \"labels\"])\n",
+        "\n",
+        "print(train_tok[0].keys())\n",
+        "\n",
+        "print(\"train size:\", len(train_tok), \"eval size:\", len(eval_tok))\n",
+        "print(\"sample keys:\", train_tok[0].keys())\n"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 133,
+          "referenced_widgets": [
+            "4737b67c3838465ca9ab2e9dcc3cc683",
+            "42f226bc5f174b6f8e317e02e9fa496b",
+            "0f33bb0195be415dbea1e6c5c16ab748",
+            "bcb4bd99536a4c0083907089f91c1f5a",
+            "dfed03a84c9d47e7bde8a25a8caf862b",
+            "bf08f2e1720c45b582cc6b5a8eb84b86",
+            "ec71e6a70a584a3a94f07e006a9b8608",
+            "17e5c77f7328430588ef6fe0ab61d40e",
+            "8e4741fef1e54978a1faa91e1ccae393",
+            "8913b81e72c94c448d3cbb5bfd070f9f",
+            "56944532f4b84f7a80a9f5a001fd26fe",
+            "55251819f23548bbb442acabd0c505eb",
+            "1bfa6b1a940c4a4c8196304d2879b285",
+            "b42e2751d207436d8417fa0d04990d7e",
+            "6308c6cd48d3482c8a0fddae0e80a530",
+            "c2248ff4957a4a38b120bddd0d9d9d7a",
+            "6c47173b965b4a748a1fba194ab96bdf",
+            "4eb0fbd3e3dd444fb94cee139f139d33",
+            "9b0a7d8afc7346db9c2180b26fb44ee3",
+            "16093d3521a243e5933029ac35320aba",
+            "e88776fcd4304de79d31709a587e65ea",
+            "5e69fb4a7a5e45758a845002e063ef4d"
+          ]
+        },
+        "id": "ga3sZ2CC7x9a",
+        "outputId": "f251f51b-2ec4-4be9-e8d9-d13020f5829f"
+      },
+      "execution_count": 65,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "Map:   0%|          | 0/6735 [00:00<?, ? examples/s]"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "4737b67c3838465ca9ab2e9dcc3cc683"
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "Map:   0%|          | 0/1684 [00:00<?, ? examples/s]"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "55251819f23548bbb442acabd0c505eb"
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "dict_keys(['input_ids', 'attention_mask', 'labels'])\n",
+            "train size: 6735 eval size: 1684\n",
+            "sample keys: dict_keys(['input_ids', 'attention_mask', 'labels'])\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Initialize Model\n",
+        "\n",
+        "bnb_config = BitsAndBytesConfig(\n",
+        "    load_in_4bit=True,\n",
+        "    bnb_4bit_quant_type=\"nf4\",\n",
+        "    bnb_4bit_use_double_quant=True,\n",
+        "    bnb_4bit_compute_dtype=torch.float16,\n",
+        ")\n",
+        "\n",
+        "model = AutoModelForCausalLM.from_pretrained(\n",
+        "    MODEL_ID,\n",
+        "    quantization_config=bnb_config,\n",
+        "    device_map=\"auto\",\n",
+        ")\n",
+        "\n",
+        "# Training-time optimizations\n",
+        "model.config.use_cache = False\n",
+        "model.gradient_checkpointing_enable()\n",
+        "\n",
+        "# Prepare for k-bit training (important for QLoRA stability)\n",
+        "model = prepare_model_for_kbit_training(model)\n",
+        "\n",
+        "lora_config = LoraConfig(\n",
+        "    r=16,\n",
+        "    lora_alpha=32,\n",
+        "    target_modules=[\"q_proj\", \"k_proj\", \"v_proj\", \"o_proj\"],\n",
+        "    lora_dropout=0.05,\n",
+        "    bias=\"none\",\n",
+        "    task_type=\"CAUSAL_LM\",\n",
+        ")\n",
+        "\n",
+        "model = get_peft_model(model, lora_config)\n",
+        "model.print_trainable_parameters()\n",
+        "\n",
+        "print(\"model loaded. first param device:\", next(model.parameters()).device)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 84,
+          "referenced_widgets": [
+            "cc3effb0e1c54e3883dbdd40cbf6da37",
+            "3c89e08097004bbf88ce5b0eac4aa7a6",
+            "1e655a5897704f47a0b55f999db4e501",
+            "f7b88122c0ac4fe5ad23013bd0cc83f3",
+            "ec30d6ac80f546cb863b5cd7c0e821c7",
+            "2f22eed3d62d4f0ea9a764ebe4d924f2",
+            "6e1ed631f95f485bbc6cc1d761b4ee9e",
+            "f88e7421f4994f31a8270737728bd622",
+            "9d9fbecd82df4bf2bc171e519059e431",
+            "dfc7a09070144b74b311c0e605006a1d",
+            "05548f2ba6f94315b4b2b75c2ff8cfad"
+          ]
+        },
+        "id": "HPliPAhfDHJb",
+        "outputId": "f06c8643-f5eb-409c-fdf7-3422b6f5b965"
+      },
+      "execution_count": 66,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "Loading checkpoint shards:   0%|          | 0/2 [00:00<?, ?it/s]"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "cc3effb0e1c54e3883dbdd40cbf6da37"
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "trainable params: 3,686,400 || all params: 2,509,858,816 || trainable%: 0.1469\n",
+            "model loaded. first param device: cuda:0\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Cast trainable adapter parameters to float32 for numerical stability\n",
+        "# and to avoid mixed-precision gradient scaling issues.\n",
+        "for n, p in model.named_parameters():\n",
+        "    if p.requires_grad:\n",
+        "        p.data = p.data.float()\n",
+        "\n",
+        "dtypes = {}\n",
+        "for n, p in model.named_parameters():\n",
+        "    if p.requires_grad:\n",
+        "        dtypes[str(p.dtype)] = dtypes.get(str(p.dtype), 0) + p.numel()\n",
+        "\n",
+        "print(\"trainable dtype counts:\", dtypes)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "ffxCFg2855kn",
+        "outputId": "cefd69cd-9357-40e0-eff0-5ae7ff60900a"
+      },
+      "execution_count": 67,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "trainable dtype counts: {'torch.float32': 3686400}\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Configure Trainer\n",
+        "\n",
+        "args = TrainingArguments(\n",
+        "    output_dir=\"./tmp_out\",\n",
+        "    max_steps=TRAINING_STEPS,                   # align Kauldron TRAINING_STEPS\n",
+        "    per_device_train_batch_size=1,   # micro-batch\n",
+        "    per_device_eval_batch_size=1,\n",
+        "    gradient_accumulation_steps=BATCH_SIZE,  # effective batch (align Kauldron BATCH_SIZE)\n",
+        "    learning_rate=1e-3,              # align Kauldron adafactor lr\n",
+        "    optim=\"adafactor\",               # align optimizer choice\n",
+        "    eval_strategy=\"steps\",\n",
+        "    eval_steps=100,\n",
+        "    save_strategy=\"steps\",\n",
+        "    save_steps=100,\n",
+        "    save_total_limit=2,\n",
+        "    logging_steps=20,\n",
+        "    report_to=\"none\",\n",
+        "    fp16=False,\n",
+        "    bf16=False,\n",
+        ")\n",
+        "\n",
+        "trainer = Trainer(\n",
+        "    model=model,\n",
+        "    args=args,\n",
+        "    train_dataset=train_tok,\n",
+        "    eval_dataset=eval_tok,\n",
+        "    data_collator=default_data_collator,\n",
+        ")\n",
+        "\n",
+        "trainer.train()\n",
+        "trainer.evaluate()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 237
+        },
+        "id": "MTlNUwnl_cST",
+        "outputId": "d9b41ba6-0a07-433e-9cc4-56d43387740d"
+      },
+      "execution_count": 68,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/eval_frame.py:1044: UserWarning: torch.utils.checkpoint: the use_reentrant parameter should be passed explicitly. Starting in PyTorch 2.9, calling checkpoint without use_reentrant will raise an exception. use_reentrant=False is recommended, but if you need to preserve the current default behavior, you can pass use_reentrant=True. Refer to docs for more details on the differences between the two variants.\n",
+            "  return fn(*args, **kwargs)\n"
+          ]
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ],
+            "text/html": [
+              "\n",
+              "    <div>\n",
+              "      \n",
+              "      <progress value='50' max='50' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
+              "      [50/50 02:58, Epoch 0/1]\n",
+              "    </div>\n",
+              "    <table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              " <tr style=\"text-align: left;\">\n",
+              "      <th>Step</th>\n",
+              "      <th>Training Loss</th>\n",
+              "      <th>Validation Loss</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "  </tbody>\n",
+              "</table><p>"
+            ]
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ],
+            "text/html": [
+              "\n",
+              "    <div>\n",
+              "      \n",
+              "      <progress value='1684' max='1684' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
+              "      [1684/1684 04:51]\n",
+              "    </div>\n",
+              "    "
+            ]
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "{'eval_loss': 0.3649670481681824,\n",
+              " 'eval_runtime': 291.5964,\n",
+              " 'eval_samples_per_second': 5.775,\n",
+              " 'eval_steps_per_second': 5.775,\n",
+              " 'epoch': 0.05939123979213066}"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 68
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Sampling\n",
+        "def infer_move(prompt: str, max_new_tokens: int = 8):\n",
+        "    device = next(model.parameters()).device\n",
+        "    inputs = tokenizer(prompt, return_tensors=\"pt\").to(device)\n",
+        "\n",
+        "    model.eval()\n",
+        "    with torch.no_grad():\n",
+        "        out = model.generate(\n",
+        "            **inputs,\n",
+        "            max_new_tokens=max_new_tokens,\n",
+        "            do_sample=False,   # greedy\n",
+        "        )\n",
+        "\n",
+        "    full_text = tokenizer.decode(out[0], skip_special_tokens=True)\n",
+        "\n",
+        "    gen_only = full_text[len(prompt):].strip().splitlines()[0]\n",
+        "\n",
+        "    return gen_only, full_text\n",
+        "\n",
+        "\n",
+        "sample_prompt = train_ds[2][\"prompt\"]\n",
+        "pred, full = infer_move(sample_prompt)\n",
+        "\n",
+        "print(\"=== PROMPT ===\")\n",
+        "print(sample_prompt)\n",
+        "print(\"\\n=== PREDICTED MOVE ===\")\n",
+        "print(pred)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "7zqMxmNl3j6o",
+        "outputId": "67d83ad1-b993-4de4-cad0-6c179607a4d4"
+      },
+      "execution_count": 79,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "=== PROMPT ===\n",
+            "You are playing a game of Tic-Tac-Toe. The current state is:\n",
+            "\n",
+            " . . o\n",
+            " . x .\n",
+            " . . .\n",
+            "\n",
+            "You need to give your move in the following format: mark(row,col)\n",
+            "Where mark is either \"x\" or \"o\" and row and col coordinates are 0-indexed.\n",
+            "\n",
+            "You are playing as player 'x'.\n",
+            "What is your next move?\n",
+            "Respond with: YOUR_MOVE\n",
+            "\n",
+            "\n",
+            "=== PREDICTED MOVE ===\n",
+            "x(0,0)\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "ZSB9atC4MLSd"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
This PR is a small holiday follow-up to the OpenSpiel 2.0 year-end announcement, generalizing the Gemma + Kauldron example to the Hugging Face ecosystem (#1414).

The notebook mirrors the original task structure (prompt → response with a loss mask), while using publicly available Hugging Face checkpoints and GPU-friendly QLoRA fine-tuning to make the example easier to run on T4 GPU on colab.

Thanks again for the OpenSpiel 2.0 wrap-up and happy holidays!