### PR TITLE
[BUG][Minor] Fix shared library build when using cached cmake config

### DIFF
--- a/open_spiel/CMakeLists.txt
+++ b/open_spiel/CMakeLists.txt
@@ -286,7 +286,6 @@ include_directories(..)
 add_subdirectory (algorithms)
 add_subdirectory (bots)
 add_subdirectory (evaluation)
-add_subdirectory (examples)
 add_subdirectory (games)
 add_subdirectory (game_transforms)
 
@@ -336,4 +335,5 @@ if (BUILD_SHARED_LIB)
   )
 endif()
 
+add_subdirectory (examples)
 add_subdirectory (tests)


### PR DESCRIPTION
Bug: In `open_spiel/CMakeLists.txt`
- When building shared lib, `examples` depends on `open_spiel` via `shared_library_example` target.
- However, `add_sub_directory(examples)` precedes target  `open_spiel` in `CMakeLists.txt`

This causes two (minor) issues:
1) When building with `BUILD_SHARED_LIB` as cmake ENV variable (i.e `BUILD_SHARED_LIB=ON cmake ...`), `shared_library_example` not even created.

2) When building with cached variables `cmake ... -DBUILD_SHARED_LIB=ON`, build fails.

To reproduce 1st issue:
`BUILD_SHARED_LIB=ON cmake -S . -B build`
`cmake --build build -j 32`
`ls build/examples`
notice no `shared_library_example` binary created

To reproduce 2nd issue:
`cmake -S . -B build -DBUILD_SHARED_LIB=ON`
`cmake --build build -j 32`
Notice build fails `/usr/bin/ld: cannot find -lopen_spiel: No such file or directory`

Fixed by simple 1 line change.