### PR TITLE
Fix TypeError when logging advantage losses in Deep CFR PyTorch

### DIFF
--- a/open_spiel/python/examples/deep_cfr_pytorch.py
+++ b/open_spiel/python/examples/deep_cfr_pytorch.py
@@ -71,8 +71,7 @@ def main(unused_argv):
 
   _, advantage_losses, policy_loss = deep_cfr_solver.solve()
   for player, losses in enumerate(advantage_losses):
-    logging.info("Advantage for player %d: %s", player,
-                 losses[:2] + ["..."] + losses[-2:])
+    logging.info("Advantage for player %d: %s", player, losses)
     assert deep_cfr_solver.advantage_buffers[player] is not None
     logging.info(
         f"Advantage Buffer Size for player {player}:"


### PR DESCRIPTION
When running Deep CFR PyTorch on Kuhn Poker, calculating advantage losses resulted in a TypeError because integers were being subset using list notation. This changes the logging statement to not assume string concatenation against lists, fixing the logging bug. It provides a simple output of the object.