### PR TITLE
Add social deduction hidden-role benchmark game

### DIFF
--- a/open_spiel/games/CMakeLists.txt
+++ b/open_spiel/games/CMakeLists.txt
@@ -202,6 +202,8 @@ set(GAME_SOURCES
   skat/skat.h
   snake/snake.cc
   snake/snake.h
+  social_deduction/social_deduction.cc
+  social_deduction/social_deduction.h
   solitaire/solitaire.cc
   solitaire/solitaire.h
   spades/spades.cc
@@ -698,6 +700,10 @@ add_test(skat_test skat_test)
 add_executable(snake_test snake/snake_test.cc ${OPEN_SPIEL_OBJECTS}
                $<TARGET_OBJECTS:tests>)
 add_test(snake_test snake_test)
+
+add_executable(social_deduction_test social_deduction/social_deduction_test.cc ${OPEN_SPIEL_OBJECTS}
+               $<TARGET_OBJECTS:tests>)
+add_test(social_deduction_test social_deduction_test)
 
 add_executable(solitaire_test solitaire/solitaire_test.cc ${OPEN_SPIEL_OBJECTS}
                $<TARGET_OBJECTS:tests>)

--- a/open_spiel/games/social_deduction/social_deduction.cc
+++ b/open_spiel/games/social_deduction/social_deduction.cc
@@ -151,10 +151,9 @@ Player SocialDeductionState::CurrentPlayer() const {
 
 std::vector<Action> SocialDeductionState::LegalActions() const {
   if (IsTerminal()) return {};
-  if (phase_ == Phase::kAssignRoles) {
-    return RoleAssignments(num_players_, parent_game_.NumImposters());
+  if (phase_ == Phase::kAssignRoles || phase_ == Phase::kObservation) {
+    return LegalChanceOutcomes();
   }
-  if (phase_ == Phase::kObservation) return ObservationSignals(alive_);
 
   std::vector<Action> actions;
   if (phase_ == Phase::kCommunication) {

--- a/open_spiel/games/social_deduction/social_deduction.cc
+++ b/open_spiel/games/social_deduction/social_deduction.cc
@@ -1,0 +1,506 @@
+// Copyright 2026 DeepMind Technologies Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "open_spiel/games/social_deduction/social_deduction.h"
+
+#include <algorithm>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "open_spiel/abseil-cpp/absl/strings/str_cat.h"
+#include "open_spiel/abseil-cpp/absl/strings/str_join.h"
+#include "open_spiel/game_parameters.h"
+#include "open_spiel/spiel_utils.h"
+
+namespace open_spiel {
+namespace social_deduction {
+namespace {
+
+constexpr int kDefaultPlayers = 6;
+constexpr int kDefaultImposters = 1;
+constexpr int kDefaultMaxRounds = 10;
+constexpr double kDefaultObservationNoise = 0.1;
+
+constexpr Action kSkip = 0;
+constexpr Action kClaimInnocent = 1;
+constexpr Action kAccuseOffset = 2;
+
+constexpr int kInnocentTeam = 0;
+constexpr int kImposterTeam = 1;
+
+const GameType kGameType{
+    /*short_name=*/"social_deduction",
+    /*long_name=*/"Social Deduction",
+    GameType::Dynamics::kSequential,
+    GameType::ChanceMode::kExplicitStochastic,
+    GameType::Information::kImperfectInformation,
+    GameType::Utility::kGeneralSum,
+    GameType::RewardModel::kTerminal,
+    /*max_num_players=*/10,
+    /*min_num_players=*/3,
+    /*provides_information_state_string=*/true,
+    /*provides_information_state_tensor=*/false,
+    /*provides_observation_string=*/true,
+    /*provides_observation_tensor=*/false,
+    /*parameter_specification=*/
+    {{"players", GameParameter(kDefaultPlayers)},
+     {"imposters", GameParameter(kDefaultImposters)},
+     {"max_rounds", GameParameter(kDefaultMaxRounds)},
+     {"observation_noise", GameParameter(kDefaultObservationNoise)}}};  // NOLINT
+
+std::shared_ptr<const Game> Factory(const GameParameters& params) {
+  return std::shared_ptr<const Game>(new SocialDeductionGame(params));
+}
+
+REGISTER_SPIEL_GAME(kGameType, Factory);
+
+int PopCount(int mask) {
+  int count = 0;
+  while (mask != 0) {
+    count += mask & 1;
+    mask >>= 1;
+  }
+  return count;
+}
+
+std::vector<Action> RoleAssignments(int num_players, int num_imposters) {
+  std::vector<Action> actions;
+  const int num_masks = 1 << num_players;
+  for (int mask = 0; mask < num_masks; ++mask) {
+    if (PopCount(mask) == num_imposters) actions.push_back(mask);
+  }
+  return actions;
+}
+
+std::vector<Action> ObservationSignals(const std::vector<bool>& alive) {
+  std::vector<Action> actions;
+  for (Player player = 0; player < alive.size(); ++player) {
+    if (alive[player]) {
+      actions.push_back(2 * player);
+      actions.push_back(2 * player + 1);
+    }
+  }
+  return actions;
+}
+
+std::string PhaseString(Phase phase) {
+  switch (phase) {
+    case Phase::kAssignRoles:
+      return "AssignRoles";
+    case Phase::kObservation:
+      return "Observation";
+    case Phase::kCommunication:
+      return "Communication";
+    case Phase::kVoting:
+      return "Voting";
+    case Phase::kTerminal:
+      return "Terminal";
+    default:
+      SpielFatalError("Unknown phase.");
+  }
+}
+
+std::string MessageString(Action action, int num_players) {
+  if (action == kSkip) return "SKIP";
+  if (action == kClaimInnocent) return "CLAIM_INNOCENT";
+  if (action >= kAccuseOffset && action < kAccuseOffset + num_players) {
+    return absl::StrCat("ACCUSE_PLAYER_", action - kAccuseOffset);
+  }
+  const Action defend_offset = kAccuseOffset + num_players;
+  if (action >= defend_offset && action < defend_offset + num_players) {
+    return absl::StrCat("DEFEND_PLAYER_", action - defend_offset);
+  }
+  return absl::StrCat("UNKNOWN_MESSAGE_", action);
+}
+
+std::string SignalString(Action action) {
+  return absl::StrCat("SIGNAL_PLAYER_", action / 2,
+                      action % 2 == 1 ? "_SUSPICIOUS" : "_CLEAR");
+}
+
+}  // namespace
+
+SocialDeductionState::SocialDeductionState(std::shared_ptr<const Game> game)
+    : State(game),
+      parent_game_(static_cast<const SocialDeductionGame&>(*game)),
+      roles_(game->NumPlayers(), Role::kInnocent),
+      alive_(game->NumPlayers(), true) {}  // NOLINT
+
+Player SocialDeductionState::CurrentPlayer() const {
+  if (IsTerminal()) return kTerminalPlayerId;
+  if (phase_ == Phase::kAssignRoles || phase_ == Phase::kObservation) {
+    return kChancePlayerId;
+  }
+  const Player next = NextAlivePlayer(actor_cursor_);
+  SPIEL_CHECK_NE(next, kInvalidPlayer);
+  return next;
+}
+
+std::vector<Action> SocialDeductionState::LegalActions() const {
+  if (IsTerminal()) return {};
+  if (phase_ == Phase::kAssignRoles) {
+    return RoleAssignments(num_players_, parent_game_.NumImposters());
+  }
+  if (phase_ == Phase::kObservation) return ObservationSignals(alive_);
+
+  std::vector<Action> actions;
+  if (phase_ == Phase::kCommunication) {
+    actions.push_back(kSkip);
+    actions.push_back(kClaimInnocent);
+    for (Player target = 0; target < num_players_; ++target) {
+      if (IsAlive(target)) actions.push_back(kAccuseOffset + target);
+    }
+    for (Player target = 0; target < num_players_; ++target) {
+      if (IsAlive(target)) {
+        actions.push_back(kAccuseOffset + num_players_ + target);
+      }
+    }
+    return actions;
+  }
+
+  if (phase_ == Phase::kVoting) {
+    const Player voter = CurrentPlayer();
+    for (Player target = 0; target < num_players_; ++target) {
+      if (IsAlive(target) && target != voter) actions.push_back(target);
+    }
+    return actions;
+  }
+
+  SpielFatalError("Unknown phase.");
+}
+
+ActionsAndProbs SocialDeductionState::ChanceOutcomes() const {
+  if (phase_ == Phase::kAssignRoles) {
+    std::vector<Action> assignments =
+        RoleAssignments(num_players_, parent_game_.NumImposters());
+    ActionsAndProbs outcomes;
+    outcomes.reserve(assignments.size());
+    const double probability = 1.0 / assignments.size();
+    for (Action action : assignments) outcomes.push_back({action, probability});
+    return outcomes;
+  }
+
+  SPIEL_CHECK_TRUE(phase_ == Phase::kObservation);
+  ActionsAndProbs outcomes;
+  const double target_probability = 1.0 / AlivePlayers();
+  for (Player target = 0; target < num_players_; ++target) {
+    if (!IsAlive(target)) continue;
+    const double suspicious_probability =
+        IsImposter(target) ? 1.0 - parent_game_.ObservationNoise()
+                           : parent_game_.ObservationNoise();
+    const double clear_probability = 1.0 - suspicious_probability;
+    if (clear_probability > 0.0) {
+      outcomes.push_back({2 * target, target_probability * clear_probability});
+    }
+    if (suspicious_probability > 0.0) {
+      outcomes.push_back(
+          {2 * target + 1, target_probability * suspicious_probability});
+    }
+  }
+  return outcomes;
+}
+
+void SocialDeductionState::DoApplyAction(Action action) {
+  if (phase_ == Phase::kAssignRoles) {
+    SPIEL_CHECK_EQ(PopCount(action), parent_game_.NumImposters());
+    for (Player player = 0; player < num_players_; ++player) {
+      roles_[player] =
+          ((action >> player) & 1) ? Role::kImposter : Role::kInnocent;
+    }
+    roles_assigned_ = true;
+    StartRound();
+    return;
+  }
+
+  if (phase_ == Phase::kObservation) {
+    SPIEL_CHECK_TRUE(roles_assigned_);
+    const Player target = action / 2;
+    SPIEL_CHECK_TRUE(IsAlive(target));
+    SPIEL_CHECK_LT(action, 2 * num_players_);
+    rounds_.back().signal_target = target;
+    rounds_.back().signal_suspicious = action % 2 == 1;
+    phase_ = Phase::kCommunication;
+    actor_cursor_ = 0;
+    return;
+  }
+
+  const Player player = CurrentPlayer();
+  if (phase_ == Phase::kCommunication) {
+    rounds_.back().messages[player] = action;
+    actor_cursor_ = player + 1;
+    if (NextAlivePlayer(actor_cursor_) == kInvalidPlayer) {
+      FinishCommunication();
+    }
+    return;
+  }
+
+  SPIEL_CHECK_TRUE(phase_ == Phase::kVoting);
+  SPIEL_CHECK_TRUE(IsAlive(action));
+  SPIEL_CHECK_NE(player, action);
+  rounds_.back().votes[player] = action;
+  actor_cursor_ = player + 1;
+  if (NextAlivePlayer(actor_cursor_) == kInvalidPlayer) ResolveVotes();
+}
+
+std::string SocialDeductionState::ActionToString(Player player,
+                                                 Action action_id) const {
+  if (player == kChancePlayerId) {
+    if (!roles_assigned_) {
+      std::vector<std::string> imposters;
+      for (Player p = 0; p < num_players_; ++p) {
+        if ((action_id >> p) & 1) imposters.push_back(absl::StrCat(p));
+      }
+      return absl::StrCat("ASSIGN_IMPOSTERS_", absl::StrJoin(imposters, "_"));
+    }
+    return SignalString(action_id);
+  }
+  if (phase_ == Phase::kVoting) {
+    return absl::StrCat("VOTE_PLAYER_", action_id);
+  }
+  return MessageString(action_id, num_players_);
+}
+
+std::string SocialDeductionState::ToString() const {
+  std::ostringstream out;
+  out << "Round: " << round_ << "\n";
+  out << "Phase: " << PhaseString(phase_) << "\n";
+  if (roles_assigned_) {
+    out << "Roles:";
+    for (Player player = 0; player < num_players_; ++player) {
+      out << " " << player << "=" << RoleString(player);
+    }
+    out << "\n";
+  }
+  AppendPublicHistory(out);
+  return out.str();
+}
+
+bool SocialDeductionState::IsTerminal() const {
+  return winner_team_ != kInvalidPlayer;
+}
+
+std::vector<double> SocialDeductionState::Returns() const {
+  std::vector<double> returns(num_players_, 0.0);
+  if (!IsTerminal()) return returns;
+  for (Player player = 0; player < num_players_; ++player) {
+    const int team = IsImposter(player) ? kImposterTeam : kInnocentTeam;
+    returns[player] = team == winner_team_ ? 1.0 : -1.0;
+  }
+  return returns;
+}
+
+std::unique_ptr<State> SocialDeductionState::Clone() const {
+  return std::unique_ptr<State>(new SocialDeductionState(*this));
+}
+
+std::string SocialDeductionState::InformationStateString(Player player) const {
+  SPIEL_CHECK_GE(player, 0);
+  SPIEL_CHECK_LT(player, num_players_);
+  std::ostringstream out;
+  out << ObservationString(player);
+  out << "InformationStatePlayer: " << player << "\n";
+  return out.str();
+}
+
+std::string SocialDeductionState::ObservationString(Player player) const {
+  SPIEL_CHECK_GE(player, 0);
+  SPIEL_CHECK_LT(player, num_players_);
+  std::ostringstream out;
+  out << "Player: " << player << "\n";
+  out << "Role: " << RoleString(player) << "\n";
+  if (roles_assigned_ && IsImposter(player)) {
+    out << "ImposterTeam:";
+    for (Player other = 0; other < num_players_; ++other) {
+      if (IsImposter(other)) out << " " << other;
+    }
+    out << "\n";
+  }
+  AppendPublicHistory(out);
+  return out.str();
+}
+
+bool SocialDeductionState::IsAlive(Player player) const {
+  return player >= 0 && player < alive_.size() && alive_[player];
+}
+
+bool SocialDeductionState::IsImposter(Player player) const {
+  return roles_[player] == Role::kImposter;
+}
+
+int SocialDeductionState::AlivePlayers() const {
+  return std::count(alive_.begin(), alive_.end(), true);
+}
+
+int SocialDeductionState::AliveImposters() const {
+  int count = 0;
+  for (Player player = 0; player < num_players_; ++player) {
+    if (IsAlive(player) && IsImposter(player)) ++count;
+  }
+  return count;
+}
+
+int SocialDeductionState::AliveInnocents() const {
+  return AlivePlayers() - AliveImposters();
+}
+
+Player SocialDeductionState::NextAlivePlayer(int start_player) const {
+  for (Player player = std::max(0, start_player); player < num_players_;
+       ++player) {
+    if (IsAlive(player)) return player;
+  }
+  return kInvalidPlayer;
+}
+
+void SocialDeductionState::StartRound() {
+  UpdateWinner();
+  if (IsTerminal()) return;
+  phase_ = Phase::kObservation;
+  actor_cursor_ = 0;
+  rounds_.push_back(RoundRecord{
+      /*signal_target=*/kInvalidPlayer,
+      /*signal_suspicious=*/false,
+      /*messages=*/std::vector<Action>(num_players_, kInvalidAction),
+      /*votes=*/std::vector<Player>(num_players_, kInvalidPlayer),
+      /*eliminated=*/kInvalidPlayer});
+}
+
+void SocialDeductionState::FinishCommunication() {
+  phase_ = Phase::kVoting;
+  actor_cursor_ = 0;
+}
+
+void SocialDeductionState::ResolveVotes() {
+  std::vector<int> vote_counts(num_players_, 0);
+  for (Player voter = 0; voter < num_players_; ++voter) {
+    if (rounds_.back().votes[voter] != kInvalidPlayer) {
+      ++vote_counts[rounds_.back().votes[voter]];
+    }
+  }
+
+  Player eliminated = kInvalidPlayer;
+  int best_votes = 0;
+  bool tied = false;
+  for (Player target = 0; target < num_players_; ++target) {
+    if (!IsAlive(target) || vote_counts[target] == 0) continue;
+    if (vote_counts[target] > best_votes) {
+      best_votes = vote_counts[target];
+      eliminated = target;
+      tied = false;
+    } else if (vote_counts[target] == best_votes) {
+      tied = true;
+    }
+  }
+
+  if (!tied && eliminated != kInvalidPlayer) {
+    alive_[eliminated] = false;
+    rounds_.back().eliminated = eliminated;
+  }
+
+  ++round_;
+  UpdateWinner();
+  if (IsTerminal()) return;
+  if (round_ >= parent_game_.MaxRounds()) {
+    winner_team_ = kImposterTeam;
+    phase_ = Phase::kTerminal;
+    return;
+  }
+  StartRound();
+}
+
+void SocialDeductionState::UpdateWinner() {
+  if (AliveImposters() == 0) {
+    winner_team_ = kInnocentTeam;
+    phase_ = Phase::kTerminal;
+  } else if (AliveImposters() >= AliveInnocents()) {
+    winner_team_ = kImposterTeam;
+    phase_ = Phase::kTerminal;
+  }
+}
+
+void SocialDeductionState::AppendPublicHistory(std::ostream& out) const {
+  out << "Alive:";
+  for (Player player = 0; player < num_players_; ++player) {
+    if (IsAlive(player)) out << " " << player;
+  }
+  out << "\n";
+  for (int r = 0; r < rounds_.size(); ++r) {
+    const RoundRecord& record = rounds_[r];
+    out << "Round " << r << "\n";
+    if (record.signal_target != kInvalidPlayer) {
+      out << "Signal: player " << record.signal_target
+          << (record.signal_suspicious ? " suspicious" : " clear") << "\n";
+    }
+    out << "Messages:";
+    for (Player player = 0; player < num_players_; ++player) {
+      if (record.messages[player] != kInvalidAction) {
+        out << " " << player << "="
+            << MessageString(record.messages[player], num_players_);
+      }
+    }
+    out << "\n";
+    out << "Votes:";
+    for (Player player = 0; player < num_players_; ++player) {
+      if (record.votes[player] != kInvalidPlayer) {
+        out << " " << player << "->" << record.votes[player];
+      }
+    }
+    out << "\n";
+    if (record.eliminated != kInvalidPlayer) {
+      out << "Eliminated: " << record.eliminated << "\n";
+    }
+  }
+}
+
+std::string SocialDeductionState::RoleString(Player player) const {
+  if (!roles_assigned_) return "Unknown";
+  return roles_[player] == Role::kImposter ? "Imposter" : "Innocent";
+}
+
+SocialDeductionGame::SocialDeductionGame(const GameParameters& params)
+    : Game(kGameType, params),
+      num_players_(ParameterValue<int>("players")),
+      num_imposters_(ParameterValue<int>("imposters")),
+      max_rounds_(ParameterValue<int>("max_rounds")),
+      observation_noise_(ParameterValue<double>("observation_noise")) {
+  SPIEL_CHECK_GE(num_players_, kGameType.min_num_players);
+  SPIEL_CHECK_LE(num_players_, kGameType.max_num_players);
+  SPIEL_CHECK_GE(num_imposters_, 1);
+  SPIEL_CHECK_LT(num_imposters_, num_players_);
+  SPIEL_CHECK_LT(num_imposters_, num_players_ - num_imposters_);
+  SPIEL_CHECK_GE(max_rounds_, 1);
+  SPIEL_CHECK_GE(observation_noise_, 0.0);
+  SPIEL_CHECK_LE(observation_noise_, 1.0);
+}
+
+int SocialDeductionGame::NumDistinctActions() const {
+  return std::max(num_players_, static_cast<int>(kAccuseOffset) +
+                                    2 * num_players_);
+}
+
+int SocialDeductionGame::MaxChanceOutcomes() const {
+  return std::max(1 << num_players_, 2 * num_players_);
+}
+
+std::unique_ptr<State> SocialDeductionGame::NewInitialState() const {
+  return std::unique_ptr<State>(new SocialDeductionState(shared_from_this()));
+}
+
+int SocialDeductionGame::MaxGameLength() const {
+  return 1 + max_rounds_ * (1 + 2 * num_players_);
+}
+
+}  // namespace social_deduction
+}  // namespace open_spiel

--- a/open_spiel/games/social_deduction/social_deduction.h
+++ b/open_spiel/games/social_deduction/social_deduction.h
@@ -1,0 +1,129 @@
+// Copyright 2026 DeepMind Technologies Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OPEN_SPIEL_GAMES_SOCIAL_DEDUCTION_SOCIAL_DEDUCTION_H_
+#define OPEN_SPIEL_GAMES_SOCIAL_DEDUCTION_SOCIAL_DEDUCTION_H_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "open_spiel/spiel.h"
+
+// A simple configurable hidden-role social deduction benchmark.
+//
+// Players are assigned hidden roles: innocents and imposters. Imposters know
+// the full imposter team, while innocents only know their own role. Each round
+// has an observation chance event, one tokenized communication action per
+// living player, and one elimination vote per living player. Innocents win by
+// eliminating all imposters. Imposters win by reaching parity or by surviving
+// until the round limit.
+
+namespace open_spiel {
+namespace social_deduction {
+
+enum class Role { kInnocent = 0, kImposter = 1 };
+
+enum class Phase {
+  kAssignRoles = 0,
+  kObservation = 1,
+  kCommunication = 2,
+  kVoting = 3,
+  kTerminal = 4
+};
+
+class SocialDeductionGame;
+
+struct RoundRecord {
+  int signal_target = kInvalidPlayer;
+  bool signal_suspicious = false;
+  std::vector<Action> messages;
+  std::vector<Player> votes;
+  Player eliminated = kInvalidPlayer;
+};
+
+class SocialDeductionState : public State {
+ public:
+  explicit SocialDeductionState(std::shared_ptr<const Game> game);
+  SocialDeductionState(const SocialDeductionState&) = default;
+
+  Player CurrentPlayer() const override;
+  std::vector<Action> LegalActions() const override;
+  std::string ActionToString(Player player, Action action_id) const override;
+  std::string ToString() const override;
+  bool IsTerminal() const override;
+  std::vector<double> Returns() const override;
+  std::unique_ptr<State> Clone() const override;
+
+  ActionsAndProbs ChanceOutcomes() const override;
+  std::string InformationStateString(Player player) const override;
+  std::string ObservationString(Player player) const override;
+
+ protected:
+  void DoApplyAction(Action action) override;
+
+ private:
+  bool IsAlive(Player player) const;
+  bool IsImposter(Player player) const;
+  int AlivePlayers() const;
+  int AliveImposters() const;
+  int AliveInnocents() const;
+  Player NextAlivePlayer(int start_player) const;
+  void StartRound();
+  void FinishCommunication();
+  void ResolveVotes();
+  void UpdateWinner();
+  void AppendPublicHistory(std::ostream& out) const;
+  std::string RoleString(Player player) const;
+
+  const SocialDeductionGame& parent_game_;
+
+  Phase phase_ = Phase::kAssignRoles;
+  int round_ = 0;
+  int actor_cursor_ = 0;
+  int winner_team_ = kInvalidPlayer;
+  bool roles_assigned_ = false;
+  std::vector<Role> roles_;
+  std::vector<bool> alive_;
+  std::vector<RoundRecord> rounds_;
+};
+
+class SocialDeductionGame : public Game {
+ public:
+  explicit SocialDeductionGame(const GameParameters& params);
+
+  int NumDistinctActions() const override;
+  int MaxChanceOutcomes() const override;
+  std::unique_ptr<State> NewInitialState() const override;
+  int NumPlayers() const override { return num_players_; }
+  double MaxUtility() const override { return 1.0; }
+  double MinUtility() const override { return -1.0; }
+  int MaxGameLength() const override;
+  int MaxChanceNodesInHistory() const override { return 1 + max_rounds_; }
+
+  int NumImposters() const { return num_imposters_; }
+  int MaxRounds() const { return max_rounds_; }
+  double ObservationNoise() const { return observation_noise_; }
+
+ private:
+  int num_players_;
+  int num_imposters_;
+  int max_rounds_;
+  double observation_noise_;
+};
+
+}  // namespace social_deduction
+}  // namespace open_spiel
+
+#endif  // OPEN_SPIEL_GAMES_SOCIAL_DEDUCTION_SOCIAL_DEDUCTION_H_

--- a/open_spiel/games/social_deduction/social_deduction_test.cc
+++ b/open_spiel/games/social_deduction/social_deduction_test.cc
@@ -1,0 +1,102 @@
+// Copyright 2026 DeepMind Technologies Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "open_spiel/game_parameters.h"
+#include "open_spiel/spiel.h"
+#include "open_spiel/spiel_utils.h"
+#include "open_spiel/tests/basic_tests.h"
+
+namespace open_spiel {
+namespace social_deduction {
+namespace {
+
+void BasicSocialDeductionTests() {
+  testing::LoadGameTest("social_deduction");
+  testing::RandomSimTest(*LoadGame("social_deduction"), 10);
+  testing::RandomSimTest(
+      *LoadGame("social_deduction",
+                {{"players", GameParameter(5)},
+                 {"imposters", GameParameter(1)},
+                 {"max_rounds", GameParameter(4)},
+                 {"observation_noise", GameParameter(0.0)}}),
+      10);
+}
+
+void HiddenRoleObservationTest() {
+  std::shared_ptr<const Game> game =
+      LoadGame("social_deduction",
+               {{"players", GameParameter(4)},
+                {"imposters", GameParameter(1)},
+                {"max_rounds", GameParameter(3)},
+                {"observation_noise", GameParameter(0.0)}});
+  std::unique_ptr<State> state = game->NewInitialState();
+
+  state->ApplyAction(1);  // Player 0 is the single imposter.
+
+  const std::string imposter_observation = state->ObservationString(0);
+  SPIEL_CHECK_NE(imposter_observation.find("Role: Imposter"),
+                 std::string::npos);
+  SPIEL_CHECK_NE(imposter_observation.find("ImposterTeam: 0"),
+                 std::string::npos);
+
+  const std::string innocent_observation = state->ObservationString(1);
+  SPIEL_CHECK_NE(innocent_observation.find("Role: Innocent"),
+                 std::string::npos);
+  SPIEL_CHECK_EQ(innocent_observation.find("ImposterTeam"),
+                 std::string::npos);
+}
+
+void InnocentsCanEliminateImposterTest() {
+  std::shared_ptr<const Game> game =
+      LoadGame("social_deduction",
+               {{"players", GameParameter(4)},
+                {"imposters", GameParameter(1)},
+                {"max_rounds", GameParameter(3)},
+                {"observation_noise", GameParameter(0.0)}});
+  std::unique_ptr<State> state = game->NewInitialState();
+
+  state->ApplyAction(1);  // Player 0 is the single imposter.
+  state->ApplyAction(1);  // Public signal: player 0 suspicious.
+
+  state->ApplyAction(0);  // Player 0: SKIP.
+  state->ApplyAction(2);  // Player 1: ACCUSE_PLAYER_0.
+  state->ApplyAction(2);  // Player 2: ACCUSE_PLAYER_0.
+  state->ApplyAction(2);  // Player 3: ACCUSE_PLAYER_0.
+
+  state->ApplyAction(1);  // Player 0 votes for player 1.
+  state->ApplyAction(0);  // Player 1 votes for player 0.
+  state->ApplyAction(0);  // Player 2 votes for player 0.
+  state->ApplyAction(0);  // Player 3 votes for player 0.
+
+  SPIEL_CHECK_TRUE(state->IsTerminal());
+  const std::vector<double> returns = state->Returns();
+  SPIEL_CHECK_EQ(returns[0], -1.0);
+  SPIEL_CHECK_EQ(returns[1], 1.0);
+  SPIEL_CHECK_EQ(returns[2], 1.0);
+  SPIEL_CHECK_EQ(returns[3], 1.0);
+}
+
+}  // namespace
+}  // namespace social_deduction
+}  // namespace open_spiel
+
+int main(int argc, char** argv) {
+  open_spiel::social_deduction::BasicSocialDeductionTests();
+  open_spiel::social_deduction::HiddenRoleObservationTest();
+  open_spiel::social_deduction::InnocentsCanEliminateImposterTest();
+}

--- a/open_spiel/integration_tests/playthroughs/social_deduction.txt
+++ b/open_spiel/integration_tests/playthroughs/social_deduction.txt
@@ -1,0 +1,844 @@
+game: social_deduction
+
+GameType.chance_mode = ChanceMode.EXPLICIT_STOCHASTIC
+GameType.dynamics = Dynamics.SEQUENTIAL
+GameType.information = Information.IMPERFECT_INFORMATION
+GameType.long_name = "Social Deduction"
+GameType.max_num_players = 10
+GameType.min_num_players = 3
+GameType.parameter_specification = ["imposters", "max_rounds", "observation_noise", "players"]
+GameType.provides_information_state_string = True
+GameType.provides_information_state_tensor = False
+GameType.provides_observation_string = True
+GameType.provides_observation_tensor = False
+GameType.provides_factored_observation_string = False
+GameType.reward_model = RewardModel.TERMINAL
+GameType.short_name = "social_deduction"
+GameType.utility = Utility.GENERAL_SUM
+
+NumDistinctActions() = 14
+PolicyTensorShape() = [14]
+MaxChanceOutcomes() = 64
+GetParameters() = {imposters=1,max_rounds=10,observation_noise=0.1,players=6}
+NumPlayers() = 6
+MinUtility() = -1.0
+MaxUtility() = 1.0
+UtilitySum() = None
+MaxGameLength() = 131
+ToString() = "social_deduction()"
+
+# State 0
+# Round: 0
+# Phase: AssignRoles
+# Alive: 0 1 2 3 4 5
+IsTerminal() = False
+History() = []
+HistoryString() = ""
+IsChanceNode() = True
+IsSimultaneousNode() = False
+CurrentPlayer() = -1
+InformationStateString(0) = "Player: 0\nRole: Unknown\nAlive: 0 1 2 3 4 5\nInformationStatePlayer: 0\n"
+InformationStateString(1) = "Player: 1\nRole: Unknown\nAlive: 0 1 2 3 4 5\nInformationStatePlayer: 1\n"
+InformationStateString(2) = "Player: 2\nRole: Unknown\nAlive: 0 1 2 3 4 5\nInformationStatePlayer: 2\n"
+InformationStateString(3) = "Player: 3\nRole: Unknown\nAlive: 0 1 2 3 4 5\nInformationStatePlayer: 3\n"
+InformationStateString(4) = "Player: 4\nRole: Unknown\nAlive: 0 1 2 3 4 5\nInformationStatePlayer: 4\n"
+InformationStateString(5) = "Player: 5\nRole: Unknown\nAlive: 0 1 2 3 4 5\nInformationStatePlayer: 5\n"
+ObservationString(0) = "Player: 0\nRole: Unknown\nAlive: 0 1 2 3 4 5\n"
+ObservationString(1) = "Player: 1\nRole: Unknown\nAlive: 0 1 2 3 4 5\n"
+ObservationString(2) = "Player: 2\nRole: Unknown\nAlive: 0 1 2 3 4 5\n"
+ObservationString(3) = "Player: 3\nRole: Unknown\nAlive: 0 1 2 3 4 5\n"
+ObservationString(4) = "Player: 4\nRole: Unknown\nAlive: 0 1 2 3 4 5\n"
+ObservationString(5) = "Player: 5\nRole: Unknown\nAlive: 0 1 2 3 4 5\n"
+ChanceOutcomes() = [(1,0.166667), (2,0.166667), (4,0.166667), (8,0.166667), (16,0.166667), (32,0.166667)]
+LegalActions() = [1, 2, 4, 8, 16, 32]
+StringLegalActions() = ["ASSIGN_IMPOSTERS_0", "ASSIGN_IMPOSTERS_1", "ASSIGN_IMPOSTERS_2", "ASSIGN_IMPOSTERS_3", "ASSIGN_IMPOSTERS_4", "ASSIGN_IMPOSTERS_5"]
+
+# Apply action "ASSIGN_IMPOSTERS_5"
+action: 32
+
+# State 1
+# Round: 0
+# Phase: Observation
+# Roles: 0=Innocent 1=Innocent 2=Innocent 3=Innocent 4=Innocent 5=Imposter
+# Alive: 0 1 2 3 4 5
+# Round 0
+# Messages:
+# Votes:
+IsTerminal() = False
+History() = [32]
+HistoryString() = "32"
+IsChanceNode() = True
+IsSimultaneousNode() = False
+CurrentPlayer() = -1
+InformationStateString(0) = "Player: 0\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nMessages:\nVotes:\nInformationStatePlayer: 0\n"
+InformationStateString(1) = "Player: 1\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nMessages:\nVotes:\nInformationStatePlayer: 1\n"
+InformationStateString(2) = "Player: 2\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nMessages:\nVotes:\nInformationStatePlayer: 2\n"
+InformationStateString(3) = "Player: 3\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nMessages:\nVotes:\nInformationStatePlayer: 3\n"
+InformationStateString(4) = "Player: 4\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nMessages:\nVotes:\nInformationStatePlayer: 4\n"
+InformationStateString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 1 2 3 4 5\nRound 0\nMessages:\nVotes:\nInformationStatePlayer: 5\n"
+ObservationString(0) = "Player: 0\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nMessages:\nVotes:\n"
+ObservationString(1) = "Player: 1\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nMessages:\nVotes:\n"
+ObservationString(2) = "Player: 2\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nMessages:\nVotes:\n"
+ObservationString(3) = "Player: 3\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nMessages:\nVotes:\n"
+ObservationString(4) = "Player: 4\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nMessages:\nVotes:\n"
+ObservationString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 1 2 3 4 5\nRound 0\nMessages:\nVotes:\n"
+ChanceOutcomes() = [(0,0.15), (1,0.0166667), (2,0.15), (3,0.0166667), (4,0.15), (5,0.0166667), (6,0.15), (7,0.0166667), (8,0.15), (9,0.0166667), (10,0.0166667), (11,0.15)]
+LegalActions() = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+StringLegalActions() = ["SIGNAL_PLAYER_0_CLEAR", "SIGNAL_PLAYER_0_SUSPICIOUS", "SIGNAL_PLAYER_1_CLEAR", "SIGNAL_PLAYER_1_SUSPICIOUS", "SIGNAL_PLAYER_2_CLEAR", "SIGNAL_PLAYER_2_SUSPICIOUS", "SIGNAL_PLAYER_3_CLEAR", "SIGNAL_PLAYER_3_SUSPICIOUS", "SIGNAL_PLAYER_4_CLEAR", "SIGNAL_PLAYER_4_SUSPICIOUS", "SIGNAL_PLAYER_5_CLEAR", "SIGNAL_PLAYER_5_SUSPICIOUS"]
+
+# Apply action "SIGNAL_PLAYER_1_CLEAR"
+action: 2
+
+# State 2
+# Round: 0
+# Phase: Communication
+# Roles: 0=Innocent 1=Innocent 2=Innocent 3=Innocent 4=Innocent 5=Imposter
+# Alive: 0 1 2 3 4 5
+# Round 0
+# Signal: player 1 clear
+# Messages:
+# Votes:
+IsTerminal() = False
+History() = [32, 2]
+HistoryString() = "32, 2"
+IsChanceNode() = False
+IsSimultaneousNode() = False
+CurrentPlayer() = 0
+InformationStateString(0) = "Player: 0\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages:\nVotes:\nInformationStatePlayer: 0\n"
+InformationStateString(1) = "Player: 1\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages:\nVotes:\nInformationStatePlayer: 1\n"
+InformationStateString(2) = "Player: 2\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages:\nVotes:\nInformationStatePlayer: 2\n"
+InformationStateString(3) = "Player: 3\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages:\nVotes:\nInformationStatePlayer: 3\n"
+InformationStateString(4) = "Player: 4\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages:\nVotes:\nInformationStatePlayer: 4\n"
+InformationStateString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages:\nVotes:\nInformationStatePlayer: 5\n"
+ObservationString(0) = "Player: 0\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages:\nVotes:\n"
+ObservationString(1) = "Player: 1\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages:\nVotes:\n"
+ObservationString(2) = "Player: 2\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages:\nVotes:\n"
+ObservationString(3) = "Player: 3\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages:\nVotes:\n"
+ObservationString(4) = "Player: 4\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages:\nVotes:\n"
+ObservationString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages:\nVotes:\n"
+Rewards() = [0, 0, 0, 0, 0, 0]
+Returns() = [0, 0, 0, 0, 0, 0]
+LegalActions() = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
+StringLegalActions() = ["SKIP", "CLAIM_INNOCENT", "ACCUSE_PLAYER_0", "ACCUSE_PLAYER_1", "ACCUSE_PLAYER_2", "ACCUSE_PLAYER_3", "ACCUSE_PLAYER_4", "ACCUSE_PLAYER_5", "DEFEND_PLAYER_0", "DEFEND_PLAYER_1", "DEFEND_PLAYER_2", "DEFEND_PLAYER_3", "DEFEND_PLAYER_4", "DEFEND_PLAYER_5"]
+
+# Apply action "DEFEND_PLAYER_4"
+action: 12
+
+# State 3
+# Round: 0
+# Phase: Communication
+# Roles: 0=Innocent 1=Innocent 2=Innocent 3=Innocent 4=Innocent 5=Imposter
+# Alive: 0 1 2 3 4 5
+# Round 0
+# Signal: player 1 clear
+# Messages: 0=DEFEND_PLAYER_4
+# Votes:
+IsTerminal() = False
+History() = [32, 2, 12]
+HistoryString() = "32, 2, 12"
+IsChanceNode() = False
+IsSimultaneousNode() = False
+CurrentPlayer() = 1
+InformationStateString(0) = "Player: 0\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4\nVotes:\nInformationStatePlayer: 0\n"
+InformationStateString(1) = "Player: 1\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4\nVotes:\nInformationStatePlayer: 1\n"
+InformationStateString(2) = "Player: 2\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4\nVotes:\nInformationStatePlayer: 2\n"
+InformationStateString(3) = "Player: 3\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4\nVotes:\nInformationStatePlayer: 3\n"
+InformationStateString(4) = "Player: 4\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4\nVotes:\nInformationStatePlayer: 4\n"
+InformationStateString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4\nVotes:\nInformationStatePlayer: 5\n"
+ObservationString(0) = "Player: 0\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4\nVotes:\n"
+ObservationString(1) = "Player: 1\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4\nVotes:\n"
+ObservationString(2) = "Player: 2\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4\nVotes:\n"
+ObservationString(3) = "Player: 3\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4\nVotes:\n"
+ObservationString(4) = "Player: 4\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4\nVotes:\n"
+ObservationString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4\nVotes:\n"
+Rewards() = [0, 0, 0, 0, 0, 0]
+Returns() = [0, 0, 0, 0, 0, 0]
+LegalActions() = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
+StringLegalActions() = ["SKIP", "CLAIM_INNOCENT", "ACCUSE_PLAYER_0", "ACCUSE_PLAYER_1", "ACCUSE_PLAYER_2", "ACCUSE_PLAYER_3", "ACCUSE_PLAYER_4", "ACCUSE_PLAYER_5", "DEFEND_PLAYER_0", "DEFEND_PLAYER_1", "DEFEND_PLAYER_2", "DEFEND_PLAYER_3", "DEFEND_PLAYER_4", "DEFEND_PLAYER_5"]
+
+# Apply action "ACCUSE_PLAYER_0"
+action: 2
+
+# State 4
+# Round: 0
+# Phase: Communication
+# Roles: 0=Innocent 1=Innocent 2=Innocent 3=Innocent 4=Innocent 5=Imposter
+# Alive: 0 1 2 3 4 5
+# Round 0
+# Signal: player 1 clear
+# Messages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0
+# Votes:
+IsTerminal() = False
+History() = [32, 2, 12, 2]
+HistoryString() = "32, 2, 12, 2"
+IsChanceNode() = False
+IsSimultaneousNode() = False
+CurrentPlayer() = 2
+InformationStateString(0) = "Player: 0\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0\nVotes:\nInformationStatePlayer: 0\n"
+InformationStateString(1) = "Player: 1\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0\nVotes:\nInformationStatePlayer: 1\n"
+InformationStateString(2) = "Player: 2\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0\nVotes:\nInformationStatePlayer: 2\n"
+InformationStateString(3) = "Player: 3\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0\nVotes:\nInformationStatePlayer: 3\n"
+InformationStateString(4) = "Player: 4\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0\nVotes:\nInformationStatePlayer: 4\n"
+InformationStateString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0\nVotes:\nInformationStatePlayer: 5\n"
+ObservationString(0) = "Player: 0\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0\nVotes:\n"
+ObservationString(1) = "Player: 1\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0\nVotes:\n"
+ObservationString(2) = "Player: 2\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0\nVotes:\n"
+ObservationString(3) = "Player: 3\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0\nVotes:\n"
+ObservationString(4) = "Player: 4\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0\nVotes:\n"
+ObservationString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0\nVotes:\n"
+Rewards() = [0, 0, 0, 0, 0, 0]
+Returns() = [0, 0, 0, 0, 0, 0]
+LegalActions() = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
+StringLegalActions() = ["SKIP", "CLAIM_INNOCENT", "ACCUSE_PLAYER_0", "ACCUSE_PLAYER_1", "ACCUSE_PLAYER_2", "ACCUSE_PLAYER_3", "ACCUSE_PLAYER_4", "ACCUSE_PLAYER_5", "DEFEND_PLAYER_0", "DEFEND_PLAYER_1", "DEFEND_PLAYER_2", "DEFEND_PLAYER_3", "DEFEND_PLAYER_4", "DEFEND_PLAYER_5"]
+
+# Apply action "ACCUSE_PLAYER_4"
+action: 6
+
+# State 5
+# Round: 0
+# Phase: Communication
+# Roles: 0=Innocent 1=Innocent 2=Innocent 3=Innocent 4=Innocent 5=Imposter
+# Alive: 0 1 2 3 4 5
+# Round 0
+# Signal: player 1 clear
+# Messages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4
+# Votes:
+IsTerminal() = False
+History() = [32, 2, 12, 2, 6]
+HistoryString() = "32, 2, 12, 2, 6"
+IsChanceNode() = False
+IsSimultaneousNode() = False
+CurrentPlayer() = 3
+InformationStateString(0) = "Player: 0\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4\nVotes:\nInformationStatePlayer: 0\n"
+InformationStateString(1) = "Player: 1\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4\nVotes:\nInformationStatePlayer: 1\n"
+InformationStateString(2) = "Player: 2\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4\nVotes:\nInformationStatePlayer: 2\n"
+InformationStateString(3) = "Player: 3\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4\nVotes:\nInformationStatePlayer: 3\n"
+InformationStateString(4) = "Player: 4\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4\nVotes:\nInformationStatePlayer: 4\n"
+InformationStateString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4\nVotes:\nInformationStatePlayer: 5\n"
+ObservationString(0) = "Player: 0\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4\nVotes:\n"
+ObservationString(1) = "Player: 1\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4\nVotes:\n"
+ObservationString(2) = "Player: 2\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4\nVotes:\n"
+ObservationString(3) = "Player: 3\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4\nVotes:\n"
+ObservationString(4) = "Player: 4\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4\nVotes:\n"
+ObservationString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4\nVotes:\n"
+Rewards() = [0, 0, 0, 0, 0, 0]
+Returns() = [0, 0, 0, 0, 0, 0]
+LegalActions() = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
+StringLegalActions() = ["SKIP", "CLAIM_INNOCENT", "ACCUSE_PLAYER_0", "ACCUSE_PLAYER_1", "ACCUSE_PLAYER_2", "ACCUSE_PLAYER_3", "ACCUSE_PLAYER_4", "ACCUSE_PLAYER_5", "DEFEND_PLAYER_0", "DEFEND_PLAYER_1", "DEFEND_PLAYER_2", "DEFEND_PLAYER_3", "DEFEND_PLAYER_4", "DEFEND_PLAYER_5"]
+
+# Apply action "CLAIM_INNOCENT"
+action: 1
+
+# State 6
+# Round: 0
+# Phase: Communication
+# Roles: 0=Innocent 1=Innocent 2=Innocent 3=Innocent 4=Innocent 5=Imposter
+# Alive: 0 1 2 3 4 5
+# Round 0
+# Signal: player 1 clear
+# Messages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT
+# Votes:
+IsTerminal() = False
+History() = [32, 2, 12, 2, 6, 1]
+HistoryString() = "32, 2, 12, 2, 6, 1"
+IsChanceNode() = False
+IsSimultaneousNode() = False
+CurrentPlayer() = 4
+InformationStateString(0) = "Player: 0\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT\nVotes:\nInformationStatePlayer: 0\n"
+InformationStateString(1) = "Player: 1\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT\nVotes:\nInformationStatePlayer: 1\n"
+InformationStateString(2) = "Player: 2\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT\nVotes:\nInformationStatePlayer: 2\n"
+InformationStateString(3) = "Player: 3\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT\nVotes:\nInformationStatePlayer: 3\n"
+InformationStateString(4) = "Player: 4\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT\nVotes:\nInformationStatePlayer: 4\n"
+InformationStateString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT\nVotes:\nInformationStatePlayer: 5\n"
+ObservationString(0) = "Player: 0\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT\nVotes:\n"
+ObservationString(1) = "Player: 1\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT\nVotes:\n"
+ObservationString(2) = "Player: 2\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT\nVotes:\n"
+ObservationString(3) = "Player: 3\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT\nVotes:\n"
+ObservationString(4) = "Player: 4\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT\nVotes:\n"
+ObservationString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT\nVotes:\n"
+Rewards() = [0, 0, 0, 0, 0, 0]
+Returns() = [0, 0, 0, 0, 0, 0]
+LegalActions() = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
+StringLegalActions() = ["SKIP", "CLAIM_INNOCENT", "ACCUSE_PLAYER_0", "ACCUSE_PLAYER_1", "ACCUSE_PLAYER_2", "ACCUSE_PLAYER_3", "ACCUSE_PLAYER_4", "ACCUSE_PLAYER_5", "DEFEND_PLAYER_0", "DEFEND_PLAYER_1", "DEFEND_PLAYER_2", "DEFEND_PLAYER_3", "DEFEND_PLAYER_4", "DEFEND_PLAYER_5"]
+
+# Apply action "ACCUSE_PLAYER_1"
+action: 3
+
+# State 7
+# Round: 0
+# Phase: Communication
+# Roles: 0=Innocent 1=Innocent 2=Innocent 3=Innocent 4=Innocent 5=Imposter
+# Alive: 0 1 2 3 4 5
+# Round 0
+# Signal: player 1 clear
+# Messages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1
+# Votes:
+IsTerminal() = False
+History() = [32, 2, 12, 2, 6, 1, 3]
+HistoryString() = "32, 2, 12, 2, 6, 1, 3"
+IsChanceNode() = False
+IsSimultaneousNode() = False
+CurrentPlayer() = 5
+InformationStateString(0) = "Player: 0\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1\nVotes:\nInformationStatePlayer: 0\n"
+InformationStateString(1) = "Player: 1\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1\nVotes:\nInformationStatePlayer: 1\n"
+InformationStateString(2) = "Player: 2\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1\nVotes:\nInformationStatePlayer: 2\n"
+InformationStateString(3) = "Player: 3\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1\nVotes:\nInformationStatePlayer: 3\n"
+InformationStateString(4) = "Player: 4\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1\nVotes:\nInformationStatePlayer: 4\n"
+InformationStateString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1\nVotes:\nInformationStatePlayer: 5\n"
+ObservationString(0) = "Player: 0\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1\nVotes:\n"
+ObservationString(1) = "Player: 1\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1\nVotes:\n"
+ObservationString(2) = "Player: 2\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1\nVotes:\n"
+ObservationString(3) = "Player: 3\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1\nVotes:\n"
+ObservationString(4) = "Player: 4\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1\nVotes:\n"
+ObservationString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1\nVotes:\n"
+Rewards() = [0, 0, 0, 0, 0, 0]
+Returns() = [0, 0, 0, 0, 0, 0]
+LegalActions() = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
+StringLegalActions() = ["SKIP", "CLAIM_INNOCENT", "ACCUSE_PLAYER_0", "ACCUSE_PLAYER_1", "ACCUSE_PLAYER_2", "ACCUSE_PLAYER_3", "ACCUSE_PLAYER_4", "ACCUSE_PLAYER_5", "DEFEND_PLAYER_0", "DEFEND_PLAYER_1", "DEFEND_PLAYER_2", "DEFEND_PLAYER_3", "DEFEND_PLAYER_4", "DEFEND_PLAYER_5"]
+
+# Apply action "DEFEND_PLAYER_2"
+action: 10
+
+# State 8
+# Round: 0
+# Phase: Voting
+# Roles: 0=Innocent 1=Innocent 2=Innocent 3=Innocent 4=Innocent 5=Imposter
+# Alive: 0 1 2 3 4 5
+# Round 0
+# Signal: player 1 clear
+# Messages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2
+# Votes:
+IsTerminal() = False
+History() = [32, 2, 12, 2, 6, 1, 3, 10]
+HistoryString() = "32, 2, 12, 2, 6, 1, 3, 10"
+IsChanceNode() = False
+IsSimultaneousNode() = False
+CurrentPlayer() = 0
+InformationStateString(0) = "Player: 0\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes:\nInformationStatePlayer: 0\n"
+InformationStateString(1) = "Player: 1\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes:\nInformationStatePlayer: 1\n"
+InformationStateString(2) = "Player: 2\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes:\nInformationStatePlayer: 2\n"
+InformationStateString(3) = "Player: 3\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes:\nInformationStatePlayer: 3\n"
+InformationStateString(4) = "Player: 4\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes:\nInformationStatePlayer: 4\n"
+InformationStateString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes:\nInformationStatePlayer: 5\n"
+ObservationString(0) = "Player: 0\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes:\n"
+ObservationString(1) = "Player: 1\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes:\n"
+ObservationString(2) = "Player: 2\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes:\n"
+ObservationString(3) = "Player: 3\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes:\n"
+ObservationString(4) = "Player: 4\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes:\n"
+ObservationString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes:\n"
+Rewards() = [0, 0, 0, 0, 0, 0]
+Returns() = [0, 0, 0, 0, 0, 0]
+LegalActions() = [1, 2, 3, 4, 5]
+StringLegalActions() = ["VOTE_PLAYER_1", "VOTE_PLAYER_2", "VOTE_PLAYER_3", "VOTE_PLAYER_4", "VOTE_PLAYER_5"]
+
+# Apply action "VOTE_PLAYER_4"
+action: 4
+
+# State 9
+# Round: 0
+# Phase: Voting
+# Roles: 0=Innocent 1=Innocent 2=Innocent 3=Innocent 4=Innocent 5=Imposter
+# Alive: 0 1 2 3 4 5
+# Round 0
+# Signal: player 1 clear
+# Messages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2
+# Votes: 0->4
+IsTerminal() = False
+History() = [32, 2, 12, 2, 6, 1, 3, 10, 4]
+HistoryString() = "32, 2, 12, 2, 6, 1, 3, 10, 4"
+IsChanceNode() = False
+IsSimultaneousNode() = False
+CurrentPlayer() = 1
+InformationStateString(0) = "Player: 0\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4\nInformationStatePlayer: 0\n"
+InformationStateString(1) = "Player: 1\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4\nInformationStatePlayer: 1\n"
+InformationStateString(2) = "Player: 2\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4\nInformationStatePlayer: 2\n"
+InformationStateString(3) = "Player: 3\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4\nInformationStatePlayer: 3\n"
+InformationStateString(4) = "Player: 4\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4\nInformationStatePlayer: 4\n"
+InformationStateString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4\nInformationStatePlayer: 5\n"
+ObservationString(0) = "Player: 0\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4\n"
+ObservationString(1) = "Player: 1\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4\n"
+ObservationString(2) = "Player: 2\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4\n"
+ObservationString(3) = "Player: 3\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4\n"
+ObservationString(4) = "Player: 4\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4\n"
+ObservationString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4\n"
+Rewards() = [0, 0, 0, 0, 0, 0]
+Returns() = [0, 0, 0, 0, 0, 0]
+LegalActions() = [0, 2, 3, 4, 5]
+StringLegalActions() = ["VOTE_PLAYER_0", "VOTE_PLAYER_2", "VOTE_PLAYER_3", "VOTE_PLAYER_4", "VOTE_PLAYER_5"]
+
+# Apply action "VOTE_PLAYER_2"
+action: 2
+
+# State 10
+# Round: 0
+# Phase: Voting
+# Roles: 0=Innocent 1=Innocent 2=Innocent 3=Innocent 4=Innocent 5=Imposter
+# Alive: 0 1 2 3 4 5
+# Round 0
+# Signal: player 1 clear
+# Messages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2
+# Votes: 0->4 1->2
+IsTerminal() = False
+History() = [32, 2, 12, 2, 6, 1, 3, 10, 4, 2]
+HistoryString() = "32, 2, 12, 2, 6, 1, 3, 10, 4, 2"
+IsChanceNode() = False
+IsSimultaneousNode() = False
+CurrentPlayer() = 2
+InformationStateString(0) = "Player: 0\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2\nInformationStatePlayer: 0\n"
+InformationStateString(1) = "Player: 1\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2\nInformationStatePlayer: 1\n"
+InformationStateString(2) = "Player: 2\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2\nInformationStatePlayer: 2\n"
+InformationStateString(3) = "Player: 3\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2\nInformationStatePlayer: 3\n"
+InformationStateString(4) = "Player: 4\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2\nInformationStatePlayer: 4\n"
+InformationStateString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2\nInformationStatePlayer: 5\n"
+ObservationString(0) = "Player: 0\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2\n"
+ObservationString(1) = "Player: 1\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2\n"
+ObservationString(2) = "Player: 2\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2\n"
+ObservationString(3) = "Player: 3\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2\n"
+ObservationString(4) = "Player: 4\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2\n"
+ObservationString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2\n"
+Rewards() = [0, 0, 0, 0, 0, 0]
+Returns() = [0, 0, 0, 0, 0, 0]
+LegalActions() = [0, 1, 3, 4, 5]
+StringLegalActions() = ["VOTE_PLAYER_0", "VOTE_PLAYER_1", "VOTE_PLAYER_3", "VOTE_PLAYER_4", "VOTE_PLAYER_5"]
+
+# Apply action "VOTE_PLAYER_1"
+action: 1
+
+# State 11
+# Round: 0
+# Phase: Voting
+# Roles: 0=Innocent 1=Innocent 2=Innocent 3=Innocent 4=Innocent 5=Imposter
+# Alive: 0 1 2 3 4 5
+# Round 0
+# Signal: player 1 clear
+# Messages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2
+# Votes: 0->4 1->2 2->1
+IsTerminal() = False
+History() = [32, 2, 12, 2, 6, 1, 3, 10, 4, 2, 1]
+HistoryString() = "32, 2, 12, 2, 6, 1, 3, 10, 4, 2, 1"
+IsChanceNode() = False
+IsSimultaneousNode() = False
+CurrentPlayer() = 3
+InformationStateString(0) = "Player: 0\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1\nInformationStatePlayer: 0\n"
+InformationStateString(1) = "Player: 1\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1\nInformationStatePlayer: 1\n"
+InformationStateString(2) = "Player: 2\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1\nInformationStatePlayer: 2\n"
+InformationStateString(3) = "Player: 3\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1\nInformationStatePlayer: 3\n"
+InformationStateString(4) = "Player: 4\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1\nInformationStatePlayer: 4\n"
+InformationStateString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1\nInformationStatePlayer: 5\n"
+ObservationString(0) = "Player: 0\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1\n"
+ObservationString(1) = "Player: 1\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1\n"
+ObservationString(2) = "Player: 2\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1\n"
+ObservationString(3) = "Player: 3\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1\n"
+ObservationString(4) = "Player: 4\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1\n"
+ObservationString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1\n"
+Rewards() = [0, 0, 0, 0, 0, 0]
+Returns() = [0, 0, 0, 0, 0, 0]
+LegalActions() = [0, 1, 2, 4, 5]
+StringLegalActions() = ["VOTE_PLAYER_0", "VOTE_PLAYER_1", "VOTE_PLAYER_2", "VOTE_PLAYER_4", "VOTE_PLAYER_5"]
+
+# Apply action "VOTE_PLAYER_0"
+action: 0
+
+# State 12
+# Round: 0
+# Phase: Voting
+# Roles: 0=Innocent 1=Innocent 2=Innocent 3=Innocent 4=Innocent 5=Imposter
+# Alive: 0 1 2 3 4 5
+# Round 0
+# Signal: player 1 clear
+# Messages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2
+# Votes: 0->4 1->2 2->1 3->0
+IsTerminal() = False
+History() = [32, 2, 12, 2, 6, 1, 3, 10, 4, 2, 1, 0]
+HistoryString() = "32, 2, 12, 2, 6, 1, 3, 10, 4, 2, 1, 0"
+IsChanceNode() = False
+IsSimultaneousNode() = False
+CurrentPlayer() = 4
+InformationStateString(0) = "Player: 0\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0\nInformationStatePlayer: 0\n"
+InformationStateString(1) = "Player: 1\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0\nInformationStatePlayer: 1\n"
+InformationStateString(2) = "Player: 2\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0\nInformationStatePlayer: 2\n"
+InformationStateString(3) = "Player: 3\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0\nInformationStatePlayer: 3\n"
+InformationStateString(4) = "Player: 4\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0\nInformationStatePlayer: 4\n"
+InformationStateString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0\nInformationStatePlayer: 5\n"
+ObservationString(0) = "Player: 0\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0\n"
+ObservationString(1) = "Player: 1\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0\n"
+ObservationString(2) = "Player: 2\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0\n"
+ObservationString(3) = "Player: 3\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0\n"
+ObservationString(4) = "Player: 4\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0\n"
+ObservationString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0\n"
+Rewards() = [0, 0, 0, 0, 0, 0]
+Returns() = [0, 0, 0, 0, 0, 0]
+LegalActions() = [0, 1, 2, 3, 5]
+StringLegalActions() = ["VOTE_PLAYER_0", "VOTE_PLAYER_1", "VOTE_PLAYER_2", "VOTE_PLAYER_3", "VOTE_PLAYER_5"]
+
+# Apply action "VOTE_PLAYER_1"
+action: 1
+
+# State 13
+# Round: 0
+# Phase: Voting
+# Roles: 0=Innocent 1=Innocent 2=Innocent 3=Innocent 4=Innocent 5=Imposter
+# Alive: 0 1 2 3 4 5
+# Round 0
+# Signal: player 1 clear
+# Messages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2
+# Votes: 0->4 1->2 2->1 3->0 4->1
+IsTerminal() = False
+History() = [32, 2, 12, 2, 6, 1, 3, 10, 4, 2, 1, 0, 1]
+HistoryString() = "32, 2, 12, 2, 6, 1, 3, 10, 4, 2, 1, 0, 1"
+IsChanceNode() = False
+IsSimultaneousNode() = False
+CurrentPlayer() = 5
+InformationStateString(0) = "Player: 0\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1\nInformationStatePlayer: 0\n"
+InformationStateString(1) = "Player: 1\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1\nInformationStatePlayer: 1\n"
+InformationStateString(2) = "Player: 2\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1\nInformationStatePlayer: 2\n"
+InformationStateString(3) = "Player: 3\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1\nInformationStatePlayer: 3\n"
+InformationStateString(4) = "Player: 4\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1\nInformationStatePlayer: 4\n"
+InformationStateString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1\nInformationStatePlayer: 5\n"
+ObservationString(0) = "Player: 0\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1\n"
+ObservationString(1) = "Player: 1\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1\n"
+ObservationString(2) = "Player: 2\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1\n"
+ObservationString(3) = "Player: 3\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1\n"
+ObservationString(4) = "Player: 4\nRole: Innocent\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1\n"
+ObservationString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 1 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1\n"
+Rewards() = [0, 0, 0, 0, 0, 0]
+Returns() = [0, 0, 0, 0, 0, 0]
+LegalActions() = [0, 1, 2, 3, 4]
+StringLegalActions() = ["VOTE_PLAYER_0", "VOTE_PLAYER_1", "VOTE_PLAYER_2", "VOTE_PLAYER_3", "VOTE_PLAYER_4"]
+
+# Apply action "VOTE_PLAYER_1"
+action: 1
+
+# State 14
+# Apply action "SIGNAL_PLAYER_0_CLEAR"
+action: 0
+
+# State 15
+# Round: 1
+# Phase: Communication
+# Roles: 0=Innocent 1=Innocent 2=Innocent 3=Innocent 4=Innocent 5=Imposter
+# Alive: 0 2 3 4 5
+# Round 0
+# Signal: player 1 clear
+# Messages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2
+# Votes: 0->4 1->2 2->1 3->0 4->1 5->1
+# Eliminated: 1
+# Round 1
+# Signal: player 0 clear
+# Messages:
+# Votes:
+IsTerminal() = False
+History() = [32, 2, 12, 2, 6, 1, 3, 10, 4, 2, 1, 0, 1, 1, 0]
+HistoryString() = "32, 2, 12, 2, 6, 1, 3, 10, 4, 2, 1, 0, 1, 1, 0"
+IsChanceNode() = False
+IsSimultaneousNode() = False
+CurrentPlayer() = 0
+InformationStateString(0) = "Player: 0\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages:\nVotes:\nInformationStatePlayer: 0\n"
+InformationStateString(1) = "Player: 1\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages:\nVotes:\nInformationStatePlayer: 1\n"
+InformationStateString(2) = "Player: 2\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages:\nVotes:\nInformationStatePlayer: 2\n"
+InformationStateString(3) = "Player: 3\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages:\nVotes:\nInformationStatePlayer: 3\n"
+InformationStateString(4) = "Player: 4\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages:\nVotes:\nInformationStatePlayer: 4\n"
+InformationStateString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages:\nVotes:\nInformationStatePlayer: 5\n"
+ObservationString(0) = "Player: 0\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages:\nVotes:\n"
+ObservationString(1) = "Player: 1\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages:\nVotes:\n"
+ObservationString(2) = "Player: 2\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages:\nVotes:\n"
+ObservationString(3) = "Player: 3\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages:\nVotes:\n"
+ObservationString(4) = "Player: 4\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages:\nVotes:\n"
+ObservationString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages:\nVotes:\n"
+Rewards() = [0, 0, 0, 0, 0, 0]
+Returns() = [0, 0, 0, 0, 0, 0]
+LegalActions() = [0, 1, 2, 4, 5, 6, 7, 8, 10, 11, 12, 13]
+StringLegalActions() = ["SKIP", "CLAIM_INNOCENT", "ACCUSE_PLAYER_0", "ACCUSE_PLAYER_2", "ACCUSE_PLAYER_3", "ACCUSE_PLAYER_4", "ACCUSE_PLAYER_5", "DEFEND_PLAYER_0", "DEFEND_PLAYER_2", "DEFEND_PLAYER_3", "DEFEND_PLAYER_4", "DEFEND_PLAYER_5"]
+
+# Apply action "SKIP"
+action: 0
+
+# State 16
+# Round: 1
+# Phase: Communication
+# Roles: 0=Innocent 1=Innocent 2=Innocent 3=Innocent 4=Innocent 5=Imposter
+# Alive: 0 2 3 4 5
+# Round 0
+# Signal: player 1 clear
+# Messages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2
+# Votes: 0->4 1->2 2->1 3->0 4->1 5->1
+# Eliminated: 1
+# Round 1
+# Signal: player 0 clear
+# Messages: 0=SKIP
+# Votes:
+IsTerminal() = False
+History() = [32, 2, 12, 2, 6, 1, 3, 10, 4, 2, 1, 0, 1, 1, 0, 0]
+HistoryString() = "32, 2, 12, 2, 6, 1, 3, 10, 4, 2, 1, 0, 1, 1, 0, 0"
+IsChanceNode() = False
+IsSimultaneousNode() = False
+CurrentPlayer() = 2
+InformationStateString(0) = "Player: 0\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP\nVotes:\nInformationStatePlayer: 0\n"
+InformationStateString(1) = "Player: 1\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP\nVotes:\nInformationStatePlayer: 1\n"
+InformationStateString(2) = "Player: 2\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP\nVotes:\nInformationStatePlayer: 2\n"
+InformationStateString(3) = "Player: 3\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP\nVotes:\nInformationStatePlayer: 3\n"
+InformationStateString(4) = "Player: 4\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP\nVotes:\nInformationStatePlayer: 4\n"
+InformationStateString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP\nVotes:\nInformationStatePlayer: 5\n"
+ObservationString(0) = "Player: 0\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP\nVotes:\n"
+ObservationString(1) = "Player: 1\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP\nVotes:\n"
+ObservationString(2) = "Player: 2\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP\nVotes:\n"
+ObservationString(3) = "Player: 3\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP\nVotes:\n"
+ObservationString(4) = "Player: 4\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP\nVotes:\n"
+ObservationString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP\nVotes:\n"
+Rewards() = [0, 0, 0, 0, 0, 0]
+Returns() = [0, 0, 0, 0, 0, 0]
+LegalActions() = [0, 1, 2, 4, 5, 6, 7, 8, 10, 11, 12, 13]
+StringLegalActions() = ["SKIP", "CLAIM_INNOCENT", "ACCUSE_PLAYER_0", "ACCUSE_PLAYER_2", "ACCUSE_PLAYER_3", "ACCUSE_PLAYER_4", "ACCUSE_PLAYER_5", "DEFEND_PLAYER_0", "DEFEND_PLAYER_2", "DEFEND_PLAYER_3", "DEFEND_PLAYER_4", "DEFEND_PLAYER_5"]
+
+# Apply action "DEFEND_PLAYER_3"
+action: 11
+
+# State 17
+# Round: 1
+# Phase: Communication
+# Roles: 0=Innocent 1=Innocent 2=Innocent 3=Innocent 4=Innocent 5=Imposter
+# Alive: 0 2 3 4 5
+# Round 0
+# Signal: player 1 clear
+# Messages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2
+# Votes: 0->4 1->2 2->1 3->0 4->1 5->1
+# Eliminated: 1
+# Round 1
+# Signal: player 0 clear
+# Messages: 0=SKIP 2=DEFEND_PLAYER_3
+# Votes:
+IsTerminal() = False
+History() = [32, 2, 12, 2, 6, 1, 3, 10, 4, 2, 1, 0, 1, 1, 0, 0, 11]
+HistoryString() = "32, 2, 12, 2, 6, 1, 3, 10, 4, 2, 1, 0, 1, 1, 0, 0, 11"
+IsChanceNode() = False
+IsSimultaneousNode() = False
+CurrentPlayer() = 3
+InformationStateString(0) = "Player: 0\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3\nVotes:\nInformationStatePlayer: 0\n"
+InformationStateString(1) = "Player: 1\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3\nVotes:\nInformationStatePlayer: 1\n"
+InformationStateString(2) = "Player: 2\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3\nVotes:\nInformationStatePlayer: 2\n"
+InformationStateString(3) = "Player: 3\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3\nVotes:\nInformationStatePlayer: 3\n"
+InformationStateString(4) = "Player: 4\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3\nVotes:\nInformationStatePlayer: 4\n"
+InformationStateString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3\nVotes:\nInformationStatePlayer: 5\n"
+ObservationString(0) = "Player: 0\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3\nVotes:\n"
+ObservationString(1) = "Player: 1\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3\nVotes:\n"
+ObservationString(2) = "Player: 2\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3\nVotes:\n"
+ObservationString(3) = "Player: 3\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3\nVotes:\n"
+ObservationString(4) = "Player: 4\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3\nVotes:\n"
+ObservationString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3\nVotes:\n"
+Rewards() = [0, 0, 0, 0, 0, 0]
+Returns() = [0, 0, 0, 0, 0, 0]
+LegalActions() = [0, 1, 2, 4, 5, 6, 7, 8, 10, 11, 12, 13]
+StringLegalActions() = ["SKIP", "CLAIM_INNOCENT", "ACCUSE_PLAYER_0", "ACCUSE_PLAYER_2", "ACCUSE_PLAYER_3", "ACCUSE_PLAYER_4", "ACCUSE_PLAYER_5", "DEFEND_PLAYER_0", "DEFEND_PLAYER_2", "DEFEND_PLAYER_3", "DEFEND_PLAYER_4", "DEFEND_PLAYER_5"]
+
+# Apply action "ACCUSE_PLAYER_2"
+action: 4
+
+# State 18
+# Round: 1
+# Phase: Communication
+# Roles: 0=Innocent 1=Innocent 2=Innocent 3=Innocent 4=Innocent 5=Imposter
+# Alive: 0 2 3 4 5
+# Round 0
+# Signal: player 1 clear
+# Messages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2
+# Votes: 0->4 1->2 2->1 3->0 4->1 5->1
+# Eliminated: 1
+# Round 1
+# Signal: player 0 clear
+# Messages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2
+# Votes:
+IsTerminal() = False
+History() = [32, 2, 12, 2, 6, 1, 3, 10, 4, 2, 1, 0, 1, 1, 0, 0, 11, 4]
+HistoryString() = "32, 2, 12, 2, 6, 1, 3, 10, 4, 2, 1, 0, 1, 1, 0, 0, 11, 4"
+IsChanceNode() = False
+IsSimultaneousNode() = False
+CurrentPlayer() = 4
+InformationStateString(0) = "Player: 0\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2\nVotes:\nInformationStatePlayer: 0\n"
+InformationStateString(1) = "Player: 1\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2\nVotes:\nInformationStatePlayer: 1\n"
+InformationStateString(2) = "Player: 2\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2\nVotes:\nInformationStatePlayer: 2\n"
+InformationStateString(3) = "Player: 3\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2\nVotes:\nInformationStatePlayer: 3\n"
+InformationStateString(4) = "Player: 4\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2\nVotes:\nInformationStatePlayer: 4\n"
+InformationStateString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2\nVotes:\nInformationStatePlayer: 5\n"
+ObservationString(0) = "Player: 0\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2\nVotes:\n"
+ObservationString(1) = "Player: 1\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2\nVotes:\n"
+ObservationString(2) = "Player: 2\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2\nVotes:\n"
+ObservationString(3) = "Player: 3\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2\nVotes:\n"
+ObservationString(4) = "Player: 4\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2\nVotes:\n"
+ObservationString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2\nVotes:\n"
+Rewards() = [0, 0, 0, 0, 0, 0]
+Returns() = [0, 0, 0, 0, 0, 0]
+LegalActions() = [0, 1, 2, 4, 5, 6, 7, 8, 10, 11, 12, 13]
+StringLegalActions() = ["SKIP", "CLAIM_INNOCENT", "ACCUSE_PLAYER_0", "ACCUSE_PLAYER_2", "ACCUSE_PLAYER_3", "ACCUSE_PLAYER_4", "ACCUSE_PLAYER_5", "DEFEND_PLAYER_0", "DEFEND_PLAYER_2", "DEFEND_PLAYER_3", "DEFEND_PLAYER_4", "DEFEND_PLAYER_5"]
+
+# Apply action "ACCUSE_PLAYER_3"
+action: 5
+
+# State 19
+# Round: 1
+# Phase: Communication
+# Roles: 0=Innocent 1=Innocent 2=Innocent 3=Innocent 4=Innocent 5=Imposter
+# Alive: 0 2 3 4 5
+# Round 0
+# Signal: player 1 clear
+# Messages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2
+# Votes: 0->4 1->2 2->1 3->0 4->1 5->1
+# Eliminated: 1
+# Round 1
+# Signal: player 0 clear
+# Messages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2 4=ACCUSE_PLAYER_3
+# Votes:
+IsTerminal() = False
+History() = [32, 2, 12, 2, 6, 1, 3, 10, 4, 2, 1, 0, 1, 1, 0, 0, 11, 4, 5]
+HistoryString() = "32, 2, 12, 2, 6, 1, 3, 10, 4, 2, 1, 0, 1, 1, 0, 0, 11, 4, 5"
+IsChanceNode() = False
+IsSimultaneousNode() = False
+CurrentPlayer() = 5
+InformationStateString(0) = "Player: 0\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2 4=ACCUSE_PLAYER_3\nVotes:\nInformationStatePlayer: 0\n"
+InformationStateString(1) = "Player: 1\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2 4=ACCUSE_PLAYER_3\nVotes:\nInformationStatePlayer: 1\n"
+InformationStateString(2) = "Player: 2\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2 4=ACCUSE_PLAYER_3\nVotes:\nInformationStatePlayer: 2\n"
+InformationStateString(3) = "Player: 3\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2 4=ACCUSE_PLAYER_3\nVotes:\nInformationStatePlayer: 3\n"
+InformationStateString(4) = "Player: 4\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2 4=ACCUSE_PLAYER_3\nVotes:\nInformationStatePlayer: 4\n"
+InformationStateString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2 4=ACCUSE_PLAYER_3\nVotes:\nInformationStatePlayer: 5\n"
+ObservationString(0) = "Player: 0\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2 4=ACCUSE_PLAYER_3\nVotes:\n"
+ObservationString(1) = "Player: 1\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2 4=ACCUSE_PLAYER_3\nVotes:\n"
+ObservationString(2) = "Player: 2\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2 4=ACCUSE_PLAYER_3\nVotes:\n"
+ObservationString(3) = "Player: 3\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2 4=ACCUSE_PLAYER_3\nVotes:\n"
+ObservationString(4) = "Player: 4\nRole: Innocent\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2 4=ACCUSE_PLAYER_3\nVotes:\n"
+ObservationString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 2 3 4 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2 4=ACCUSE_PLAYER_3\nVotes:\n"
+Rewards() = [0, 0, 0, 0, 0, 0]
+Returns() = [0, 0, 0, 0, 0, 0]
+LegalActions() = [0, 1, 2, 4, 5, 6, 7, 8, 10, 11, 12, 13]
+StringLegalActions() = ["SKIP", "CLAIM_INNOCENT", "ACCUSE_PLAYER_0", "ACCUSE_PLAYER_2", "ACCUSE_PLAYER_3", "ACCUSE_PLAYER_4", "ACCUSE_PLAYER_5", "DEFEND_PLAYER_0", "DEFEND_PLAYER_2", "DEFEND_PLAYER_3", "DEFEND_PLAYER_4", "DEFEND_PLAYER_5"]
+
+# Apply action "SKIP"
+action: 0
+
+# State 20
+# Apply action "VOTE_PLAYER_2"
+action: 2
+
+# State 21
+# Apply action "VOTE_PLAYER_0"
+action: 0
+
+# State 22
+# Apply action "VOTE_PLAYER_2"
+action: 2
+
+# State 23
+# Apply action "VOTE_PLAYER_5"
+action: 5
+
+# State 24
+# Apply action "VOTE_PLAYER_4"
+action: 4
+
+# State 25
+# Apply action "SIGNAL_PLAYER_3_CLEAR"
+action: 6
+
+# State 26
+# Apply action "ACCUSE_PLAYER_4"
+action: 6
+
+# State 27
+# Apply action "DEFEND_PLAYER_3"
+action: 11
+
+# State 28
+# Apply action "ACCUSE_PLAYER_0"
+action: 2
+
+# State 29
+# Apply action "ACCUSE_PLAYER_4"
+action: 6
+
+# State 30
+# Apply action "VOTE_PLAYER_3"
+action: 3
+
+# State 31
+# Apply action "VOTE_PLAYER_4"
+action: 4
+
+# State 32
+# Apply action "VOTE_PLAYER_0"
+action: 0
+
+# State 33
+# Apply action "VOTE_PLAYER_3"
+action: 3
+
+# State 34
+# Apply action "SIGNAL_PLAYER_4_SUSPICIOUS"
+action: 9
+
+# State 35
+# Apply action "ACCUSE_PLAYER_5"
+action: 7
+
+# State 36
+# Apply action "ACCUSE_PLAYER_5"
+action: 7
+
+# State 37
+# Apply action "ACCUSE_PLAYER_5"
+action: 7
+
+# State 38
+# Apply action "VOTE_PLAYER_4"
+action: 4
+
+# State 39
+# Apply action "VOTE_PLAYER_5"
+action: 5
+
+# State 40
+# Apply action "VOTE_PLAYER_4"
+action: 4
+
+# State 41
+# Round: 4
+# Phase: Terminal
+# Roles: 0=Innocent 1=Innocent 2=Innocent 3=Innocent 4=Innocent 5=Imposter
+# Alive: 0 5
+# Round 0
+# Signal: player 1 clear
+# Messages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2
+# Votes: 0->4 1->2 2->1 3->0 4->1 5->1
+# Eliminated: 1
+# Round 1
+# Signal: player 0 clear
+# Messages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2 4=ACCUSE_PLAYER_3 5=SKIP
+# Votes: 0->2 2->0 3->2 4->5 5->4
+# Eliminated: 2
+# Round 2
+# Signal: player 3 clear
+# Messages: 0=ACCUSE_PLAYER_4 3=DEFEND_PLAYER_3 4=ACCUSE_PLAYER_0 5=ACCUSE_PLAYER_4
+# Votes: 0->3 3->4 4->0 5->3
+# Eliminated: 3
+# Round 3
+# Signal: player 4 suspicious
+# Messages: 0=ACCUSE_PLAYER_5 4=ACCUSE_PLAYER_5 5=ACCUSE_PLAYER_5
+# Votes: 0->4 4->5 5->4
+# Eliminated: 4
+IsTerminal() = True
+History() = [32, 2, 12, 2, 6, 1, 3, 10, 4, 2, 1, 0, 1, 1, 0, 0, 11, 4, 5, 0, 2, 0, 2, 5, 4, 6, 6, 11, 2, 6, 3, 4, 0, 3, 9, 7, 7, 7, 4, 5, 4]
+HistoryString() = "32, 2, 12, 2, 6, 1, 3, 10, 4, 2, 1, 0, 1, 1, 0, 0, 11, 4, 5, 0, 2, 0, 2, 5, 4, 6, 6, 11, 2, 6, 3, 4, 0, 3, 9, 7, 7, 7, 4, 5, 4"
+IsChanceNode() = False
+IsSimultaneousNode() = False
+CurrentPlayer() = -4
+InformationStateString(0) = "Player: 0\nRole: Innocent\nAlive: 0 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2 4=ACCUSE_PLAYER_3 5=SKIP\nVotes: 0->2 2->0 3->2 4->5 5->4\nEliminated: 2\nRound 2\nSignal: player 3 clear\nMessages: 0=ACCUSE_PLAYER_4 3=DEFEND_PLAYER_3 4=ACCUSE_PLAYER_0 5=ACCUSE_PLAYER_4\nVotes: 0->3 3->4 4->0 5->3\nEliminated: 3\nRound 3\nSignal: player 4 suspicious\nMessages: 0=ACCUSE_PLAYER_5 4=ACCUSE_PLAYER_5 5=ACCUSE_PLAYER_5\nVotes: 0->4 4->5 5->4\nEliminated: 4\nInformationStatePlayer: 0\n"
+InformationStateString(1) = "Player: 1\nRole: Innocent\nAlive: 0 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2 4=ACCUSE_PLAYER_3 5=SKIP\nVotes: 0->2 2->0 3->2 4->5 5->4\nEliminated: 2\nRound 2\nSignal: player 3 clear\nMessages: 0=ACCUSE_PLAYER_4 3=DEFEND_PLAYER_3 4=ACCUSE_PLAYER_0 5=ACCUSE_PLAYER_4\nVotes: 0->3 3->4 4->0 5->3\nEliminated: 3\nRound 3\nSignal: player 4 suspicious\nMessages: 0=ACCUSE_PLAYER_5 4=ACCUSE_PLAYER_5 5=ACCUSE_PLAYER_5\nVotes: 0->4 4->5 5->4\nEliminated: 4\nInformationStatePlayer: 1\n"
+InformationStateString(2) = "Player: 2\nRole: Innocent\nAlive: 0 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2 4=ACCUSE_PLAYER_3 5=SKIP\nVotes: 0->2 2->0 3->2 4->5 5->4\nEliminated: 2\nRound 2\nSignal: player 3 clear\nMessages: 0=ACCUSE_PLAYER_4 3=DEFEND_PLAYER_3 4=ACCUSE_PLAYER_0 5=ACCUSE_PLAYER_4\nVotes: 0->3 3->4 4->0 5->3\nEliminated: 3\nRound 3\nSignal: player 4 suspicious\nMessages: 0=ACCUSE_PLAYER_5 4=ACCUSE_PLAYER_5 5=ACCUSE_PLAYER_5\nVotes: 0->4 4->5 5->4\nEliminated: 4\nInformationStatePlayer: 2\n"
+InformationStateString(3) = "Player: 3\nRole: Innocent\nAlive: 0 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2 4=ACCUSE_PLAYER_3 5=SKIP\nVotes: 0->2 2->0 3->2 4->5 5->4\nEliminated: 2\nRound 2\nSignal: player 3 clear\nMessages: 0=ACCUSE_PLAYER_4 3=DEFEND_PLAYER_3 4=ACCUSE_PLAYER_0 5=ACCUSE_PLAYER_4\nVotes: 0->3 3->4 4->0 5->3\nEliminated: 3\nRound 3\nSignal: player 4 suspicious\nMessages: 0=ACCUSE_PLAYER_5 4=ACCUSE_PLAYER_5 5=ACCUSE_PLAYER_5\nVotes: 0->4 4->5 5->4\nEliminated: 4\nInformationStatePlayer: 3\n"
+InformationStateString(4) = "Player: 4\nRole: Innocent\nAlive: 0 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2 4=ACCUSE_PLAYER_3 5=SKIP\nVotes: 0->2 2->0 3->2 4->5 5->4\nEliminated: 2\nRound 2\nSignal: player 3 clear\nMessages: 0=ACCUSE_PLAYER_4 3=DEFEND_PLAYER_3 4=ACCUSE_PLAYER_0 5=ACCUSE_PLAYER_4\nVotes: 0->3 3->4 4->0 5->3\nEliminated: 3\nRound 3\nSignal: player 4 suspicious\nMessages: 0=ACCUSE_PLAYER_5 4=ACCUSE_PLAYER_5 5=ACCUSE_PLAYER_5\nVotes: 0->4 4->5 5->4\nEliminated: 4\nInformationStatePlayer: 4\n"
+InformationStateString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2 4=ACCUSE_PLAYER_3 5=SKIP\nVotes: 0->2 2->0 3->2 4->5 5->4\nEliminated: 2\nRound 2\nSignal: player 3 clear\nMessages: 0=ACCUSE_PLAYER_4 3=DEFEND_PLAYER_3 4=ACCUSE_PLAYER_0 5=ACCUSE_PLAYER_4\nVotes: 0->3 3->4 4->0 5->3\nEliminated: 3\nRound 3\nSignal: player 4 suspicious\nMessages: 0=ACCUSE_PLAYER_5 4=ACCUSE_PLAYER_5 5=ACCUSE_PLAYER_5\nVotes: 0->4 4->5 5->4\nEliminated: 4\nInformationStatePlayer: 5\n"
+ObservationString(0) = "Player: 0\nRole: Innocent\nAlive: 0 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2 4=ACCUSE_PLAYER_3 5=SKIP\nVotes: 0->2 2->0 3->2 4->5 5->4\nEliminated: 2\nRound 2\nSignal: player 3 clear\nMessages: 0=ACCUSE_PLAYER_4 3=DEFEND_PLAYER_3 4=ACCUSE_PLAYER_0 5=ACCUSE_PLAYER_4\nVotes: 0->3 3->4 4->0 5->3\nEliminated: 3\nRound 3\nSignal: player 4 suspicious\nMessages: 0=ACCUSE_PLAYER_5 4=ACCUSE_PLAYER_5 5=ACCUSE_PLAYER_5\nVotes: 0->4 4->5 5->4\nEliminated: 4\n"
+ObservationString(1) = "Player: 1\nRole: Innocent\nAlive: 0 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2 4=ACCUSE_PLAYER_3 5=SKIP\nVotes: 0->2 2->0 3->2 4->5 5->4\nEliminated: 2\nRound 2\nSignal: player 3 clear\nMessages: 0=ACCUSE_PLAYER_4 3=DEFEND_PLAYER_3 4=ACCUSE_PLAYER_0 5=ACCUSE_PLAYER_4\nVotes: 0->3 3->4 4->0 5->3\nEliminated: 3\nRound 3\nSignal: player 4 suspicious\nMessages: 0=ACCUSE_PLAYER_5 4=ACCUSE_PLAYER_5 5=ACCUSE_PLAYER_5\nVotes: 0->4 4->5 5->4\nEliminated: 4\n"
+ObservationString(2) = "Player: 2\nRole: Innocent\nAlive: 0 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2 4=ACCUSE_PLAYER_3 5=SKIP\nVotes: 0->2 2->0 3->2 4->5 5->4\nEliminated: 2\nRound 2\nSignal: player 3 clear\nMessages: 0=ACCUSE_PLAYER_4 3=DEFEND_PLAYER_3 4=ACCUSE_PLAYER_0 5=ACCUSE_PLAYER_4\nVotes: 0->3 3->4 4->0 5->3\nEliminated: 3\nRound 3\nSignal: player 4 suspicious\nMessages: 0=ACCUSE_PLAYER_5 4=ACCUSE_PLAYER_5 5=ACCUSE_PLAYER_5\nVotes: 0->4 4->5 5->4\nEliminated: 4\n"
+ObservationString(3) = "Player: 3\nRole: Innocent\nAlive: 0 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2 4=ACCUSE_PLAYER_3 5=SKIP\nVotes: 0->2 2->0 3->2 4->5 5->4\nEliminated: 2\nRound 2\nSignal: player 3 clear\nMessages: 0=ACCUSE_PLAYER_4 3=DEFEND_PLAYER_3 4=ACCUSE_PLAYER_0 5=ACCUSE_PLAYER_4\nVotes: 0->3 3->4 4->0 5->3\nEliminated: 3\nRound 3\nSignal: player 4 suspicious\nMessages: 0=ACCUSE_PLAYER_5 4=ACCUSE_PLAYER_5 5=ACCUSE_PLAYER_5\nVotes: 0->4 4->5 5->4\nEliminated: 4\n"
+ObservationString(4) = "Player: 4\nRole: Innocent\nAlive: 0 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2 4=ACCUSE_PLAYER_3 5=SKIP\nVotes: 0->2 2->0 3->2 4->5 5->4\nEliminated: 2\nRound 2\nSignal: player 3 clear\nMessages: 0=ACCUSE_PLAYER_4 3=DEFEND_PLAYER_3 4=ACCUSE_PLAYER_0 5=ACCUSE_PLAYER_4\nVotes: 0->3 3->4 4->0 5->3\nEliminated: 3\nRound 3\nSignal: player 4 suspicious\nMessages: 0=ACCUSE_PLAYER_5 4=ACCUSE_PLAYER_5 5=ACCUSE_PLAYER_5\nVotes: 0->4 4->5 5->4\nEliminated: 4\n"
+ObservationString(5) = "Player: 5\nRole: Imposter\nImposterTeam: 5\nAlive: 0 5\nRound 0\nSignal: player 1 clear\nMessages: 0=DEFEND_PLAYER_4 1=ACCUSE_PLAYER_0 2=ACCUSE_PLAYER_4 3=CLAIM_INNOCENT 4=ACCUSE_PLAYER_1 5=DEFEND_PLAYER_2\nVotes: 0->4 1->2 2->1 3->0 4->1 5->1\nEliminated: 1\nRound 1\nSignal: player 0 clear\nMessages: 0=SKIP 2=DEFEND_PLAYER_3 3=ACCUSE_PLAYER_2 4=ACCUSE_PLAYER_3 5=SKIP\nVotes: 0->2 2->0 3->2 4->5 5->4\nEliminated: 2\nRound 2\nSignal: player 3 clear\nMessages: 0=ACCUSE_PLAYER_4 3=DEFEND_PLAYER_3 4=ACCUSE_PLAYER_0 5=ACCUSE_PLAYER_4\nVotes: 0->3 3->4 4->0 5->3\nEliminated: 3\nRound 3\nSignal: player 4 suspicious\nMessages: 0=ACCUSE_PLAYER_5 4=ACCUSE_PLAYER_5 5=ACCUSE_PLAYER_5\nVotes: 0->4 4->5 5->4\nEliminated: 4\n"
+Rewards() = [-1, -1, -1, -1, -1, 1]
+Returns() = [-1, -1, -1, -1, -1, 1]

--- a/open_spiel/python/tests/pyspiel_test.py
+++ b/open_spiel/python/tests/pyspiel_test.py
@@ -151,6 +151,7 @@ EXPECTED_MANDATORY_GAMES = frozenset([
     "shogi",
     "skat",
     "snake",
+    "social_deduction",
     "start_at",
     "solitaire",
     "spades",


### PR DESCRIPTION
## Summary
Adds `social_deduction`, a configurable hidden-role multi-agent benchmark game for studying deception, trust, voting, and coalition dynamics.
The game models a sequential imperfect-information environment with:
- Explicit stochastic hidden-role assignment
- Innocent and imposter teams
- Noisy public observation signals
- Tokenized communication actions
- Elimination voting
- Terminal team win/loss rewards
- - 
## Design Notes
The game is registered as `GameType::Utility::kGeneralSum`. Although it is strategically team-vs-team, individual utilities are `+1/-1` by role-team outcome, so total utility is not guaranteed to sum to zero when team sizes differ.
Default parameters keep the game small and default-loadable:
- `players=6`
- `imposters=1`
- `max_rounds=10`
- `observation_noise=0.1`