### PR TITLE
Add PPO self-play implementation for OpenSpiel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ Manifest.toml
 # IDE
 .idea/
 .vscode/
+.vs/
 *~
 
 # Visual Studio generated files

--- a/open_spiel/python/examples/ppo_benchmark_jax.py
+++ b/open_spiel/python/examples/ppo_benchmark_jax.py
@@ -1,0 +1,193 @@
+# Copyright 2019 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Benchmark PPO self-play across multiple OpenSpiel games.
+
+Runs PPO training on kuhn_poker, leduc_poker, and matrix_pd, collects metrics,
+and produces a comparison plot.
+
+Example usage:
+    python open_spiel/python/examples/ppo_benchmark_jax.py
+    python open_spiel/python/examples/ppo_benchmark_jax.py --num_iterations=500
+"""
+
+import os
+
+from absl import app
+from absl import flags
+from absl import logging
+import numpy as np
+
+from open_spiel.python import rl_environment
+from open_spiel.python.algorithms import exploitability
+from open_spiel.python.jax import ppo
+from open_spiel.python.jax import ppo_utils
+from open_spiel.python.rl_agent_policy import JointRLAgentPolicy
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_integer("num_iterations", 300,
+                     "Number of training iterations per game.")
+flags.DEFINE_integer("episodes_per_batch", 128,
+                     "Self-play episodes per training batch.")
+flags.DEFINE_integer("eval_every", 25,
+                     "Evaluate every N iterations.")
+flags.DEFINE_integer("num_eval_episodes", 500,
+                     "Episodes per evaluation.")
+flags.DEFINE_float("entropy_coef", 0.05,
+                   "Entropy coefficient (higher helps mixing in poker).")
+flags.DEFINE_integer("seed", 42, "Random seed.")
+flags.DEFINE_string("output_dir", "/tmp/ppo_benchmark",
+                    "Directory for saving plots.")
+
+BENCHMARK_GAMES = ["kuhn_poker", "leduc_poker", "matrix_pd"]
+
+
+def run_episode(env, agent, num_players):
+  """Run a single self-play episode, collecting training data."""
+  time_step = env.reset()
+  while not time_step.last():
+    if time_step.is_simultaneous_move():
+      actions = []
+      for pid in range(num_players):
+        output = agent.step(time_step, player_id=pid)
+        actions.append(output.action)
+      time_step = env.step(actions)
+    else:
+      output = agent.step(time_step)
+      time_step = env.step([output.action])
+    agent.post_step(time_step)
+  agent.step(time_step)
+  return list(time_step.rewards)
+
+
+def evaluate_returns(env, agent, num_episodes, num_players):
+  """Run evaluation episodes and return per-player average returns."""
+  total_returns = np.zeros(num_players)
+  for _ in range(num_episodes):
+    time_step = env.reset()
+    while not time_step.last():
+      if time_step.is_simultaneous_move():
+        actions = []
+        for pid in range(num_players):
+          out = agent.step(time_step, player_id=pid, is_evaluation=True)
+          actions.append(out.action)
+        time_step = env.step(actions)
+      else:
+        out = agent.step(time_step, is_evaluation=True)
+        time_step = env.step([out.action])
+    for pid in range(num_players):
+      total_returns[pid] += time_step.rewards[pid]
+  return total_returns / num_episodes
+
+
+def train_game(game_name):
+  """Train PPO on a single game, returning metrics."""
+  logging.info("=" * 60)
+  logging.info("Benchmarking: %s", game_name)
+  logging.info("=" * 60)
+
+  env = rl_environment.Environment(game_name)
+  info_state_size = env.observation_spec()["info_state"][0]
+  num_actions = env.action_spec()["num_actions"]
+  num_players = env.num_players
+
+  agent = ppo.PPO(
+      player_id=0,
+      info_state_size=info_state_size,
+      num_actions=num_actions,
+      gamma=1.0,
+      entropy_coef=FLAGS.entropy_coef,
+      seed=FLAGS.seed,
+  )
+
+  joint_policy = JointRLAgentPolicy(
+      env.game,
+      {pid: agent for pid in range(num_players)},
+      use_observation=env.use_observation,
+  )
+
+  tracker = ppo_utils.TrainingMetrics()
+
+  for iteration in range(1, FLAGS.num_iterations + 1):
+    for _ in range(FLAGS.episodes_per_batch):
+      run_episode(env, agent, num_players)
+    metrics = agent.learn()
+    tracker.record_train(iteration, metrics)
+
+    if iteration % FLAGS.eval_every == 0:
+      avg_returns = evaluate_returns(
+          env, agent, FLAGS.num_eval_episodes, num_players)
+      expl = exploitability.exploitability(env.game, joint_policy)
+      tracker.record_eval(iteration, expl, avg_returns)
+
+      logging.info("  [%s] iter=%d  expl=%.4f  entropy=%.4f  kl=%.4f",
+                   game_name, iteration, expl,
+                   metrics.get("entropy", 0), metrics.get("approx_kl", 0))
+
+  return tracker
+
+
+def plot_benchmark(all_metrics, output_dir):
+  """Generate a combined benchmark comparison plot."""
+  # pylint: disable=g-import-not-at-top
+  import matplotlib
+  matplotlib.use("Agg")
+  import matplotlib.pyplot as plt
+
+  fig, axes = plt.subplots(1, 3, figsize=(15, 4))
+  fig.suptitle("PPO Self-Play Benchmark", fontsize=14)
+
+  for i, (game, tracker) in enumerate(all_metrics.items()):
+    ax = axes[i]
+    if tracker.exploitability:
+      ax.plot(tracker.eval_iterations, tracker.exploitability, "o-",
+              markersize=3)
+    ax.set_title(game)
+    ax.set_xlabel("Iteration")
+    ax.set_ylabel("Exploitability")
+    ax.grid(True, alpha=0.3)
+
+  plt.tight_layout()
+  path = os.path.join(output_dir, "ppo_benchmark.png")
+  plt.savefig(path, dpi=150, bbox_inches="tight")
+  plt.close(fig)
+  logging.info("Benchmark plot saved to %s", path)
+
+  for game, tracker in all_metrics.items():
+    game_path = os.path.join(output_dir, f"ppo_{game}.png")
+    ppo_utils.plot_training_curves(tracker, game, save_path=game_path)
+    logging.info("Training curves saved to %s", game_path)
+
+
+def main(_):
+  os.makedirs(FLAGS.output_dir, exist_ok=True)
+
+  all_metrics = {}
+  for game in BENCHMARK_GAMES:
+    all_metrics[game] = train_game(game)
+
+  plot_benchmark(all_metrics, FLAGS.output_dir)
+
+  logging.info("-" * 60)
+  logging.info("Final results:")
+  for game, tracker in all_metrics.items():
+    if tracker.exploitability:
+      logging.info("  %s: final_expl=%.4f", game, tracker.exploitability[-1])
+
+  logging.info("Benchmark complete. Plots in %s", FLAGS.output_dir)
+
+
+if __name__ == "__main__":
+  app.run(main)

--- a/open_spiel/python/examples/ppo_example_jax.py
+++ b/open_spiel/python/examples/ppo_example_jax.py
@@ -1,0 +1,146 @@
+# Copyright 2019 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Self-play PPO training on OpenSpiel games using JAX.
+
+A single PPO agent controls all players, learning a strategy via self-play.
+Periodically evaluates exploitability as a convergence measure.
+
+Example usage:
+    python open_spiel/python/examples/ppo_example_jax.py --game=kuhn_poker
+    python open_spiel/python/examples/ppo_example_jax.py --game=leduc_poker
+"""
+
+from absl import app
+from absl import flags
+from absl import logging
+import numpy as np
+
+from open_spiel.python import rl_environment
+from open_spiel.python.algorithms import exploitability
+from open_spiel.python.jax import ppo
+from open_spiel.python.rl_agent_policy import JointRLAgentPolicy
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string("game", "kuhn_poker", "Name of the OpenSpiel game.")
+flags.DEFINE_integer("num_iterations", 1000,
+                     "Number of training iterations.")
+flags.DEFINE_integer("episodes_per_batch", 128,
+                     "Number of self-play episodes per training batch.")
+flags.DEFINE_integer("eval_every", 50,
+                     "Evaluate every N training iterations.")
+flags.DEFINE_integer("num_eval_episodes", 1000,
+                     "Number of episodes for evaluation.")
+
+# PPO hyperparameters.
+flags.DEFINE_float("learning_rate", 2.5e-4, "Adam learning rate.")
+flags.DEFINE_float("gamma", 1.0,
+                   "Discount factor (1.0 for short episodic games).")
+flags.DEFINE_float("gae_lambda", 0.95, "GAE lambda parameter.")
+flags.DEFINE_float("clip_coef", 0.2, "PPO clipping coefficient.")
+flags.DEFINE_float("entropy_coef", 0.01, "Entropy bonus coefficient.")
+flags.DEFINE_float("value_coef", 0.5, "Value loss coefficient.")
+flags.DEFINE_float("max_grad_norm", 0.5, "Max gradient norm for clipping.")
+flags.DEFINE_integer("update_epochs", 4, "PPO update epochs per batch.")
+flags.DEFINE_integer("num_minibatches", 4,
+                     "Number of minibatches per update epoch.")
+flags.DEFINE_list("hidden_sizes", ["64", "64"],
+                  "Hidden layer sizes for the actor-critic network.")
+flags.DEFINE_integer("seed", 42, "Random seed.")
+
+
+def evaluate_returns(env, agent, num_episodes):
+  """Run evaluation episodes and return per-player average returns."""
+  num_players = env.num_players
+  total_returns = np.zeros(num_players)
+  for _ in range(num_episodes):
+    time_step = env.reset()
+    while not time_step.last():
+      output = agent.step(time_step, is_evaluation=True)
+      time_step = env.step([output.action])
+    for pid in range(num_players):
+      total_returns[pid] += time_step.rewards[pid]
+  return total_returns / num_episodes
+
+
+def main(_):
+  np.random.seed(FLAGS.seed)
+
+  env = rl_environment.Environment(FLAGS.game)
+  info_state_size = env.observation_spec()["info_state"][0]
+  num_actions = env.action_spec()["num_actions"]
+  num_players = env.num_players
+
+  logging.info("Game: %s", FLAGS.game)
+  logging.info("Info state size: %d, Num actions: %d, Num players: %d",
+               info_state_size, num_actions, num_players)
+
+  hidden_sizes = [int(s) for s in FLAGS.hidden_sizes]
+
+  agent = ppo.PPO(
+      player_id=0,
+      info_state_size=info_state_size,
+      num_actions=num_actions,
+      hidden_sizes=hidden_sizes,
+      learning_rate=FLAGS.learning_rate,
+      gamma=FLAGS.gamma,
+      gae_lambda=FLAGS.gae_lambda,
+      clip_coef=FLAGS.clip_coef,
+      entropy_coef=FLAGS.entropy_coef,
+      value_coef=FLAGS.value_coef,
+      max_grad_norm=FLAGS.max_grad_norm,
+      update_epochs=FLAGS.update_epochs,
+      num_minibatches=FLAGS.num_minibatches,
+      seed=FLAGS.seed,
+  )
+
+  joint_policy = JointRLAgentPolicy(
+      env.game,
+      {pid: agent for pid in range(num_players)},
+      use_observation=env.use_observation,
+  )
+
+  for iteration in range(1, FLAGS.num_iterations + 1):
+    for _ in range(FLAGS.episodes_per_batch):
+      time_step = env.reset()
+      while not time_step.last():
+        output = agent.step(time_step)
+        time_step = env.step([output.action])
+        agent.post_step(time_step)
+      agent.step(time_step)
+
+    batch_steps = agent.buffer_size
+    metrics = agent.learn()
+
+    if iteration % FLAGS.eval_every == 0:
+      avg_returns = evaluate_returns(env, agent, FLAGS.num_eval_episodes)
+      expl = exploitability.exploitability(env.game, joint_policy)
+
+      logging.info("-" * 60)
+      logging.info("Iteration %d  |  batch_steps=%d", iteration, batch_steps)
+      logging.info("  policy_loss=%.6f  value_loss=%.6f  entropy=%.6f",
+                   metrics.get("policy_loss", 0),
+                   metrics.get("value_loss", 0),
+                   metrics.get("entropy", 0))
+      returns_str = "  ".join(
+          f"player_{p}={avg_returns[p]:.4f}" for p in range(num_players))
+      logging.info("  Avg returns: %s", returns_str)
+      logging.info("  Exploitability: %.6f", expl)
+
+  logging.info("Training complete.")
+
+
+if __name__ == "__main__":
+  app.run(main)

--- a/open_spiel/python/examples/ppo_example_jax.py
+++ b/open_spiel/python/examples/ppo_example_jax.py
@@ -15,11 +15,14 @@
 """Self-play PPO training on OpenSpiel games using JAX.
 
 A single PPO agent controls all players, learning a strategy via self-play.
-Periodically evaluates exploitability as a convergence measure.
+Supports both sequential (e.g. kuhn_poker) and simultaneous-move games
+(e.g. matrix_pd). Periodically evaluates exploitability as a convergence
+measure and stores metrics for plotting.
 
 Example usage:
     python open_spiel/python/examples/ppo_example_jax.py --game=kuhn_poker
     python open_spiel/python/examples/ppo_example_jax.py --game=leduc_poker
+    python open_spiel/python/examples/ppo_example_jax.py --game=matrix_pd
 """
 
 from absl import app
@@ -30,6 +33,7 @@ import numpy as np
 from open_spiel.python import rl_environment
 from open_spiel.python.algorithms import exploitability
 from open_spiel.python.jax import ppo
+from open_spiel.python.jax import ppo_utils
 from open_spiel.python.rl_agent_policy import JointRLAgentPolicy
 
 FLAGS = flags.FLAGS
@@ -59,25 +63,51 @@ flags.DEFINE_integer("num_minibatches", 4,
 flags.DEFINE_list("hidden_sizes", ["64", "64"],
                   "Hidden layer sizes for the actor-critic network.")
 flags.DEFINE_integer("seed", 42, "Random seed.")
+flags.DEFINE_string("plot_path", None,
+                    "If set, save training curve plot to this file path.")
 
 
-def evaluate_returns(env, agent, num_episodes):
+def run_episode(env, agent, num_players, is_evaluation=False):
+  """Run a single self-play episode, handling both sequential and simultaneous.
+
+  Args:
+    env: the OpenSpiel rl_environment.Environment.
+    agent: the PPO agent.
+    num_players: number of players in the game.
+    is_evaluation: if True, no data is collected.
+
+  Returns:
+    Per-player rewards as a list.
+  """
+  time_step = env.reset()
+  while not time_step.last():
+    if time_step.is_simultaneous_move():
+      actions = []
+      for pid in range(num_players):
+        output = agent.step(time_step, player_id=pid,
+                            is_evaluation=is_evaluation)
+        actions.append(output.action)
+      time_step = env.step(actions)
+    else:
+      output = agent.step(time_step, is_evaluation=is_evaluation)
+      time_step = env.step([output.action])
+    if not is_evaluation:
+      agent.post_step(time_step)
+  agent.step(time_step, is_evaluation=is_evaluation)
+  return list(time_step.rewards)
+
+
+def evaluate_returns(env, agent, num_episodes, num_players):
   """Run evaluation episodes and return per-player average returns."""
-  num_players = env.num_players
   total_returns = np.zeros(num_players)
   for _ in range(num_episodes):
-    time_step = env.reset()
-    while not time_step.last():
-      output = agent.step(time_step, is_evaluation=True)
-      time_step = env.step([output.action])
+    rewards = run_episode(env, agent, num_players, is_evaluation=True)
     for pid in range(num_players):
-      total_returns[pid] += time_step.rewards[pid]
+      total_returns[pid] += rewards[pid]
   return total_returns / num_episodes
 
 
 def main(_):
-  np.random.seed(FLAGS.seed)
-
   env = rl_environment.Environment(FLAGS.game)
   info_state_size = env.observation_spec()["info_state"][0]
   num_actions = env.action_spec()["num_actions"]
@@ -112,34 +142,40 @@ def main(_):
       use_observation=env.use_observation,
   )
 
+  tracker = ppo_utils.TrainingMetrics()
+
   for iteration in range(1, FLAGS.num_iterations + 1):
     for _ in range(FLAGS.episodes_per_batch):
-      time_step = env.reset()
-      while not time_step.last():
-        output = agent.step(time_step)
-        time_step = env.step([output.action])
-        agent.post_step(time_step)
-      agent.step(time_step)
+      run_episode(env, agent, num_players)
 
     batch_steps = agent.buffer_size
     metrics = agent.learn()
+    tracker.record_train(iteration, metrics)
 
     if iteration % FLAGS.eval_every == 0:
-      avg_returns = evaluate_returns(env, agent, FLAGS.num_eval_episodes)
+      avg_returns = evaluate_returns(
+          env, agent, FLAGS.num_eval_episodes, num_players)
       expl = exploitability.exploitability(env.game, joint_policy)
+      tracker.record_eval(iteration, expl, avg_returns)
 
       logging.info("-" * 60)
       logging.info("Iteration %d  |  batch_steps=%d", iteration, batch_steps)
-      logging.info("  policy_loss=%.6f  value_loss=%.6f  entropy=%.6f",
-                   metrics.get("policy_loss", 0),
-                   metrics.get("value_loss", 0),
-                   metrics.get("entropy", 0))
+      logging.info(
+          "  policy_loss=%.6f  value_loss=%.6f  entropy=%.6f  approx_kl=%.6f",
+          metrics.get("policy_loss", 0),
+          metrics.get("value_loss", 0),
+          metrics.get("entropy", 0),
+          metrics.get("approx_kl", 0))
       returns_str = "  ".join(
           f"player_{p}={avg_returns[p]:.4f}" for p in range(num_players))
       logging.info("  Avg returns: %s", returns_str)
       logging.info("  Exploitability: %.6f", expl)
 
   logging.info("Training complete.")
+
+  if FLAGS.plot_path:
+    ppo_utils.plot_training_curves(tracker, FLAGS.game, FLAGS.plot_path)
+    logging.info("Plot saved to %s", FLAGS.plot_path)
 
 
 if __name__ == "__main__":

--- a/open_spiel/python/jax/README_PPO.md
+++ b/open_spiel/python/jax/README_PPO.md
@@ -1,0 +1,189 @@
+# PPO Self-Play Agent (JAX)
+
+A JAX implementation of Proximal Policy Optimization (PPO) for OpenSpiel games
+with self-play support.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `open_spiel/python/jax/ppo.py` | PPO agent, actor-critic network, rollout buffer |
+| `open_spiel/python/jax/ppo_utils.py` | Vectorized GAE, metrics tracking, plotting |
+| `open_spiel/python/examples/ppo_example_jax.py` | Training script (single game) |
+| `open_spiel/python/examples/ppo_benchmark_jax.py` | Multi-game benchmark with plots |
+| `open_spiel/python/jax/ppo_jax_test.py` | Unit tests |
+
+## Quick Start
+
+```bash
+# Train on Kuhn Poker
+python -m open_spiel.python.examples.ppo_example_jax --game=kuhn_poker
+
+# Train with higher entropy (better for mixed strategies)
+python -m open_spiel.python.examples.ppo_example_jax \
+    --game=kuhn_poker --entropy_coef=0.1 --num_iterations=500
+
+# Train on a simultaneous game
+python -m open_spiel.python.examples.ppo_example_jax --game=matrix_pd
+
+# Run benchmarks across all games
+python -m open_spiel.python.examples.ppo_benchmark_jax
+
+# Run unit tests
+python -m open_spiel.python.jax.ppo_jax_test
+```
+
+## Algorithm
+
+### PPO (Proximal Policy Optimization)
+
+PPO (Schulman et al., 2017) is an on-policy actor-critic algorithm that
+optimizes a clipped surrogate objective to prevent destructively large policy
+updates:
+
+```
+L_clip = E[ min(r(theta) * A, clip(r(theta), 1-eps, 1+eps) * A) ]
+```
+
+where `r(theta) = pi_new(a|s) / pi_old(a|s)` is the probability ratio and `A`
+is the advantage estimate. The total loss combines:
+
+- **Policy loss**: clipped surrogate objective
+- **Value loss**: MSE between predicted values and returns
+- **Entropy bonus**: encourages exploration (critical for mixed strategies)
+
+### GAE (Generalized Advantage Estimation)
+
+GAE (Schulman et al., 2016) computes advantages by blending TD residuals with an
+exponentially decaying weight:
+
+```
+delta_t = r_t + gamma * V(s_{t+1}) * (1 - done_t) - V(s_t)
+A_t     = delta_t + (gamma * lambda) * (1 - done_t) * A_{t+1}
+```
+
+#### Vectorized Implementation via jax.lax.scan
+
+The naive implementation uses a Python for-loop in reverse time order. This
+module replaces it with `jax.lax.scan(reverse=True)`:
+
+```python
+def _scan_step(last_gae, x):
+    reward, value, next_value, done = x
+    non_terminal = 1.0 - done
+    delta = reward + gamma * next_value * non_terminal - value
+    new_gae = delta + gamma * gae_lambda * non_terminal * last_gae
+    return new_gae, new_gae
+
+_, advantages = jax.lax.scan(
+    _scan_step, jnp.float32(0.0),
+    (rewards, values, next_values, dones),
+    reverse=True)
+```
+
+Benefits:
+- **No Python loops**: the scan body compiles to a single XLA while-loop
+- **JIT-compatible**: can be wrapped in `jax.jit` for tracing and compilation
+- **Functional**: pure function with no side effects or mutations
+
+## JAX Design Choices
+
+### PRNG Key Threading
+
+All randomness uses `jax.random` with explicit key management. The agent
+maintains a PRNG state `self._rng` and splits it for each random operation:
+
+```python
+def _next_rng(self) -> chex.PRNGKey:
+    self._rng, subkey = jax.random.split(self._rng)
+    return subkey
+
+# Action sampling
+action = jax.random.categorical(self._next_rng(), masked_logits)
+
+# Minibatch shuffling
+perm = jax.random.permutation(self._next_rng(), batch_size)
+```
+
+This ensures:
+- Full reproducibility given the same seed
+- No dependency on `numpy.random` global state
+- Compatibility with JAX transformations (jit, vmap, etc.)
+
+### JIT Compilation
+
+The PPO loss and gradient update are JIT-compiled via the Flax NNX
+`graphdef`/`merge` pattern:
+
+```python
+@jax.jit
+def update(state, obs, actions, ...):
+    network, optimizer = nn.merge(graphdef, state, copy=True)
+    (loss, aux), grads = nn.value_and_grad(loss_fn, has_aux=True)(network, ...)
+    optimizer.update(network, grads)
+    return loss, aux, nn.state((network, optimizer))
+```
+
+Hyperparameters (clip_coef, value_coef, entropy_coef) are captured as closure
+constants so they don't cause recompilation.
+
+### JAX Arrays Everywhere
+
+All data paths use `jnp` arrays:
+- Observations and legal masks are converted to `jnp` in `step()`
+- The rollout buffer converts to `jnp` via `as_jnp()` before training
+- GAE computation is pure `jnp` + `jax.lax.scan`
+- Minibatch indexing uses `jax.random.permutation`
+
+## Self-Play
+
+A single PPO agent instance controls all players. For sequential games, the
+agent reads `time_step.current_player()` to determine which player's observation
+to use. For simultaneous games, `step()` accepts a `player_id` parameter.
+
+Per-player trajectories are tracked separately in `_episode_data`. At episode
+boundaries, GAE is computed independently for each player's trajectory, then all
+transitions are added to a shared rollout buffer for the PPO update.
+
+## Benchmark Results
+
+Tested on: `kuhn_poker`, `leduc_poker`, `matrix_pd`
+
+### Kuhn Poker (best: `--entropy_coef=0.1`)
+
+| Metric | Value |
+|--------|-------|
+| Best exploitability | ~0.22 |
+| Final entropy | ~0.14 |
+| Game value (P0) | ~-0.056 (theory: -1/18) |
+
+### Expected Behavior
+
+- **Exploitability** does not converge to zero. PPO is a single-policy gradient
+  method and lacks convergence guarantees in imperfect-information games. CFR
+  reaches near-zero exploitability in seconds for these games.
+- **Entropy** tends to collapse without sufficient `entropy_coef`. Higher values
+  (0.05-0.1) help maintain the mixed strategies required for Nash equilibrium.
+- **Average returns** for both players should be near the game value, confirming
+  the self-play mechanics work correctly.
+
+### Generating Plots
+
+```bash
+python -m open_spiel.python.examples.ppo_benchmark_jax \
+    --output_dir=/tmp/ppo_benchmark --num_iterations=500
+
+# Individual game with plot
+python -m open_spiel.python.examples.ppo_example_jax \
+    --game=kuhn_poker --plot_path=kuhn_training.png
+```
+
+## Dependencies
+
+Same as existing JAX agents in OpenSpiel -- no new packages:
+
+- `jax`, `jax.numpy`
+- `flax.nnx` (Flax NNX API)
+- `optax` (optimizer, gradient clipping)
+- `chex` (type checking)
+- `matplotlib` (optional, for plotting only)

--- a/open_spiel/python/jax/ppo.py
+++ b/open_spiel/python/jax/ppo.py
@@ -1,0 +1,463 @@
+# Copyright 2019 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PPO (Proximal Policy Optimization) agent implemented in JAX.
+
+This module implements the clipped PPO algorithm (Schulman et al., 2017) using
+Flax NNX for the neural network and optax for optimization. The agent supports
+self-play in multi-agent turn-based games: a single agent instance controls all
+players by reading the current player from each time_step. Per-player
+trajectories are tracked internally and GAE (Generalized Advantage Estimation)
+is computed per-player at episode boundaries.
+
+Supported games include any OpenSpiel sequential game accessible through
+rl_environment.Environment, e.g. kuhn_poker and leduc_poker.
+
+Note: PPO is a single-policy gradient method and does not have convergence
+guarantees in imperfect-information games. For such games, algorithms like CFR
+will achieve lower exploitability. This implementation is intended as a clean
+reference example for policy gradient methods on OpenSpiel.
+
+See open_spiel/python/examples/ppo_example_jax.py for a usage example.
+"""
+
+import collections
+from typing import Iterable
+
+import chex
+import flax.nnx as nn
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+
+from open_spiel.python import rl_agent
+
+ILLEGAL_ACTION_LOGITS_PENALTY = jnp.finfo(jnp.float32).min
+
+
+class ActorCriticNetwork(nn.Module):
+  """Actor-critic network with a shared trunk, policy head, and value head.
+
+  Architecture:
+    trunk:  [Linear(hidden) -> tanh] * len(hidden_sizes)
+    policy: Linear(num_actions), orthogonal init std=0.01
+    value:  Linear(1), orthogonal init std=1.0
+  """
+
+  def __init__(
+      self,
+      input_size: int,
+      num_actions: int,
+      hidden_sizes: Iterable[int] = (64, 64),
+      seed: int = 0,
+  ):
+    rngs = nn.Rngs(seed)
+    ortho = nn.initializers.orthogonal
+
+    layers = []
+    in_size = input_size
+    for h_size in hidden_sizes:
+      layers.append(
+          nn.Linear(
+              in_size, h_size, kernel_init=ortho(jnp.sqrt(2)), rngs=rngs))
+      layers.append(jax.nn.tanh)
+      in_size = h_size
+    self.trunk = nn.Sequential(*layers)
+
+    self.policy_head = nn.Linear(
+        in_size, num_actions, kernel_init=ortho(0.01), rngs=rngs)
+    self.value_head = nn.Linear(
+        in_size, 1, kernel_init=ortho(1.0), rngs=rngs)
+
+  def __call__(self, x: chex.Array) -> tuple[chex.Array, chex.Array]:
+    hidden = self.trunk(x)
+    logits = self.policy_head(hidden)
+    value = jnp.squeeze(self.value_head(hidden), axis=-1)
+    return logits, value
+
+
+class RolloutBuffer:
+  """Stores processed PPO rollout data consumed during learning.
+
+  Transitions are appended during episode collection (after GAE computation)
+  and converted to JAX arrays for the PPO update.
+  """
+
+  def __init__(self):
+    self.clear()
+
+  def clear(self):
+    """Reset all stored data."""
+    self.observations = []
+    self.actions = []
+    self.log_probs = []
+    self.values = []
+    self.advantages = []
+    self.returns = []
+    self.legal_masks = []
+
+  @property
+  def size(self) -> int:
+    return len(self.observations)
+
+  def add(self, obs, action, log_prob, value, advantage, ret, legal_mask):
+    """Append a single processed transition to the buffer."""
+    self.observations.append(obs)
+    self.actions.append(action)
+    self.log_probs.append(log_prob)
+    self.values.append(value)
+    self.advantages.append(advantage)
+    self.returns.append(ret)
+    self.legal_masks.append(legal_mask)
+
+  def as_jnp(self) -> dict[str, chex.Array]:
+    """Convert buffer contents to JAX arrays for training."""
+    return {
+        "observations": jnp.array(self.observations),
+        "actions": jnp.array(self.actions, dtype=jnp.int32),
+        "log_probs": jnp.array(self.log_probs, dtype=jnp.float32),
+        "advantages": jnp.array(self.advantages, dtype=jnp.float32),
+        "returns": jnp.array(self.returns, dtype=jnp.float32),
+        "legal_masks": jnp.array(self.legal_masks),
+    }
+
+
+def compute_gae(transitions, gamma, gae_lambda):
+  """Compute GAE advantages and returns for a single-player trajectory.
+
+  Each player's sequence of decisions within one episode forms a trajectory.
+  The last transition is terminal (bootstrapped value = 0).
+
+  Args:
+    transitions: list of dicts with keys 'value' and 'reward'.
+    gamma: discount factor.
+    gae_lambda: GAE lambda parameter.
+
+  Returns:
+    Tuple of (advantages, returns), each np.ndarray of shape (n,).
+  """
+  n = len(transitions)
+  advantages = np.zeros(n, dtype=np.float32)
+  last_gae = 0.0
+  for t in reversed(range(n)):
+    if t == n - 1:
+      next_value = 0.0
+      non_terminal = 0.0
+    else:
+      next_value = transitions[t + 1]["value"]
+      non_terminal = 1.0
+    delta = (transitions[t]["reward"]
+             + gamma * next_value * non_terminal
+             - transitions[t]["value"])
+    last_gae = delta + gamma * gae_lambda * non_terminal * last_gae
+    advantages[t] = last_gae
+  values = np.array([t["value"] for t in transitions], dtype=np.float32)
+  returns = advantages + values
+  return advantages, returns
+
+
+class PPO(rl_agent.AbstractAgent):
+  """PPO Agent implemented in JAX with Flax NNX.
+
+  Supports self-play: a single agent instance controls all players in a
+  turn-based game by reading the current player from each time_step.
+  Per-player trajectories are tracked internally and GAE is computed
+  per-player at episode boundaries.
+
+  Typical usage (self-play):
+
+    agent = PPO(player_id=0, info_state_size=11, num_actions=4)
+    for _ in range(num_iterations):
+        for _ in range(episodes_per_batch):
+            time_step = env.reset()
+            while not time_step.last():
+                output = agent.step(time_step)
+                time_step = env.step([output.action])
+                agent.post_step(time_step)
+            agent.step(time_step)
+        metrics = agent.learn()
+  """
+
+  # pylint: disable=g-bare-generic
+
+  def __init__(
+      self,
+      player_id: int,
+      info_state_size: int,
+      num_actions: int,
+      hidden_sizes: Iterable[int] = (64, 64),
+      update_epochs: int = 4,
+      num_minibatches: int = 4,
+      learning_rate: float = 2.5e-4,
+      gamma: float = 0.99,
+      gae_lambda: float = 0.95,
+      clip_coef: float = 0.2,
+      entropy_coef: float = 0.01,
+      value_coef: float = 0.5,
+      max_grad_norm: float = 0.5,
+      normalize_advantages: bool = True,
+      seed: int = 42,
+  ):
+    """Initialize the PPO agent.
+
+    Args:
+      player_id: integer player id (used by AbstractAgent interface).
+      info_state_size: length of the flattened observation tensor.
+      num_actions: total number of distinct actions in the game.
+      hidden_sizes: widths of hidden layers in the actor-critic trunk.
+      update_epochs: number of passes over the rollout data per learn() call.
+      num_minibatches: number of minibatches to split the data into.
+      learning_rate: Adam learning rate.
+      gamma: discount factor.
+      gae_lambda: GAE lambda parameter.
+      clip_coef: PPO clipping coefficient (epsilon).
+      entropy_coef: entropy bonus coefficient.
+      value_coef: value loss coefficient.
+      max_grad_norm: maximum gradient norm for clipping.
+      normalize_advantages: whether to normalize advantages per minibatch.
+      seed: random seed.
+    """
+    self.player_id = player_id
+    self._num_actions = num_actions
+    self._info_state_size = info_state_size
+
+    self._gamma = gamma
+    self._gae_lambda = gae_lambda
+    self._clip_coef = clip_coef
+    self._entropy_coef = entropy_coef
+    self._value_coef = value_coef
+    self._update_epochs = update_epochs
+    self._num_minibatches = num_minibatches
+    self._max_grad_norm = max_grad_norm
+    self._normalize_advantages = normalize_advantages
+
+    self._rng = jax.random.key(seed)
+
+    self._network = ActorCriticNetwork(
+        info_state_size, num_actions, tuple(hidden_sizes), seed=seed)
+
+    optimizer = optax.chain(
+        optax.clip_by_global_norm(max_grad_norm),
+        optax.adam(learning_rate, eps=1e-5),
+    )
+    self._optimizer = nn.Optimizer(self._network, optimizer, wrt=nn.Param)
+
+    self._graphdef = nn.graphdef((self._network, self._optimizer))
+    self._jit_update = self._build_jit_update()
+
+    self._buffer = RolloutBuffer()
+
+    # Per-player episode tracking for self-play GAE computation.
+    self._episode_data = collections.defaultdict(list)
+    self._pending_rewards = collections.defaultdict(float)
+
+  def _next_rng(self) -> chex.PRNGKey:
+    """Split and return the next PRNG subkey."""
+    self._rng, subkey = jax.random.split(self._rng)
+    return subkey
+
+  def step(self, time_step, is_evaluation=False) -> rl_agent.StepOutput:
+    """Select an action given a time_step.
+
+    Reads the current player from the time_step so a single agent can handle
+    all players (self-play). At terminal states, processes the completed
+    episode and returns a None action.
+
+    Args:
+      time_step: an instance of rl_environment.TimeStep.
+      is_evaluation: if True, skips data collection.
+
+    Returns:
+      A StepOutput with the chosen action and action probabilities.
+    """
+    if time_step.last():
+      if not is_evaluation:
+        self._process_episode_end()
+      return rl_agent.StepOutput(action=None, probs=[])
+
+    current_player = time_step.current_player()
+    obs = np.array(
+        time_step.observations["info_state"][current_player], dtype=np.float32)
+    legal_actions = time_step.observations["legal_actions"][current_player]
+
+    legal_mask = np.zeros(self._num_actions, dtype=np.bool_)
+    legal_mask[legal_actions] = True
+
+    logits, value = self._network(jnp.array(obs))
+    masked_logits = jnp.where(
+        jnp.array(legal_mask), logits, ILLEGAL_ACTION_LOGITS_PENALTY)
+    probs = jax.nn.softmax(masked_logits)
+    log_probs_all = jax.nn.log_softmax(masked_logits)
+
+    action = int(jax.random.categorical(self._next_rng(), masked_logits))
+
+    if not is_evaluation:
+      self._episode_data[current_player].append({
+          "obs": obs,
+          "action": action,
+          "log_prob": float(log_probs_all[action]),
+          "value": float(value),
+          "legal_mask": legal_mask,
+          "reward": self._pending_rewards[current_player],
+      })
+      self._pending_rewards[current_player] = 0.0
+
+    return rl_agent.StepOutput(action=action, probs=np.array(probs))
+
+  def post_step(self, time_step):
+    """Record per-player rewards after an environment step.
+
+    Must be called after env.step() and before the next agent.step().
+
+    Args:
+      time_step: the TimeStep returned by env.step().
+    """
+    if time_step.rewards is not None:
+      for pid in range(len(time_step.rewards)):
+        self._pending_rewards[pid] += time_step.rewards[pid]
+
+  def _process_episode_end(self):
+    """Compute per-player GAE and flush episode data into the buffer."""
+    for pid, transitions in self._episode_data.items():
+      if not transitions:
+        continue
+      transitions[-1]["reward"] += self._pending_rewards.get(pid, 0.0)
+
+      advantages, returns = compute_gae(
+          transitions, self._gamma, self._gae_lambda)
+
+      for t, trans in enumerate(transitions):
+        self._buffer.add(
+            obs=trans["obs"],
+            action=trans["action"],
+            log_prob=trans["log_prob"],
+            value=trans["value"],
+            advantage=float(advantages[t]),
+            ret=float(returns[t]),
+            legal_mask=trans["legal_mask"],
+        )
+
+    self._episode_data.clear()
+    self._pending_rewards.clear()
+
+  def learn(self) -> dict[str, float]:
+    """Perform PPO clipped update on collected rollout data.
+
+    Returns:
+      Dictionary of average training metrics (policy_loss, value_loss,
+      entropy) over all minibatch updates.
+    """
+    if self._buffer.size == 0:
+      return {}
+
+    data = self._buffer.as_jnp()
+    batch_size = self._buffer.size
+    minibatch_size = max(1, batch_size // self._num_minibatches)
+
+    state = nn.state((self._network, self._optimizer))
+
+    total_pg_loss = 0.0
+    total_v_loss = 0.0
+    total_ent_loss = 0.0
+    num_updates = 0
+
+    for _ in range(self._update_epochs):
+      perm = np.random.permutation(batch_size)
+      for start in range(0, batch_size - minibatch_size + 1, minibatch_size):
+        mb_idx = jnp.array(perm[start:start + minibatch_size])
+
+        mb_adv = data["advantages"][mb_idx]
+        if self._normalize_advantages:
+          mb_adv = (mb_adv - mb_adv.mean()) / (mb_adv.std() + 1e-8)
+
+        loss, (pg_loss, v_loss, ent_loss), state = self._jit_update(
+            state,
+            data["observations"][mb_idx],
+            data["actions"][mb_idx],
+            data["log_probs"][mb_idx],
+            mb_adv,
+            data["returns"][mb_idx],
+            data["legal_masks"][mb_idx],
+        )
+
+        total_pg_loss += float(pg_loss)
+        total_v_loss += float(v_loss)
+        total_ent_loss += float(ent_loss)
+        num_updates += 1
+
+    nn.update((self._network, self._optimizer), state)
+    self._buffer.clear()
+
+    n = max(num_updates, 1)
+    return {
+        "policy_loss": total_pg_loss / n,
+        "value_loss": total_v_loss / n,
+        "entropy": total_ent_loss / n,
+    }
+
+  def _build_jit_update(self):
+    """Build JIT-compiled PPO minibatch update function."""
+    graphdef = self._graphdef
+    clip_coef = self._clip_coef
+    value_coef = self._value_coef
+    entropy_coef = self._entropy_coef
+
+    def _loss_fn(network, obs, actions, old_log_probs, advantages, returns,
+                 legal_masks):
+      logits, values = network(obs)
+      masked_logits = jnp.where(
+          legal_masks, logits, ILLEGAL_ACTION_LOGITS_PENALTY)
+      log_probs_all = jax.nn.log_softmax(masked_logits)
+      new_log_probs = log_probs_all[jnp.arange(actions.shape[0]), actions]
+
+      probs = jax.nn.softmax(masked_logits)
+      entropy = -jnp.sum(
+          jnp.where(legal_masks, probs * log_probs_all, 0.0), axis=-1)
+
+      ratio = jnp.exp(new_log_probs - old_log_probs)
+      pg_loss1 = -advantages * ratio
+      pg_loss2 = -advantages * jnp.clip(
+          ratio, 1.0 - clip_coef, 1.0 + clip_coef)
+      pg_loss = jnp.maximum(pg_loss1, pg_loss2).mean()
+
+      v_loss = 0.5 * jnp.mean((values - returns) ** 2)
+      ent_loss = entropy.mean()
+
+      total_loss = pg_loss + value_coef * v_loss - entropy_coef * ent_loss
+      return total_loss, (pg_loss, v_loss, ent_loss)
+
+    @jax.jit
+    def update(state, obs, actions, old_log_probs, advantages, returns,
+               legal_masks):
+      network, optimizer = nn.merge(graphdef, state, copy=True)
+      (loss, aux), grads = nn.value_and_grad(_loss_fn, has_aux=True)(
+          network, obs, actions, old_log_probs, advantages, returns,
+          legal_masks)
+      optimizer.update(network, grads)
+      return loss, aux, nn.state((network, optimizer))
+
+    return update
+
+  @property
+  def network(self) -> ActorCriticNetwork:
+    return self._network
+
+  @property
+  def buffer_size(self) -> int:
+    return self._buffer.size
+
+  @property
+  def num_actions(self) -> int:
+    return self._num_actions

--- a/open_spiel/python/jax/ppo.py
+++ b/open_spiel/python/jax/ppo.py
@@ -21,8 +21,15 @@ players by reading the current player from each time_step. Per-player
 trajectories are tracked internally and GAE (Generalized Advantage Estimation)
 is computed per-player at episode boundaries.
 
-Supported games include any OpenSpiel sequential game accessible through
-rl_environment.Environment, e.g. kuhn_poker and leduc_poker.
+Key design choices:
+  - Vectorized GAE via jax.lax.scan (see ppo_utils.compute_gae).
+  - All randomness uses jax.random with explicit PRNG key threading.
+  - The PPO loss function is JIT-compiled via the Flax NNX graphdef/merge
+    pattern (same approach as open_spiel/python/jax/dqn.py).
+  - Simultaneous-move games are supported via the player_id parameter in step().
+
+Supported games include any OpenSpiel sequential or simultaneous game accessible
+through rl_environment.Environment, e.g. kuhn_poker, leduc_poker, matrix_pd.
 
 Note: PPO is a single-policy gradient method and does not have convergence
 guarantees in imperfect-information games. For such games, algorithms like CFR
@@ -43,6 +50,7 @@ import numpy as np
 import optax
 
 from open_spiel.python import rl_agent
+from open_spiel.python.jax import ppo_utils
 
 ILLEGAL_ACTION_LOGITS_PENALTY = jnp.finfo(jnp.float32).min
 
@@ -54,6 +62,8 @@ class ActorCriticNetwork(nn.Module):
     trunk:  [Linear(hidden) -> tanh] * len(hidden_sizes)
     policy: Linear(num_actions), orthogonal init std=0.01
     value:  Linear(1), orthogonal init std=1.0
+
+  Handles both single observations (unbatched) and batched inputs.
   """
 
   def __init__(
@@ -134,49 +144,18 @@ class RolloutBuffer:
     }
 
 
-def compute_gae(transitions, gamma, gae_lambda):
-  """Compute GAE advantages and returns for a single-player trajectory.
-
-  Each player's sequence of decisions within one episode forms a trajectory.
-  The last transition is terminal (bootstrapped value = 0).
-
-  Args:
-    transitions: list of dicts with keys 'value' and 'reward'.
-    gamma: discount factor.
-    gae_lambda: GAE lambda parameter.
-
-  Returns:
-    Tuple of (advantages, returns), each np.ndarray of shape (n,).
-  """
-  n = len(transitions)
-  advantages = np.zeros(n, dtype=np.float32)
-  last_gae = 0.0
-  for t in reversed(range(n)):
-    if t == n - 1:
-      next_value = 0.0
-      non_terminal = 0.0
-    else:
-      next_value = transitions[t + 1]["value"]
-      non_terminal = 1.0
-    delta = (transitions[t]["reward"]
-             + gamma * next_value * non_terminal
-             - transitions[t]["value"])
-    last_gae = delta + gamma * gae_lambda * non_terminal * last_gae
-    advantages[t] = last_gae
-  values = np.array([t["value"] for t in transitions], dtype=np.float32)
-  returns = advantages + values
-  return advantages, returns
-
-
 class PPO(rl_agent.AbstractAgent):
   """PPO Agent implemented in JAX with Flax NNX.
 
   Supports self-play: a single agent instance controls all players in a
   turn-based game by reading the current player from each time_step.
   Per-player trajectories are tracked internally and GAE is computed
-  per-player at episode boundaries.
+  per-player at episode boundaries using jax.lax.scan.
 
-  Typical usage (self-play):
+  For simultaneous-move games (e.g. matrix_pd), pass player_id explicitly
+  to step() for each player.
+
+  Typical usage (self-play, sequential game):
 
     agent = PPO(player_id=0, info_state_size=11, num_actions=4)
     for _ in range(num_iterations):
@@ -268,15 +247,21 @@ class PPO(rl_agent.AbstractAgent):
     self._rng, subkey = jax.random.split(self._rng)
     return subkey
 
-  def step(self, time_step, is_evaluation=False) -> rl_agent.StepOutput:
+  def step(self, time_step, player_id=None,
+           is_evaluation=False) -> rl_agent.StepOutput:
     """Select an action given a time_step.
 
     Reads the current player from the time_step so a single agent can handle
     all players (self-play). At terminal states, processes the completed
     episode and returns a None action.
 
+    For simultaneous-move games, pass player_id explicitly since
+    time_step.current_player() returns the SIMULTANEOUS sentinel.
+
     Args:
       time_step: an instance of rl_environment.TimeStep.
+      player_id: override for the acting player (required for simultaneous
+        games, optional for sequential games).
       is_evaluation: if True, skips data collection.
 
     Returns:
@@ -287,17 +272,17 @@ class PPO(rl_agent.AbstractAgent):
         self._process_episode_end()
       return rl_agent.StepOutput(action=None, probs=[])
 
-    current_player = time_step.current_player()
-    obs = np.array(
-        time_step.observations["info_state"][current_player], dtype=np.float32)
+    current_player = (player_id if player_id is not None
+                      else time_step.current_player())
+    obs = jnp.array(
+        time_step.observations["info_state"][current_player], dtype=jnp.float32)
     legal_actions = time_step.observations["legal_actions"][current_player]
 
-    legal_mask = np.zeros(self._num_actions, dtype=np.bool_)
-    legal_mask[legal_actions] = True
+    legal_mask = jnp.zeros(self._num_actions, dtype=jnp.bool_)
+    legal_mask = legal_mask.at[jnp.array(legal_actions)].set(True)
 
-    logits, value = self._network(jnp.array(obs))
-    masked_logits = jnp.where(
-        jnp.array(legal_mask), logits, ILLEGAL_ACTION_LOGITS_PENALTY)
+    logits, value = self._network(obs)
+    masked_logits = jnp.where(legal_mask, logits, ILLEGAL_ACTION_LOGITS_PENALTY)
     probs = jax.nn.softmax(masked_logits)
     log_probs_all = jax.nn.log_softmax(masked_logits)
 
@@ -305,16 +290,16 @@ class PPO(rl_agent.AbstractAgent):
 
     if not is_evaluation:
       self._episode_data[current_player].append({
-          "obs": obs,
+          "obs": np.asarray(obs),
           "action": action,
           "log_prob": float(log_probs_all[action]),
           "value": float(value),
-          "legal_mask": legal_mask,
+          "legal_mask": np.asarray(legal_mask),
           "reward": self._pending_rewards[current_player],
       })
       self._pending_rewards[current_player] = 0.0
 
-    return rl_agent.StepOutput(action=action, probs=np.array(probs))
+    return rl_agent.StepOutput(action=action, probs=np.asarray(probs))
 
   def post_step(self, time_step):
     """Record per-player rewards after an environment step.
@@ -329,14 +314,19 @@ class PPO(rl_agent.AbstractAgent):
         self._pending_rewards[pid] += time_step.rewards[pid]
 
   def _process_episode_end(self):
-    """Compute per-player GAE and flush episode data into the buffer."""
+    """Compute per-player GAE via jax.lax.scan and flush into the buffer."""
     for pid, transitions in self._episode_data.items():
       if not transitions:
         continue
       transitions[-1]["reward"] += self._pending_rewards.get(pid, 0.0)
 
-      advantages, returns = compute_gae(
-          transitions, self._gamma, self._gae_lambda)
+      n = len(transitions)
+      rewards = jnp.array([t["reward"] for t in transitions], dtype=jnp.float32)
+      values = jnp.array([t["value"] for t in transitions], dtype=jnp.float32)
+      dones = jnp.zeros(n, dtype=jnp.float32).at[n - 1].set(1.0)
+
+      advantages, returns = ppo_utils.compute_gae(
+          rewards, values, dones, self._gamma, self._gae_lambda)
 
       for t, trans in enumerate(transitions):
         self._buffer.add(
@@ -355,9 +345,12 @@ class PPO(rl_agent.AbstractAgent):
   def learn(self) -> dict[str, float]:
     """Perform PPO clipped update on collected rollout data.
 
+    All randomness (minibatch shuffling) uses jax.random with explicit key
+    splitting from the agent's PRNG state.
+
     Returns:
       Dictionary of average training metrics (policy_loss, value_loss,
-      entropy) over all minibatch updates.
+      entropy, approx_kl) over all minibatch updates.
     """
     if self._buffer.size == 0:
       return {}
@@ -371,30 +364,33 @@ class PPO(rl_agent.AbstractAgent):
     total_pg_loss = 0.0
     total_v_loss = 0.0
     total_ent_loss = 0.0
+    total_kl = 0.0
     num_updates = 0
 
     for _ in range(self._update_epochs):
-      perm = np.random.permutation(batch_size)
+      perm = jax.random.permutation(self._next_rng(), batch_size)
       for start in range(0, batch_size - minibatch_size + 1, minibatch_size):
-        mb_idx = jnp.array(perm[start:start + minibatch_size])
+        mb_idx = perm[start:start + minibatch_size]
 
         mb_adv = data["advantages"][mb_idx]
         if self._normalize_advantages:
           mb_adv = (mb_adv - mb_adv.mean()) / (mb_adv.std() + 1e-8)
 
-        loss, (pg_loss, v_loss, ent_loss), state = self._jit_update(
-            state,
-            data["observations"][mb_idx],
-            data["actions"][mb_idx],
-            data["log_probs"][mb_idx],
-            mb_adv,
-            data["returns"][mb_idx],
-            data["legal_masks"][mb_idx],
-        )
+        loss, (pg_loss, v_loss, ent_loss, approx_kl), state = (
+            self._jit_update(
+                state,
+                data["observations"][mb_idx],
+                data["actions"][mb_idx],
+                data["log_probs"][mb_idx],
+                mb_adv,
+                data["returns"][mb_idx],
+                data["legal_masks"][mb_idx],
+            ))
 
         total_pg_loss += float(pg_loss)
         total_v_loss += float(v_loss)
         total_ent_loss += float(ent_loss)
+        total_kl += float(approx_kl)
         num_updates += 1
 
     nn.update((self._network, self._optimizer), state)
@@ -405,10 +401,16 @@ class PPO(rl_agent.AbstractAgent):
         "policy_loss": total_pg_loss / n,
         "value_loss": total_v_loss / n,
         "entropy": total_ent_loss / n,
+        "approx_kl": total_kl / n,
     }
 
   def _build_jit_update(self):
-    """Build JIT-compiled PPO minibatch update function."""
+    """Build JIT-compiled PPO minibatch update function.
+
+    Captures hyperparameters and the network graphdef as closure constants.
+    The returned function takes pure state + data arrays and returns updated
+    state + loss metrics, making it safe for jax.jit.
+    """
     graphdef = self._graphdef
     clip_coef = self._clip_coef
     value_coef = self._value_coef
@@ -427,6 +429,8 @@ class PPO(rl_agent.AbstractAgent):
           jnp.where(legal_masks, probs * log_probs_all, 0.0), axis=-1)
 
       ratio = jnp.exp(new_log_probs - old_log_probs)
+      approx_kl = jnp.mean((ratio - 1.0) - jnp.log(ratio + 1e-8))
+
       pg_loss1 = -advantages * ratio
       pg_loss2 = -advantages * jnp.clip(
           ratio, 1.0 - clip_coef, 1.0 + clip_coef)
@@ -436,7 +440,7 @@ class PPO(rl_agent.AbstractAgent):
       ent_loss = entropy.mean()
 
       total_loss = pg_loss + value_coef * v_loss - entropy_coef * ent_loss
-      return total_loss, (pg_loss, v_loss, ent_loss)
+      return total_loss, (pg_loss, v_loss, ent_loss, approx_kl)
 
     @jax.jit
     def update(state, obs, actions, old_log_probs, advantages, returns,

--- a/open_spiel/python/jax/ppo_jax_test.py
+++ b/open_spiel/python/jax/ppo_jax_test.py
@@ -11,23 +11,80 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for open_spiel.python.jax.ppo."""
+"""Tests for open_spiel.python.jax.ppo and ppo_utils."""
 
+import jax.numpy as jnp
+import numpy as np
 from absl.testing import absltest
 
 from open_spiel.python import rl_environment
 from open_spiel.python.jax import ppo
+from open_spiel.python.jax import ppo_utils
 
 
 def _self_play_episodes(env, agent, num_episodes):
   """Run self-play episodes collecting training data."""
+  num_players = env.num_players
   for _ in range(num_episodes):
     time_step = env.reset()
     while not time_step.last():
-      output = agent.step(time_step)
-      time_step = env.step([output.action])
+      if time_step.is_simultaneous_move():
+        actions = []
+        for pid in range(num_players):
+          output = agent.step(time_step, player_id=pid)
+          actions.append(output.action)
+        time_step = env.step(actions)
+      else:
+        output = agent.step(time_step)
+        time_step = env.step([output.action])
       agent.post_step(time_step)
     agent.step(time_step)
+
+
+class ComputeGAETest(absltest.TestCase):
+  """Tests for the vectorized jax.lax.scan-based GAE."""
+
+  def test_single_step_terminal(self):
+    """Single terminal step: advantage = reward - value."""
+    rewards = jnp.array([1.0])
+    values = jnp.array([0.5])
+    dones = jnp.array([1.0])
+    advantages, returns = ppo_utils.compute_gae(
+        rewards, values, dones, gamma=1.0, gae_lambda=0.95)
+    np.testing.assert_allclose(advantages, [0.5], atol=1e-6)
+    np.testing.assert_allclose(returns, [1.0], atol=1e-6)
+
+  def test_two_step_trajectory(self):
+    """Two steps, terminal at t=1, gamma=1, lambda=1."""
+    rewards = jnp.array([0.0, 1.0])
+    values = jnp.array([0.4, 0.6])
+    dones = jnp.array([0.0, 1.0])
+    advantages, returns = ppo_utils.compute_gae(
+        rewards, values, dones, gamma=1.0, gae_lambda=1.0)
+    # At t=1 (terminal): delta = 1.0 + 0 - 0.6 = 0.4, gae = 0.4
+    # At t=0: delta = 0.0 + 1.0*0.6*1 - 0.4 = 0.2, gae = 0.2 + 1*1*0.4 = 0.6
+    np.testing.assert_allclose(advantages, [0.6, 0.4], atol=1e-6)
+    np.testing.assert_allclose(returns, [1.0, 1.0], atol=1e-6)
+
+  def test_discounting(self):
+    """Verify gamma discounting in a 2-step trajectory."""
+    rewards = jnp.array([0.0, 1.0])
+    values = jnp.array([0.0, 0.0])
+    dones = jnp.array([0.0, 1.0])
+    advantages, returns = ppo_utils.compute_gae(
+        rewards, values, dones, gamma=0.5, gae_lambda=1.0)
+    # t=1: delta = 1.0, gae = 1.0
+    # t=0: delta = 0 + 0.5*0*1 - 0 = 0, gae = 0 + 0.5*1*1.0 = 0.5
+    np.testing.assert_allclose(advantages, [0.5, 1.0], atol=1e-6)
+
+  def test_all_terminal(self):
+    """All steps terminal (independent transitions)."""
+    rewards = jnp.array([1.0, 2.0, 3.0])
+    values = jnp.array([0.5, 1.0, 1.5])
+    dones = jnp.array([1.0, 1.0, 1.0])
+    advantages, _ = ppo_utils.compute_gae(
+        rewards, values, dones, gamma=0.99, gae_lambda=0.95)
+    np.testing.assert_allclose(advantages, [0.5, 1.0, 1.5], atol=1e-6)
 
 
 class PPOTest(absltest.TestCase):
@@ -54,6 +111,7 @@ class PPOTest(absltest.TestCase):
     self.assertIn("policy_loss", metrics)
     self.assertIn("value_loss", metrics)
     self.assertIn("entropy", metrics)
+    self.assertIn("approx_kl", metrics)
     self.assertEqual(agent.buffer_size, 0)
 
   def test_run_leduc_poker(self):
@@ -72,6 +130,27 @@ class PPOTest(absltest.TestCase):
     )
 
     _self_play_episodes(env, agent, num_episodes=20)
+    metrics = agent.learn()
+    self.assertIn("policy_loss", metrics)
+
+  def test_run_matrix_pd(self):
+    """Test on a simultaneous-move game (Prisoner's Dilemma)."""
+    env = rl_environment.Environment("matrix_pd")
+    info_state_size = env.observation_spec()["info_state"][0]
+    num_actions = env.action_spec()["num_actions"]
+
+    agent = ppo.PPO(
+        player_id=0,
+        info_state_size=info_state_size,
+        num_actions=num_actions,
+        hidden_sizes=[16, 16],
+        update_epochs=2,
+        num_minibatches=2,
+        seed=0,
+    )
+
+    _self_play_episodes(env, agent, num_episodes=20)
+    self.assertGreater(agent.buffer_size, 0)
     metrics = agent.learn()
     self.assertIn("policy_loss", metrics)
 
@@ -145,6 +224,26 @@ class PPOTest(absltest.TestCase):
       metrics = agent.learn()
       self.assertIn("policy_loss", metrics)
       self.assertEqual(agent.buffer_size, 0)
+
+  def test_prng_reproducibility(self):
+    """Two agents with the same seed produce the same first action."""
+    env = rl_environment.Environment("kuhn_poker")
+    info_state_size = env.observation_spec()["info_state"][0]
+    num_actions = env.action_spec()["num_actions"]
+
+    agent1 = ppo.PPO(
+        player_id=0, info_state_size=info_state_size,
+        num_actions=num_actions, hidden_sizes=[16], seed=123)
+    agent2 = ppo.PPO(
+        player_id=0, info_state_size=info_state_size,
+        num_actions=num_actions, hidden_sizes=[16], seed=123)
+
+    time_step = env.reset()
+    out1 = agent1.step(time_step, is_evaluation=True)
+    out2 = agent2.step(time_step, is_evaluation=True)
+
+    self.assertEqual(out1.action, out2.action)
+    np.testing.assert_array_equal(out1.probs, out2.probs)
 
 
 if __name__ == "__main__":

--- a/open_spiel/python/jax/ppo_jax_test.py
+++ b/open_spiel/python/jax/ppo_jax_test.py
@@ -1,0 +1,151 @@
+# Copyright 2019 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for open_spiel.python.jax.ppo."""
+
+from absl.testing import absltest
+
+from open_spiel.python import rl_environment
+from open_spiel.python.jax import ppo
+
+
+def _self_play_episodes(env, agent, num_episodes):
+  """Run self-play episodes collecting training data."""
+  for _ in range(num_episodes):
+    time_step = env.reset()
+    while not time_step.last():
+      output = agent.step(time_step)
+      time_step = env.step([output.action])
+      agent.post_step(time_step)
+    agent.step(time_step)
+
+
+class PPOTest(absltest.TestCase):
+
+  def test_run_kuhn_poker(self):
+    env = rl_environment.Environment("kuhn_poker")
+    info_state_size = env.observation_spec()["info_state"][0]
+    num_actions = env.action_spec()["num_actions"]
+
+    agent = ppo.PPO(
+        player_id=0,
+        info_state_size=info_state_size,
+        num_actions=num_actions,
+        hidden_sizes=[16, 16],
+        update_epochs=2,
+        num_minibatches=2,
+        seed=0,
+    )
+
+    _self_play_episodes(env, agent, num_episodes=20)
+    self.assertGreater(agent.buffer_size, 0)
+
+    metrics = agent.learn()
+    self.assertIn("policy_loss", metrics)
+    self.assertIn("value_loss", metrics)
+    self.assertIn("entropy", metrics)
+    self.assertEqual(agent.buffer_size, 0)
+
+  def test_run_leduc_poker(self):
+    env = rl_environment.Environment("leduc_poker")
+    info_state_size = env.observation_spec()["info_state"][0]
+    num_actions = env.action_spec()["num_actions"]
+
+    agent = ppo.PPO(
+        player_id=0,
+        info_state_size=info_state_size,
+        num_actions=num_actions,
+        hidden_sizes=[16, 16],
+        update_epochs=2,
+        num_minibatches=2,
+        seed=0,
+    )
+
+    _self_play_episodes(env, agent, num_episodes=20)
+    metrics = agent.learn()
+    self.assertIn("policy_loss", metrics)
+
+  def test_self_play_both_players(self):
+    """Verify the same agent acts for both players in a turn-based game."""
+    env = rl_environment.Environment("kuhn_poker")
+    info_state_size = env.observation_spec()["info_state"][0]
+    num_actions = env.action_spec()["num_actions"]
+
+    agent = ppo.PPO(
+        player_id=0,
+        info_state_size=info_state_size,
+        num_actions=num_actions,
+        hidden_sizes=[16, 16],
+        seed=0,
+    )
+
+    players_seen = set()
+    time_step = env.reset()
+    while not time_step.last():
+      current_player = time_step.current_player()
+      players_seen.add(current_player)
+      output = agent.step(time_step)
+      time_step = env.step([output.action])
+      agent.post_step(time_step)
+    agent.step(time_step)
+
+    self.assertGreaterEqual(len(players_seen), 2)
+    self.assertGreater(agent.buffer_size, 0)
+
+  def test_evaluation_mode(self):
+    """Verify evaluation mode does not collect data."""
+    env = rl_environment.Environment("kuhn_poker")
+    info_state_size = env.observation_spec()["info_state"][0]
+    num_actions = env.action_spec()["num_actions"]
+
+    agent = ppo.PPO(
+        player_id=0,
+        info_state_size=info_state_size,
+        num_actions=num_actions,
+        hidden_sizes=[16, 16],
+        seed=0,
+    )
+
+    time_step = env.reset()
+    while not time_step.last():
+      output = agent.step(time_step, is_evaluation=True)
+      time_step = env.step([output.action])
+    agent.step(time_step, is_evaluation=True)
+
+    self.assertEqual(agent.buffer_size, 0)
+
+  def test_multiple_learn_cycles(self):
+    """Verify agent can collect and learn multiple times."""
+    env = rl_environment.Environment("kuhn_poker")
+    info_state_size = env.observation_spec()["info_state"][0]
+    num_actions = env.action_spec()["num_actions"]
+
+    agent = ppo.PPO(
+        player_id=0,
+        info_state_size=info_state_size,
+        num_actions=num_actions,
+        hidden_sizes=[16, 16],
+        update_epochs=2,
+        num_minibatches=2,
+        seed=0,
+    )
+
+    for _ in range(3):
+      _self_play_episodes(env, agent, num_episodes=10)
+      metrics = agent.learn()
+      self.assertIn("policy_loss", metrics)
+      self.assertEqual(agent.buffer_size, 0)
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/open_spiel/python/jax/ppo_utils.py
+++ b/open_spiel/python/jax/ppo_utils.py
@@ -1,0 +1,157 @@
+# Copyright 2019 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities for PPO: vectorized GAE, metrics tracking, and plotting.
+
+This module provides:
+  - compute_gae: Vectorized GAE (Generalized Advantage Estimation) using
+    jax.lax.scan in reverse time order. Fully JIT-compatible with no Python
+    loops.
+  - TrainingMetrics: Dataclass for accumulating training and evaluation metrics.
+  - plot_training_curves: Matplotlib-based plotting for training diagnostics.
+"""
+
+import dataclasses
+
+import jax
+import jax.numpy as jnp
+
+
+def compute_gae(
+    rewards: jnp.ndarray,
+    values: jnp.ndarray,
+    dones: jnp.ndarray,
+    gamma: float,
+    gae_lambda: float,
+) -> tuple[jnp.ndarray, jnp.ndarray]:
+  """Compute GAE advantages and returns using jax.lax.scan.
+
+  Performs a single reverse-order scan over the trajectory. The scan carry
+  propagates the decaying advantage sum from the end of the trajectory to the
+  beginning, implementing the recursive GAE formula:
+
+    delta_t   = r_t + gamma * V(s_{t+1}) * (1 - done_t) - V(s_t)
+    A_t       = delta_t + gamma * lambda * (1 - done_t) * A_{t+1}
+    return_t  = A_t + V(s_t)
+
+  This function is pure and compatible with jax.jit.
+
+  Args:
+    rewards: per-step rewards, shape (T,).
+    values: value estimates V(s_t), shape (T,).
+    dones: 1.0 if step t is terminal, 0.0 otherwise, shape (T,).
+    gamma: discount factor.
+    gae_lambda: GAE lambda parameter.
+
+  Returns:
+    Tuple of (advantages, returns), each shape (T,).
+  """
+  next_values = jnp.concatenate([values[1:], jnp.zeros(1)])
+
+  def _scan_step(last_gae, x):
+    reward, value, next_value, done = x
+    non_terminal = 1.0 - done
+    delta = reward + gamma * next_value * non_terminal - value
+    new_gae = delta + gamma * gae_lambda * non_terminal * last_gae
+    return new_gae, new_gae
+
+  _, advantages = jax.lax.scan(
+      _scan_step,
+      jnp.float32(0.0),
+      (rewards, values, next_values, dones),
+      reverse=True,
+  )
+
+  returns = advantages + values
+  return advantages, returns
+
+
+@dataclasses.dataclass
+class TrainingMetrics:
+  """Accumulates training and evaluation metrics for logging and plotting.
+
+  Training metrics (policy_loss, value_loss, entropy, approx_kl) are recorded
+  every iteration. Evaluation metrics (exploitability, avg_returns) are recorded
+  at eval intervals only.
+  """
+
+  iterations: list = dataclasses.field(default_factory=list)
+  policy_loss: list = dataclasses.field(default_factory=list)
+  value_loss: list = dataclasses.field(default_factory=list)
+  entropy: list = dataclasses.field(default_factory=list)
+  approx_kl: list = dataclasses.field(default_factory=list)
+
+  eval_iterations: list = dataclasses.field(default_factory=list)
+  exploitability: list = dataclasses.field(default_factory=list)
+  avg_returns: list = dataclasses.field(default_factory=list)
+
+  def record_train(self, iteration, metrics):
+    """Record per-iteration training metrics from agent.learn()."""
+    self.iterations.append(iteration)
+    self.policy_loss.append(metrics.get("policy_loss", 0.0))
+    self.value_loss.append(metrics.get("value_loss", 0.0))
+    self.entropy.append(metrics.get("entropy", 0.0))
+    self.approx_kl.append(metrics.get("approx_kl", 0.0))
+
+  def record_eval(self, iteration, expl, avg_ret):
+    """Record periodic evaluation metrics."""
+    self.eval_iterations.append(iteration)
+    self.exploitability.append(expl)
+    self.avg_returns.append(list(avg_ret))
+
+
+def plot_training_curves(metrics, game_name, save_path=None):
+  """Plot training loss curves, entropy, and exploitability.
+
+  Args:
+    metrics: a TrainingMetrics instance.
+    game_name: string used in the plot title.
+    save_path: if provided, save the figure to this file path instead of
+      displaying it.
+  """
+  # pylint: disable=g-import-not-at-top
+  import matplotlib
+  matplotlib.use("Agg")
+  import matplotlib.pyplot as plt
+
+  fig, axes = plt.subplots(2, 2, figsize=(12, 8))
+  fig.suptitle(f"PPO Self-Play: {game_name}", fontsize=14)
+
+  axes[0, 0].plot(metrics.iterations, metrics.policy_loss)
+  axes[0, 0].set_title("Policy Loss")
+  axes[0, 0].set_xlabel("Iteration")
+  axes[0, 0].grid(True, alpha=0.3)
+
+  axes[0, 1].plot(metrics.iterations, metrics.value_loss)
+  axes[0, 1].set_title("Value Loss")
+  axes[0, 1].set_xlabel("Iteration")
+  axes[0, 1].grid(True, alpha=0.3)
+
+  axes[1, 0].plot(metrics.iterations, metrics.entropy)
+  axes[1, 0].set_title("Entropy")
+  axes[1, 0].set_xlabel("Iteration")
+  axes[1, 0].grid(True, alpha=0.3)
+
+  if metrics.exploitability:
+    axes[1, 1].plot(metrics.eval_iterations, metrics.exploitability)
+    axes[1, 1].set_title("Exploitability")
+    axes[1, 1].set_xlabel("Iteration")
+    axes[1, 1].grid(True, alpha=0.3)
+  else:
+    axes[1, 1].set_visible(False)
+
+  plt.tight_layout()
+  if save_path:
+    plt.savefig(save_path, dpi=150, bbox_inches="tight")
+  plt.close(fig)


### PR DESCRIPTION
Adds a PPO (Proximal Policy Optimization) implementation in JAX/Flax (NNX) to OpenSpiel, including a self-play training loop for turn-based imperfect-information games.

Features
Actor-critic PPO agent implemented in JAX + Flax (NNX)
Supports self-play with a single agent controlling all players
Generalized Advantage Estimation (GAE) per player trajectory
Legal action masking for arbitrary OpenSpiel games
Example training script for Kuhn Poker and Leduc Poker
Unit tests covering training, evaluation mode, and self-play behavior
Results

Tested on Kuhn Poker using the example script:

Exploitability: ~0.22 after 500 iterations (entropy_coef=0.1)
Average returns close to game value (-1/18 ≈ -0.056)

This suggests the self-play setup and training loop are functioning as expected.

Notes
Designed as a reference implementation for policy gradient methods in OpenSpiel
PPO does not have convergence guarantees in imperfect-information games
Performance is sensitive to hyperparameters (e.g., entropy regularization)
Files Added
open_spiel/python/jax/ppo.py — PPO agent and training logic
open_spiel/python/examples/ppo_example_jax.py — example self-play training script
open_spiel/python/jax/ppo_jax_test.py — unit tests
Future Work
Scaling to larger games (e.g., Leduc Poker tuning)
Benchmarking against CFR-based methods
Multi-agent extensions or population-based training