### PR TITLE
chore: silence warning on optional pokerkit dependency

### DIFF
--- a/open_spiel/python/games/__init__.py
+++ b/open_spiel/python/games/__init__.py
@@ -45,10 +45,9 @@ try:
   # imported there is no point importing the latter.
   from open_spiel.python.games import repeated_pokerkit
   # pylint: enable=g-import-not-at-top
-except ImportError as e:
+except ImportError:
   # Initialize to None on failure to ensure that this won't trigger NameError
   # later if someone tries to check for the module's presence.
-  print(f"Optional module pokerkit_wrapper was not importable: {e}")
   pokerkit_wrapper = None
   repeated_pokerkit = None
   pass


### PR DESCRIPTION
Remove `print()` warnings on missing an optional dependency on pokerkit when no pokerkit related functionality is requested. This warning currently prints whenever a model is being trained, multiple times if with multiple threads.