### PR TITLE
docs: add spielviz as visualization tool reference

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -107,6 +107,9 @@ Otherwise, happy hacking!
 
 -   **Visualizations of games**. There exists an interactive viewer for
     OpenSpiel games called [SpielViz](https://github.com/michalsustr/spielviz).
+    A standalone visualization library called [spielviz](https://github.com/kvr06-ai/spielviz)
+    (`pip install spielviz`) is also available for rendering game trees, information sets,
+    and strategy profiles.
     Contributions to this project, and more visualization tools with OpenSpiel,
     are very welcome as they could help immensely with debugging and testing
     the AI beyond the console.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -46,3 +46,7 @@ There is a basic visualizer based on graphviz, see
 
 There is an interactive viewer for OpenSpiel games called
 [SpielViz](https://github.com/michalsustr/spielviz).
+
+There is also [spielviz](https://github.com/kvr06-ai/spielviz), a standalone Python
+library (`pip install spielviz`) that renders game trees, information sets, and
+strategy profiles using matplotlib.


### PR DESCRIPTION
Adds a reference to [spielviz](https://github.com/kvr06-ai/spielviz) (`pip install spielviz`) in the visualization sections of `docs/intro.md` and `docs/contributing.md`.

spielviz is a standalone Python library that renders OpenSpiel game trees, information sets, and strategy profiles using matplotlib. It addresses the gap left by the unmaintained SpielViz project (ref: #1224).

No code changes — documentation only.