### PR TITLE
amazons: add configurable board_size parameter (6, 8, or 10)

### DIFF
--- a/open_spiel/games/amazons/amazons.cc
+++ b/open_spiel/games/amazons/amazons.cc
@@ -40,8 +40,8 @@ const GameType kGameType{
     /*provides_information_state_tensor=*/false,
     /*provides_observation_string=*/true,
     /*provides_observation_tensor=*/true,
-    /*parameter_specification=*/{}  // no parameters
-};
+    /*parameter_specification=*/
+    {{"board_size", GameParameter(kDefaultBoardSize)}}};
 
 std::shared_ptr<const Game> Factory(const GameParameters &params) {
   return std::shared_ptr<const Game>(new AmazonsGame(params));
@@ -83,8 +83,8 @@ std::string StateToString(CellState state) {
 std::vector<Action> AmazonsState::GetAllMoves(Action cell) const {
   std::vector<Action> moves;
 
-  const int row = static_cast<int>(cell) / kNumCols;
-  const int col = static_cast<int>(cell) % kNumCols;
+  const int row = static_cast<int>(cell) / board_size_;
+  const int col = static_cast<int>(cell) % board_size_;
 
   // Directions: left, right, up, down, and the four diagonals.
   static constexpr int kDirRow[8] = {0,  0, -1, 1, -1, -1,  1,  1};
@@ -95,8 +95,8 @@ std::vector<Action> AmazonsState::GetAllMoves(Action cell) const {
     int c = col + kDirCol[d];
 
     // Walk along this ray until we leave the board or hit a non-empty cell.
-    while (r >= 0 && r < kNumRows && c >= 0 && c < kNumCols) {
-      const Action focus = r * kNumCols + c;
+    while (r >= 0 && r < board_size_ && c >= 0 && c < board_size_) {
+      const Action focus = r * board_size_ + c;
       if (board_[focus] != CellState::kEmpty) {
         break;  // blocked by amazon or arrow
       }
@@ -110,8 +110,8 @@ std::vector<Action> AmazonsState::GetAllMoves(Action cell) const {
 }
 
 bool AmazonsState::HasAnyMoveFromCell(Action cell) const {
-  const int row = static_cast<int>(cell) / kNumCols;
-  const int col = static_cast<int>(cell) % kNumCols;
+  const int row = static_cast<int>(cell) / board_size_;
+  const int col = static_cast<int>(cell) % board_size_;
 
   static constexpr int kDirRow[8] = {0,  0, -1, 1, -1, -1,  1,  1};
   static constexpr int kDirCol[8] = {-1, 1,  0, 0, -1,  1, -1,  1};
@@ -120,8 +120,8 @@ bool AmazonsState::HasAnyMoveFromCell(Action cell) const {
     int r = row + kDirRow[d];
     int c = col + kDirCol[d];
 
-    while (r >= 0 && r < kNumRows && c >= 0 && c < kNumCols) {
-      const Action focus = r * kNumCols + c;
+    while (r >= 0 && r < board_size_ && c >= 0 && c < board_size_) {
+      const Action focus = r * board_size_ + c;
       if (board_[focus] != CellState::kEmpty) break;  // ray blocked
       return true;  // found at least one legal destination
     r += kDirRow[d];
@@ -133,7 +133,8 @@ bool AmazonsState::HasAnyMoveFromCell(Action cell) const {
 
 bool AmazonsState::PlayerHasAnyMove(Player p) const {
   const CellState mine = PlayerToState(p);
-  for (int i = 0; i < static_cast<int>(kNumCells); ++i) {
+  const int num_cells = board_size_ * board_size_;
+  for (int i = 0; i < num_cells; ++i) {
     if (board_[i] == mine && HasAnyMoveFromCell(i)) return true;
   }
   return false;
@@ -217,7 +218,7 @@ std::vector<Action> AmazonsState::LegalActions() const {
 
   switch (state_) {
     case amazon_select:
-      for (int i = 0; i < board_.size(); i++) {
+      for (int i = 0; i < static_cast<int>(board_.size()); i++) {
         if (board_[i] == PlayerToState(CurrentPlayer())) {
           // check if the selected amazon has a possible move
           if (!HasAnyMoveFromCell(i)) continue;
@@ -243,8 +244,8 @@ std::vector<Action> AmazonsState::LegalActions() const {
 
 std::string AmazonsState::ActionToString(Player player,
                                          Action action) const {
-  const int row = static_cast<int>(action) / kNumCols;
-  const int col = static_cast<int>(action) % kNumCols;
+  const int row = static_cast<int>(action) / board_size_;
+  const int col = static_cast<int>(action) % board_size_;
 
   std::string coord = absl::StrCat("(", row + 1, ", ", col + 1, ")");
 
@@ -266,29 +267,59 @@ std::string AmazonsState::ActionToString(Player player,
   SpielFatalError("Unhandled state in AmazonsState::ActionToString");
 }
 
-AmazonsState::AmazonsState(std::shared_ptr<const Game> game)
-    : State(game) {
-  std::fill(begin(board_), end(board_), CellState::kEmpty);
-
-  // Standard Amazons is defined for a 10x10 board
-  SPIEL_CHECK_EQ(kNumRows, 10);
-  SPIEL_CHECK_EQ(kNumCols, 10);
-
-  // Player 1 (Nought, 'O') – black: a7, d10, g10, j7
-  board_[3]  = CellState::kNought;  // d10
-  board_[6]  = CellState::kNought;  // g10
-  board_[30] = CellState::kNought;  // a7
-  board_[39] = CellState::kNought;  // j7
-
-  // Player 0 (Cross, 'X') – white: a4, d1, g1, j4
-  board_[60] = CellState::kCross;   // a4
-  board_[69] = CellState::kCross;   // j4
-  board_[93] = CellState::kCross;   // d1
-  board_[96] = CellState::kCross;   // g1
+AmazonsState::AmazonsState(std::shared_ptr<const Game> game, int board_size)
+    : State(game),
+      board_size_(board_size),
+      board_(board_size * board_size, CellState::kEmpty) {
+  // Amazons starting positions are scaled symmetrically from the standard
+  // 10x10 layout (4 amazons per side along the two ranks closest to each
+  // player's edge).
+  switch (board_size_) {
+    case 10:
+      // Player 1 (Nought, 'O') – d10, g10, a7, j7
+      board_[3]  = CellState::kNought;
+      board_[6]  = CellState::kNought;
+      board_[30] = CellState::kNought;
+      board_[39] = CellState::kNought;
+      // Player 0 (Cross, 'X') – a4, j4, d1, g1
+      board_[60] = CellState::kCross;
+      board_[69] = CellState::kCross;
+      board_[93] = CellState::kCross;
+      board_[96] = CellState::kCross;
+      break;
+    case 8:
+      // Player 1 (Nought, 'O') – c8, f8, a6, h6
+      board_[2]  = CellState::kNought;
+      board_[5]  = CellState::kNought;
+      board_[16] = CellState::kNought;
+      board_[23] = CellState::kNought;
+      // Player 0 (Cross, 'X') – a3, h3, c1, f1
+      board_[40] = CellState::kCross;
+      board_[47] = CellState::kCross;
+      board_[58] = CellState::kCross;
+      board_[61] = CellState::kCross;
+      break;
+    case 6:
+      // Player 1 (Nought, 'O') – b6, e6, a5, f5
+      board_[1]  = CellState::kNought;
+      board_[4]  = CellState::kNought;
+      board_[6]  = CellState::kNought;
+      board_[11] = CellState::kNought;
+      // Player 0 (Cross, 'X') – a2, f2, b1, e1
+      board_[24] = CellState::kCross;
+      board_[29] = CellState::kCross;
+      board_[31] = CellState::kCross;
+      board_[34] = CellState::kCross;
+      break;
+    default:
+      SpielFatalError(
+          absl::StrCat("Unsupported board_size: ", board_size_));
+  }
 }
 
 void AmazonsState::SetState(int cur_player, MoveState move_state,
-                            const std::array<CellState, kNumCells>& board) {
+                            const std::vector<CellState>& board) {
+  SPIEL_CHECK_EQ(board.size(), board_.size());
   current_player_ = cur_player;
   state_ = move_state;
   board_ = board;
@@ -296,11 +327,11 @@ void AmazonsState::SetState(int cur_player, MoveState move_state,
 
 std::string AmazonsState::ToString() const {
   std::string str;
-  for (int r = 0; r < kNumRows; ++r) {
-    for (int c = 0; c < kNumCols; ++c) {
+  for (int r = 0; r < board_size_; ++r) {
+    for (int c = 0; c < board_size_; ++c) {
       absl::StrAppend(&str, StateToString(BoardAt(r, c)));
     }
-    if (r < (kNumRows - 1)) {
+    if (r < (board_size_ - 1)) {
       absl::StrAppend(&str, "\n");
     }
   }
@@ -335,13 +366,14 @@ void AmazonsState::ObservationTensor(Player player,
                                      absl::Span<float> values) const {
   SPIEL_CHECK_GE(player, 0);
   SPIEL_CHECK_LT(player, num_players_);
-  SPIEL_CHECK_EQ(values.size(), kCellStates * kNumCells);
+  const int num_cells = board_size_ * board_size_;
+  SPIEL_CHECK_EQ(values.size(), kCellStates * num_cells);
 
   // Clear tensor first.
   std::fill(values.begin(), values.end(), 0.0f);
 
-  TensorView<2> view(values, {kCellStates, kNumCells}, true);
-  for (int cell = 0; cell < kNumCells; ++cell) {
+  TensorView<2> view(values, {kCellStates, num_cells}, true);
+  for (int cell = 0; cell < num_cells; ++cell) {
     const int channel = static_cast<int>(board_[cell]);
     view[{channel, cell}] = 1.0f;
   }
@@ -352,7 +384,10 @@ std::unique_ptr<State> AmazonsState::Clone() const {
 }
 
 AmazonsGame::AmazonsGame(const GameParameters &params)
-    : Game(kGameType, params) {}
+    : Game(kGameType, params),
+      board_size_(ParameterValue<int>("board_size")) {
+  SPIEL_CHECK_TRUE(board_size_ == 6 || board_size_ == 8 || board_size_ == 10);
+}
 
 }  // namespace amazons
 }  // namespace open_spiel

--- a/open_spiel/games/amazons/amazons.h
+++ b/open_spiel/games/amazons/amazons.h
@@ -15,7 +15,6 @@
 #ifndef OPEN_SPIEL_GAMES_AMAZONS_H_
 #define OPEN_SPIEL_GAMES_AMAZONS_H_
 
-#include <array>
 #include <memory>
 #include <string>
 #include <vector>
@@ -24,19 +23,18 @@
 
 // The "Game of Amazons":
 // https://en.wikipedia.org/wiki/Game_of_the_Amazons
+//
+// Parameters:
+//   "board_size"  int   side length of the (square) board.
+//                       Supported values: 6, 8, 10 (default 10).
 
 namespace open_spiel {
 namespace amazons {
 
 // Constants.
 inline constexpr int kNumPlayers = 2;
-inline constexpr int kNumRows = 10;
-inline constexpr int kNumCols = 10;
-inline constexpr int kNumCells = kNumRows * kNumCols;
+inline constexpr int kDefaultBoardSize = 10;
 inline constexpr int kCellStates = 4;  // empty, 'X', 'O', '@'.
-
-// Hensgens et al = 10e40 for 10x10
-inline constexpr int kNumberStates = 1000000000;
 
 // State of a cell.
 enum class CellState { kEmpty, kNought, kCross, kBlock };
@@ -48,7 +46,7 @@ class AmazonsState : public State {
  public:
   enum MoveState { amazon_select, destination_select, shot_select };
 
-  AmazonsState(std::shared_ptr<const Game> game);
+  AmazonsState(std::shared_ptr<const Game> game, int board_size);
 
   AmazonsState(const AmazonsState&) = default;
 
@@ -64,7 +62,7 @@ class AmazonsState : public State {
   bool IsTerminal() const override;
 
   void SetState(int cur_player, MoveState move_state,
-                const std::array<CellState, kNumCells>& board);
+                const std::vector<CellState>& board);
 
   std::vector<double> Returns() const override;
 
@@ -83,11 +81,14 @@ class AmazonsState : public State {
 
   CellState BoardAt(int cell) const { return board_[cell]; }
   CellState BoardAt(int row, int column) const {
-    return board_[row * kNumCols + column];
+    return board_[row * board_size_ + column];
   }
+  int BoardSize() const { return board_size_; }
+  int NumCells() const { return board_size_ * board_size_; }
 
  protected:
-  std::array<CellState, kNumCells> board_;
+  int board_size_;
+  std::vector<CellState> board_;
 
   void DoApplyAction(Action action) override;
 
@@ -111,10 +112,13 @@ class AmazonsGame : public Game {
  public:
   explicit AmazonsGame(const GameParameters& params);
 
-  int NumDistinctActions() const override { return kNumCells; }
+  int NumDistinctActions() const override {
+    return board_size_ * board_size_;
+  }
 
   std::unique_ptr<State> NewInitialState() const override {
-    return std::unique_ptr<State>(new AmazonsState(shared_from_this()));
+    return std::unique_ptr<State>(
+        new AmazonsState(shared_from_this(), board_size_));
   }
 
   int NumPlayers() const override { return kNumPlayers; }
@@ -124,10 +128,17 @@ class AmazonsGame : public Game {
   double MaxUtility() const override { return 1; }
 
   std::vector<int> ObservationTensorShape() const override {
-    return {kCellStates, kNumRows, kNumCols};
+    return {kCellStates, board_size_, board_size_};
   }
 
-  int MaxGameLength() const override { return 3 * kNumCells; }
+  int MaxGameLength() const override {
+    return 3 * board_size_ * board_size_;
+  }
+
+  int board_size() const { return board_size_; }
+
+ private:
+  const int board_size_;
 };
 
 CellState PlayerToState(Player player);

--- a/open_spiel/games/amazons/amazons_test.cc
+++ b/open_spiel/games/amazons/amazons_test.cc
@@ -15,6 +15,7 @@
 #include "open_spiel/games/amazons/amazons.h"
 
 #include <algorithm>
+#include <vector>
 
 #include "open_spiel/spiel.h"
 #include "open_spiel/tests/basic_tests.h"
@@ -29,6 +30,12 @@ void BasicSpielTests() {
   testing::LoadGameTest("amazons");
   testing::RandomSimTest(*LoadGame("amazons"), 100);
   testing::RandomSimTestWithUndo(*LoadGame("amazons"), 5);
+
+  // Parameterized board sizes.
+  for (int size : {6, 8, 10}) {
+    GameParameters params = {{"board_size", GameParameter(size)}};
+    testing::RandomSimTest(*LoadGame("amazons", params), 20);
+  }
 }
 
 // Test the given configuration for player 1 win:
@@ -39,10 +46,7 @@ void PlayerOneSimpleWinTest() {
   std::unique_ptr<State> state = game->NewInitialState();
   AmazonsState* astate = static_cast<AmazonsState*>(state.get());
 
-  std::array<CellState, kNumCells> board = {};
-  for (int i = 0; i < board.size(); i++) {
-    board[i] = CellState::kBlock;
-  }
+  std::vector<CellState> board(astate->NumCells(), CellState::kBlock);
   board[0] = CellState::kNought;
   board[2] = CellState::kCross;
   board[3] = CellState::kEmpty;
@@ -65,10 +69,7 @@ void PlayerTwoSimpleWinTest() {
   std::unique_ptr<State> state = game->NewInitialState();
   AmazonsState* astate = static_cast<AmazonsState*>(state.get());
 
-  std::array<CellState, kNumCells> board = {};
-  for (int i = 0; i < board.size(); i++) {
-    board[i] = CellState::kBlock;
-  }
+  std::vector<CellState> board(astate->NumCells(), CellState::kBlock);
   board[0] = CellState::kCross;
   board[2] = CellState::kNought;
   board[3] = CellState::kEmpty;
@@ -94,17 +95,15 @@ void PlayerOneTrappedByAmazonsTest() {
   std::unique_ptr<State> state = game->NewInitialState();
   AmazonsState* astate = static_cast<AmazonsState*>(state.get());
 
-  std::array<CellState, kNumCells> board = {};
-  for (int i = 0; i < board.size(); i++) {
-    board[i] = CellState::kEmpty;
-  }
-  int center = kNumCells / 2 + kNumRows / 2;
+  const int size = astate->BoardSize();
+  std::vector<CellState> board(astate->NumCells(), CellState::kEmpty);
+  int center = astate->NumCells() / 2 + size / 2;
   board[center] = CellState::kCross;
   board[center - 1] = board[center + 1] = CellState::kNought;
-  board[center - kNumRows] = board[center - kNumRows - 1] =
-      board[center - kNumRows + 1] = CellState::kNought;
-  board[center + kNumRows] = board[center + kNumRows - 1] =
-      board[center + kNumRows + 1] = CellState::kNought;
+  board[center - size] = board[center - size - 1] =
+      board[center - size + 1] = CellState::kNought;
+  board[center + size] = board[center + size - 1] =
+      board[center + size + 1] = CellState::kNought;
 
   astate->SetState(0, AmazonsState::MoveState::amazon_select, board);
 
@@ -127,17 +126,15 @@ void PlayerOneTrappedByBlocksTest() {
   std::unique_ptr<State> state = game->NewInitialState();
   AmazonsState* astate = static_cast<AmazonsState*>(state.get());
 
-  std::array<CellState, kNumCells> board = {};
-  for (int i = 0; i < board.size(); i++) {
-    board[i] = CellState::kEmpty;
-  }
-  int center = kNumCells / 2 + kNumRows / 2;
+  const int size = astate->BoardSize();
+  std::vector<CellState> board(astate->NumCells(), CellState::kEmpty);
+  int center = astate->NumCells() / 2 + size / 2;
   board[center] = CellState::kCross;
   board[center - 1] = board[center + 1] = CellState::kBlock;
-  board[center - kNumRows] = board[center - kNumRows - 1] =
-      board[center - kNumRows + 1] = CellState::kBlock;
-  board[center + kNumRows] = board[center + kNumRows - 1] =
-      board[center + kNumRows + 1] = CellState::kBlock;
+  board[center - size] = board[center - size - 1] =
+      board[center - size + 1] = CellState::kBlock;
+  board[center + size] = board[center + size - 1] =
+      board[center + size + 1] = CellState::kBlock;
 
   astate->SetState(0, AmazonsState::MoveState::amazon_select, board);
 
@@ -244,8 +241,7 @@ void TerminalAndReturnsOnShotTest() {
   AmazonsState* astate = static_cast<AmazonsState*>(state.get());
 
   // Only a single X on an otherwise empty board.
-  std::array<CellState, kNumCells> board;
-  board.fill(CellState::kEmpty);
+  std::vector<CellState> board(astate->NumCells(), CellState::kEmpty);
   board[55] = CellState::kCross;
   astate->SetState(0, AmazonsState::MoveState::amazon_select, board);
 
@@ -274,6 +270,33 @@ void TerminalAndReturnsOnShotTest() {
   SPIEL_CHECK_EQ(returns[1], -1.0);
 }
 
+// Verifies smaller-board games load with the expected dimensions and
+// initial amazon counts.
+void BoardSizeParameterTest() {
+  for (int size : {6, 8, 10}) {
+    GameParameters params = {{"board_size", GameParameter(size)}};
+    std::shared_ptr<const Game> game = LoadGame("amazons", params);
+    SPIEL_CHECK_EQ(game->NumDistinctActions(), size * size);
+
+    std::unique_ptr<State> state = game->NewInitialState();
+    AmazonsState* astate = static_cast<AmazonsState*>(state.get());
+    SPIEL_CHECK_EQ(astate->BoardSize(), size);
+    SPIEL_CHECK_EQ(astate->NumCells(), size * size);
+
+    int crosses = 0;
+    int noughts = 0;
+    for (int i = 0; i < astate->NumCells(); ++i) {
+      if (astate->BoardAt(i) == CellState::kCross) ++crosses;
+      if (astate->BoardAt(i) == CellState::kNought) ++noughts;
+    }
+    SPIEL_CHECK_EQ(crosses, 4);
+    SPIEL_CHECK_EQ(noughts, 4);
+
+    // Player 0 (Cross) moves first and must have legal selections.
+    SPIEL_CHECK_EQ(astate->CurrentPlayer(), 0);
+    SPIEL_CHECK_EQ(astate->LegalActions().size(), 4);
+  }
+}
 
 }  // namespace
 }  // namespace amazons
@@ -288,4 +311,5 @@ int main(int argc, char** argv) {
   open_spiel::amazons::PhasedMoveGenerationAndStringsTest();
   open_spiel::amazons::UndoRoundTripTest();
   open_spiel::amazons::TerminalAndReturnsOnShotTest();
+  open_spiel::amazons::BoardSizeParameterTest();
 }

--- a/open_spiel/integration_tests/playthroughs/amazons.txt
+++ b/open_spiel/integration_tests/playthroughs/amazons.txt
@@ -6,7 +6,7 @@ GameType.information = Information.PERFECT_INFORMATION
 GameType.long_name = "Amazons"
 GameType.max_num_players = 2
 GameType.min_num_players = 2
-GameType.parameter_specification = []
+GameType.parameter_specification = ["board_size"]
 GameType.provides_information_state_string = True
 GameType.provides_information_state_tensor = False
 GameType.provides_observation_string = True
@@ -19,7 +19,7 @@ GameType.utility = Utility.ZERO_SUM
 NumDistinctActions() = 100
 PolicyTensorShape() = [100]
 MaxChanceOutcomes() = 0
-GetParameters() = {}
+GetParameters() = {board_size=10}
 NumPlayers() = 2
 MinUtility() = -1.0
 MaxUtility() = 1.0


### PR DESCRIPTION
Refactor the Amazons game to accept a board_size game parameter defaulting to 10. State now uses a runtime-sized board (std::vector) and the game places 4 amazons per side using scaled-mirror layouts for 6x6, 8x8, and 10x10. The 10x10 default layout is unchanged.