### PR TITLE
fix install.sh bug with a command failing and not printing the intended error message

### DIFF
--- a/open_spiel/scripts/install.sh
+++ b/open_spiel/scripts/install.sh
@@ -287,12 +287,13 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
     EXT_DEPS="${EXT_DEPS} rustc cargo"
   fi
 
-  APT_GET=`which apt-get`
-  if [ "$APT_GET" = "" ]
+  if command -v apt-get &> /dev/null
   then
-     echo "This script assumes a Debian-based Linux distribution. Please install these packages manually or using your distribution's package manager:"
-     echo "$EXT_DEPS"
-     exit 1
+      APT_GET=$(command -v apt-get)
+  else
+    echo "This script assumes a Debian-based Linux distribution. Please install these packages manually or using your distribution's package manager:"
+    echo "$EXT_DEPS"
+    exit 1
   fi
 
   # We install the packages only if they are not present yet.


### PR DESCRIPTION
When which didn't find apt-get, the script exited because of set -e and did not print the message afterwards.