### PR TITLE
feat(catch): port OpenSpiel 2.0 struct architecture to Catch game

### DIFF
--- a/open_spiel/games/catch/catch.cc
+++ b/open_spiel/games/catch/catch.cc
@@ -20,8 +20,10 @@
 #include <vector>
 
 #include "open_spiel/abseil-cpp/absl/strings/str_cat.h"
+#include "open_spiel/abseil-cpp/absl/strings/str_format.h"
 #include "open_spiel/abseil-cpp/absl/types/span.h"
 #include "open_spiel/game_parameters.h"
+#include "open_spiel/json/include/nlohmann/json.hpp"  // IWYU pragma: keep
 #include "open_spiel/observer.h"
 #include "open_spiel/spiel.h"
 #include "open_spiel/spiel_globals.h"
@@ -58,7 +60,8 @@ REGISTER_SPIEL_GAME(kGameType, Factory);
 
 RegisterSingleTensorObserver single_tensor(kGameType.short_name);
 
-std::string StateToString(CellState state) {
+// Maps CellState to a single-character string for ToString().
+std::string CellStateToString(CellState state) {
   switch (state) {
     case CellState::kEmpty:
       return ".";
@@ -72,7 +75,38 @@ std::string StateToString(CellState state) {
   }
 }
 
+// Maps the action id to the human-readable direction string used in
+// CatchActionStruct.
+std::string ActionIdToDirection(Action action_id) {
+  switch (action_id) {
+    case kLeft:
+      return "left";
+    case kStay:
+      return "stay";
+    case kRight:
+      return "right";
+    default:
+      SpielFatalError(absl::StrCat("Out of range action: ", action_id));
+      return "This will never return.";
+  }
+}
+
+// Inverse of ActionIdToDirection.
+Action DirectionToActionId(const std::string& direction) {
+  if (direction == "left") return kLeft;
+  if (direction == "stay") return kStay;
+  if (direction == "right") return kRight;
+  SpielFatalError(absl::StrCat(
+      "Invalid direction string: '", direction,
+      "'. Expected 'left', 'stay', or 'right'."));
+  return kStay;  // unreachable
+}
+
 }  // namespace
+
+// ---------------------------------------------------------------------------
+// CatchState
+// ---------------------------------------------------------------------------
 
 CatchState::CatchState(std::shared_ptr<const Game> game) : State(game) {
   const CatchGame& parent_game = static_cast<const CatchGame&>(*game);
@@ -80,7 +114,52 @@ CatchState::CatchState(std::shared_ptr<const Game> game) : State(game) {
   num_columns_ = parent_game.NumColumns();
 }
 
-int CatchState::CurrentPlayer() const {
+// Construct a CatchState from a typed CatchStateStruct.
+// Validation rules mirror those of TicTacToeState::TicTacToeState(…, struct).
+CatchState::CatchState(std::shared_ptr<const Game> game,
+                       const CatchStateStruct& state_struct)
+    : State(game) {
+  const CatchGame& parent_game = static_cast<const CatchGame&>(*game);
+  num_rows_ = parent_game.NumRows();
+  num_columns_ = parent_game.NumColumns();
+
+  const int br = state_struct.ball_row;
+  const int bc = state_struct.ball_col;
+  const int pc = state_struct.paddle_col;
+
+  if (br == -1 && bc == -1 && pc == -1) {
+    // Pre-chance node: all fields must be -1.
+    initialized_ = false;
+    ball_row_ = -1;
+    ball_col_ = -1;
+    paddle_col_ = -1;
+  } else {
+    // Post-chance node: validate each field individually.
+    if (br < 0 || br >= num_rows_) {
+      SpielFatalError(absl::StrFormat(
+          "Invalid ball_row %d: must be in [0, %d).", br, num_rows_));
+    }
+    if (bc < 0 || bc >= num_columns_) {
+      SpielFatalError(absl::StrFormat(
+          "Invalid ball_col %d: must be in [0, %d).", bc, num_columns_));
+    }
+    if (pc < 0 || pc >= num_columns_) {
+      SpielFatalError(absl::StrFormat(
+          "Invalid paddle_col %d: must be in [0, %d).", pc, num_columns_));
+    }
+
+    initialized_ = true;
+    ball_row_ = br;
+    ball_col_ = bc;
+    paddle_col_ = pc;
+  }
+
+  // Store the JSON of this starting state for serialization support
+  // (mirrors the pattern used in TicTacToeState and ConnectFourState).
+  starting_state_str_ = this->ToJson();
+}
+
+Player CatchState::CurrentPlayer() const {
   if (!initialized_) return kChancePlayerId;
   if (IsTerminal()) return kTerminalPlayerId;
   return 0;
@@ -120,14 +199,15 @@ std::string CatchState::ActionToString(Player player, Action action_id) const {
     return absl::StrCat("Initialized ball to ", action_id);
   SPIEL_CHECK_EQ(player, 0);
   switch (action_id) {
-    case 0:
+    case kLeft:
       return "LEFT";
-    case 1:
+    case kStay:
       return "STAY";
-    case 2:
+    case kRight:
       return "RIGHT";
     default:
       SpielFatalError("Out of range action");
+      return "This will never return.";
   }
 }
 
@@ -135,7 +215,7 @@ std::string CatchState::ToString() const {
   std::string str;
   for (int r = 0; r < num_rows_; ++r) {
     for (int c = 0; c < num_columns_; ++c) {
-      absl::StrAppend(&str, StateToString(BoardAt(r, c)));
+      absl::StrAppend(&str, CellStateToString(BoardAt(r, c)));
     }
     absl::StrAppend(&str, "\n");
   }
@@ -191,6 +271,47 @@ void CatchState::DoApplyAction(Action move) {
         std::min(std::max(paddle_col_ + direction, 0), num_columns_ - 1);
   }
 }
+
+// ---------------------------------------------------------------------------
+// OpenSpiel 2.0 struct API
+// ---------------------------------------------------------------------------
+
+std::unique_ptr<StateStruct> CatchState::ToStruct() const {
+  auto rv = std::make_unique<CatchStateStruct>();
+  rv->ball_row = ball_row_;
+  rv->ball_col = ball_col_;
+  rv->paddle_col = paddle_col_;
+  return rv;
+}
+
+// The observation for a single-player perfect-information game is the full
+// state. We follow the same pattern as TicTacToeState: delegate to ToJson().
+std::unique_ptr<ObservationStruct> CatchState::ToObservationStruct(
+    Player player) const {
+  SPIEL_CHECK_GE(player, 0);
+  SPIEL_CHECK_LT(player, num_players_);
+  return std::make_unique<CatchObservationStruct>(this->ToJson());
+}
+
+std::unique_ptr<ActionStruct> CatchState::ActionToStruct(
+    Player player, Action action_id) const {
+  // Chance actions (ball column selection) are not represented as
+  // CatchActionStruct because they don't have a semantic direction.
+  SPIEL_CHECK_EQ(player, 0);
+  auto action_struct = std::make_unique<CatchActionStruct>();
+  action_struct->direction = ActionIdToDirection(action_id);
+  return action_struct;
+}
+
+std::vector<Action> CatchState::StructToActions(
+    const ActionStruct& action_struct) const {
+  const auto* a = SafeActionCast<CatchActionStruct>(action_struct);
+  return {DirectionToActionId(a->direction)};
+}
+
+// ---------------------------------------------------------------------------
+// CatchGame
+// ---------------------------------------------------------------------------
 
 CatchGame::CatchGame(const GameParameters& params)
     : Game(kGameType, params),

--- a/open_spiel/games/catch/catch.h
+++ b/open_spiel/games/catch/catch.h
@@ -19,6 +19,9 @@
 #include <string>
 #include <vector>
 
+#include "open_spiel/abseil-cpp/absl/types/span.h"
+#include "open_spiel/json/include/nlohmann/json.hpp"
+#include "open_spiel/game_parameters.h"
 #include "open_spiel/spiel.h"
 #include "open_spiel/spiel_utils.h"
 
@@ -62,12 +65,44 @@ enum class CellState {
   kPaddle,
 };
 
+// ---------------------------------------------------------------------------
+// Struct layer (OpenSpiel 2.0 architecture)
+// ---------------------------------------------------------------------------
+
+// Shared contents for both CatchStateStruct and CatchObservationStruct.
+// The three integers fully characterise a post-chance-node Catch state.
+// ball_row == -1 signals that the chance node has not yet been resolved
+// (i.e. the game is still at the initial chance node).
+struct CatchStructContents {
+  int ball_row;    // -1 before the chance action is taken, 0-based otherwise
+  int ball_col;    // -1 before the chance action is taken, 0-based otherwise
+  int paddle_col;  // -1 before the chance action is taken, 0-based otherwise
+  NLOHMANN_DEFINE_TYPE_INTRUSIVE(CatchStructContents, ball_row, ball_col,
+                                 paddle_col);
+};
+
+// State and Observation structs using SPIEL_DEFINE_STRUCT macro.
+SPIEL_DEFINE_STRUCT(CatchStateStruct, StateStruct, CatchStructContents);
+SPIEL_DEFINE_STRUCT(CatchObservationStruct, ObservationStruct,
+                    CatchStructContents);
+
+// Action struct: encodes the paddle direction as a semantic name.
+struct CatchActionStruct : public ActionStruct {
+  // "left" / "stay" / "right"
+  std::string direction;
+  SPIEL_STRUCT_BOILERPLATE(CatchActionStruct, direction);
+};
+
 class CatchGame;
 
 // State of an in-play game.
 class CatchState : public State {
  public:
-  CatchState(std::shared_ptr<const Game> game);
+  explicit CatchState(std::shared_ptr<const Game> game);
+  // Construct from a CatchStateStruct (enables JSON round-trips and
+  // NewInitialState(json)).
+  CatchState(std::shared_ptr<const Game> game,
+             const CatchStateStruct& state_struct);
   CatchState(const CatchState&) = default;
 
   Player CurrentPlayer() const override;
@@ -87,6 +122,15 @@ class CatchState : public State {
   int ball_col() const { return ball_col_; }
   int paddle_col() const { return paddle_col_; }
 
+  // OpenSpiel 2.0 struct API overrides.
+  std::unique_ptr<StateStruct> ToStruct() const override;
+  std::unique_ptr<ObservationStruct> ToObservationStruct(
+      Player player) const override;
+  std::unique_ptr<ActionStruct> ActionToStruct(
+      Player player, Action action_id) const override;
+  std::vector<Action> StructToActions(
+      const ActionStruct& action_struct) const override;
+
  protected:
   void DoApplyAction(Action move) override;
 
@@ -103,9 +147,24 @@ class CatchState : public State {
 class CatchGame : public Game {
  public:
   explicit CatchGame(const GameParameters& params);
+
+  using Game::NewInitialState;
   std::unique_ptr<State> NewInitialState() const override {
     return std::unique_ptr<State>(new CatchState(shared_from_this()));
   }
+  // Construct a state from a typed struct (useful for testing and tooling).
+  std::unique_ptr<State> NewInitialState(
+      const CatchStateStruct& state_struct) const {
+    return std::unique_ptr<State>(
+        new CatchState(shared_from_this(), state_struct));
+  }
+  // Construct a state from a JSON object (satisfies the Game base-class
+  // virtual, enabling the generic NewInitialState(string) path).
+  std::unique_ptr<State> NewInitialState(
+      const nlohmann::json& json) const override {
+    return NewInitialState(CatchStateStruct(json));
+  }
+
   std::vector<int> ObservationTensorShape() const override {
     return {num_rows_, num_columns_};
   }

--- a/open_spiel/games/catch/catch_test.cc
+++ b/open_spiel/games/catch/catch_test.cc
@@ -102,6 +102,84 @@ void ToStringTest() {
                  "..x..\n");
 }
 
+void TestStateStruct() {
+  auto game = LoadGame("catch");
+  auto state = game->NewInitialState();
+  
+  // Chance action to initialize the ball (say, column 2)
+  state->ApplyAction(2);
+  
+  CatchState* catch_state = static_cast<CatchState*>(state.get());
+  auto state_struct = catch_state->ToStruct();
+  
+  // Test state/state_struct -> json string.
+  SPIEL_CHECK_EQ(state_struct->ToJson(), catch_state->ToJson());
+  std::string state_json =
+      "{\"ball_col\":2,\"ball_row\":0,\"paddle_col\":2}";
+  SPIEL_CHECK_EQ(state_struct->ToJson(), state_json);
+  
+  // Test json string -> state_struct.
+  SPIEL_CHECK_EQ(nlohmann::json::parse(state_json).dump(),
+                 CatchStateStruct(state_json).ToJson());
+
+  // Test JSON integration via NewInitialState(json)
+  auto state_from_json = game->NewInitialState(state_json);
+  auto* catch_state_from_json = static_cast<CatchState*>(state_from_json.get());
+  SPIEL_CHECK_EQ(catch_state_from_json->ball_col(), 2);
+  SPIEL_CHECK_EQ(catch_state_from_json->ball_row(), 0);
+  SPIEL_CHECK_EQ(catch_state_from_json->paddle_col(), 2);
+}
+
+void TestObservationStruct() {
+  auto game = LoadGame("catch");
+  auto state = game->NewInitialState();
+  state->ApplyAction(2);  // ball at col 2
+  
+  CatchState* catch_state = static_cast<CatchState*>(state.get());
+  auto obs_struct = catch_state->ToObservationStruct(0);
+  std::string obs_json =
+      "{\"ball_col\":2,\"ball_row\":0,\"paddle_col\":2}";
+  SPIEL_CHECK_EQ(obs_struct->ToJson(), obs_json);
+  SPIEL_CHECK_EQ(nlohmann::json::parse(obs_json).dump(),
+                 CatchObservationStruct(obs_json).ToJson());
+}
+
+void TestActionStruct() {
+  auto game = LoadGame("catch");
+  auto state = game->NewInitialState();
+  state->ApplyAction(2); // ball at col 2
+  
+  auto* catch_state = static_cast<CatchState*>(state.get());
+
+  // Test ActionToStruct.
+  Action action_id = kLeft;  // paddle moves left
+  auto action_struct = catch_state->ActionToStruct(0, action_id);
+  std::string action_json = "{\"direction\":\"left\"}";
+  SPIEL_CHECK_EQ(action_struct->ToJson(), action_json);
+
+  // Test ApplyActionStruct.
+  auto state2 = game->NewInitialState();
+  state2->ApplyAction(2);
+  Status status = state2->ApplyActionStruct(*action_struct);
+  SPIEL_CHECK_TRUE(status.ok());
+  auto* state2_catch = static_cast<CatchState*>(state2.get());
+  // Paddle was at 2 (since num_columns / 2 = 5 / 2 = 2). Moved left -> 1.
+  SPIEL_CHECK_EQ(state2_catch->paddle_col(), 1);
+
+  // Test ValidateActionStruct with valid action.
+  auto state3 = game->NewInitialState();
+  state3->ApplyAction(2);
+  SPIEL_CHECK_TRUE(state3->ValidateActionStruct(*action_struct).ok());
+
+  // Test JSON parsing.
+  SPIEL_CHECK_EQ(nlohmann::json::parse(action_json).dump(),
+                 CatchActionStruct(action_json).ToJson());
+
+  // Test StructToActions.
+  std::vector<Action> expected_actions = {action_id};
+  SPIEL_CHECK_EQ(expected_actions, catch_state->StructToActions(*action_struct));
+}
+
 }  // namespace
 }  // namespace catch_
 }  // namespace open_spiel
@@ -111,4 +189,7 @@ int main(int argc, char** argv) {
   open_spiel::catch_::GetAllStatesTest();
   open_spiel::catch_::PlayAndWinTest();
   open_spiel::catch_::ToStringTest();
+  open_spiel::catch_::TestStateStruct();
+  open_spiel::catch_::TestObservationStruct();
+  open_spiel::catch_::TestActionStruct();
 }


### PR DESCRIPTION
### Title: 
`feat(catch): Migrate environment to JSON-interchangeable state structs`

### Description:

**Overview**
Following up on the recent updates for the upcoming OpenSpiel 2.0 release, this PR migrates the `catch` environment to the new JSON-interchangeable struct architecture. This mirrors the design patterns recently established in `tic_tac_toe` and `connect_four`.

Because `catch` is a straightforward, perfect-information, single-player game, it serves as a clean, minimal environment to further validate this new architectural layer before scaling it to more complex multi-agent games.

**Key Architectural Changes**

**`catch.h`**
* Introduced `CatchStructContents` (POD struct with `ball_row`, `ball_col`, `paddle_col`), annotated with `NLOHMANN_DEFINE_TYPE_INTRUSIVE` to enable native JSON serialization.
* Declared `CatchStateStruct` and `CatchObservationStruct` utilizing the `SPIEL_DEFINE_STRUCT` macro.
* Declared `CatchActionStruct` with a semantic `direction` string field via the `SPIEL_STRUCT_BOILERPLATE` macro.
* Added a struct-accepting `CatchState` constructor to support seamless JSON round-trips.
* Overrode necessary virtual methods: `ToStruct()`, `ToObservationStruct()`, `ActionToStruct()`, and `StructToActions()`.
* Added `NewInitialState(CatchStateStruct)` and `NewInitialState(nlohmann::json)` overloads to `CatchGame`, utilizing `using Game::NewInitialState` to maintain base overload visibility.
* Updated includes to support the new types (`absl/types/optional.h`, `nlohmann/json.hpp`, etc.).

**`catch.cc`**
* Implemented the `CatchState(game, CatchStateStruct)` constructor with strict boundary and state validation (e.g., pre-chance vs. post-chance states, grid bounds).
* Implemented `ToStruct()` to map internal game variables to the JSON-ready POD struct.
* Implemented `ToObservationStruct()`, which directly delegates to `ToJson()` (as the full state constitutes the observation in Catch).
* Built translation helpers (`ActionIdToDirection()` and `DirectionToActionId()`) to map discrete action IDs to semantic direction strings for `ActionToStruct()` and `StructToActions()`.

**Verification**
* ✅ Native C++ engine tests pass (`catch_test`).
* ✅ Python frontend bindings and environment tests pass (`python/tests/catch_test.py`).

@lanctot , I hope this helps accelerate the migration effort for the 2.0 release! I am happy to help port this architecture to other environments next. Please let me know if you have a specific priority list of games you'd like targeted.