### PR TITLE
feat: Add MaxSerializationLength() to Game API

### DIFF
--- a/open_spiel/games/chess/chess.cc
+++ b/open_spiel/games/chess/chess.cc
@@ -592,5 +592,17 @@ int ChessGame::MaxChanceOutcomes() const {
   }
 }
 
+int ChessGame::MaxSerializationLength() const {
+  // "FEN: " + fen + "\n" + StrJoin(history, "\n") + "\n"
+  // Max FEN length is approximately 100 characters.
+  // Max history length is MaxHistoryLength().
+  // Each action is up to 5 digits (NumDistinctActions() ~ 4674).
+  int max_fen_len = 100;
+  int max_history_len = MaxHistoryLength();
+  int max_action_len = 5;  // log10(4674) + 1
+  return std::strlen("FEN: ") + max_fen_len + 1 +
+         max_history_len * (max_action_len + 1) + 1;
+}
+
 }  // namespace chess
 }  // namespace open_spiel

--- a/open_spiel/games/chess/chess.h
+++ b/open_spiel/games/chess/chess.h
@@ -269,6 +269,8 @@ class ChessGame : public Game {
   std::unique_ptr<State> DeserializeState(
       const std::string& str) const override;
 
+  int MaxSerializationLength() const override;
+
   bool IsChess960() const { return chess960_; }
 
   std::string Chess960LookupFEN(int index) const {

--- a/open_spiel/games/tic_tac_toe/tic_tac_toe.h
+++ b/open_spiel/games/tic_tac_toe/tic_tac_toe.h
@@ -169,6 +169,7 @@ class TicTacToeGame : public Game {
   }
   int MaxGameLength() const override { return kNumCells; }
   std::string ActionToString(Player player, Action action_id) const override;
+  int MaxSerializationLength() const override { return 19; }
 };
 
 CellState PlayerToState(Player player);

--- a/open_spiel/python/CMakeLists.txt
+++ b/open_spiel/python/CMakeLists.txt
@@ -27,7 +27,7 @@ endif()
 include_directories (../pybind11_abseil ../../pybind11/include)
 set(PYTHON_BINDINGS ${PYTHON_BINDINGS}
   pybind11/algorithms_infostate_tree.cc
-  pybind11/algorithms_infostate_tree.tcc
+  pybind11/algorithms_infostate_tree_templates.h
   pybind11/algorithms_infostate_tree.h
   pybind11/algorithms_corr_dist.cc
   pybind11/algorithms_corr_dist.h

--- a/open_spiel/python/pybind11/pyspiel.cc
+++ b/open_spiel/python/pybind11/pyspiel.cc
@@ -455,6 +455,7 @@ PYBIND11_MODULE(pyspiel, m) {
       .def("policy_tensor_shape", &Game::PolicyTensorShape)
       .def("deserialize_state", &Game::DeserializeState)
       .def("max_game_length", &Game::MaxGameLength)
+      .def("max_serialization_length", &Game::MaxSerializationLength)
       .def("action_to_string", &Game::ActionToString)
       .def("max_chance_nodes_in_history", &Game::MaxChanceNodesInHistory)
       .def("max_move_number", &Game::MaxMoveNumber)

--- a/open_spiel/spiel.cc
+++ b/open_spiel/spiel.cc
@@ -505,6 +505,19 @@ std::unique_ptr<State> Game::DeserializeState(const std::string& str) const {
   return state;
 }
 
+int Game::MaxSerializationLength() const {
+  // Default implementation assumes the default serialization format:
+  // history actions joined by \n, each action as decimal number.
+  // Games that override State::Serialize must override this method.
+  int num_actions = NumDistinctActions();
+  int max_action_digits = 1;
+  if (num_actions > 1) {
+    max_action_digits = static_cast<int>(std::log10(num_actions - 1)) + 1;
+  }
+  int max_history_length = MaxHistoryLength();
+  return max_history_length * (max_action_digits + 1) + 1;
+}
+
 std::string SerializeGameAndState(const Game& game, const State& state) {
   std::string str = "";
 

--- a/open_spiel/spiel.h
+++ b/open_spiel/spiel.h
@@ -969,6 +969,13 @@ class Game : public std::enable_shared_from_this<Game> {
   // State::Serialize (i.e. that method should also be overridden).
   virtual std::unique_ptr<State> DeserializeState(const std::string& str) const;
 
+  // The maximum length of the string returned by State::Serialize() for any
+  // state in this game. This is useful for allocating fixed-size buffers when
+  // working with vectorized game states.
+  // The default implementation assumes the default serialization format.
+  // Games that override State::Serialize must override this method.
+  virtual int MaxSerializationLength() const;
+
   // The maximum length of any one game (in terms of number of decision nodes
   // visited in the game tree). For a simultaneous action game, this is the
   // maximum number of joint decisions. In a turn-based game, this is the


### PR DESCRIPTION
i added a new virtual method `MaxSerializationLength()` to the `Game` class which allows consumers (especially in JAX/vectorized environments) to pre-allocate fixed-size string buffers for state serialization without guessing or over-allocating.

**Changes:**
* Added default implementation in `spiel.cc` based on `MaxGameLength` and action digits.
* Overridden implementation for **Chess** (accounts for FEN + history).
* Overridden implementation for **Tic-Tac-Toe** (fixed constant).

This should help unblock the JAX vectorization work mentioned in #1452.