### PR TITLE
Fix wrong player's piece placed on free-move in Ultimate Tic-Tac-Toe

### DIFF
--- a/open_spiel/games/ultimate_tic_tac_toe/ultimate_tic_tac_toe.cc
+++ b/open_spiel/games/ultimate_tic_tac_toe/ultimate_tic_tac_toe.cc
@@ -70,6 +70,13 @@ void UltimateTTTState::DoApplyAction(Action move) {
     SPIEL_CHECK_GE(move, 0);
     SPIEL_CHECK_LT(move, ttt::kNumCells);
     current_state_ = move;
+    // Sync the chosen local board's current player with the meta-game's
+    // current player. Without this, the local board's current player is
+    // whatever it was left at after the previous visit (which flips it),
+    // so the next ApplyAction would place the wrong player's piece.
+    // The mirror SetCurrentPlayer call below (after a normal choose_cell
+    // that redirects to a new board) does not run on this code path.
+    local_state(current_state_)->SetCurrentPlayer(current_player_);
   } else {
     // Apply action to local state, then apply that move.
     SPIEL_CHECK_FALSE(local_states_[current_state_]->IsTerminal());

--- a/open_spiel/games/ultimate_tic_tac_toe/ultimate_tic_tac_toe.cc
+++ b/open_spiel/games/ultimate_tic_tac_toe/ultimate_tic_tac_toe.cc
@@ -70,12 +70,8 @@ void UltimateTTTState::DoApplyAction(Action move) {
     SPIEL_CHECK_GE(move, 0);
     SPIEL_CHECK_LT(move, ttt::kNumCells);
     current_state_ = move;
-    // Sync the chosen local board's current player with the meta-game's
-    // current player. Without this, the local board's current player is
-    // whatever it was left at after the previous visit (which flips it),
-    // so the next ApplyAction would place the wrong player's piece.
-    // The mirror SetCurrentPlayer call below (after a normal choose_cell
-    // that redirects to a new board) does not run on this code path.
+    // Sync the chosen board's current player; mirrors the SetCurrentPlayer
+    // call in the choose_cell branch below.
     local_state(current_state_)->SetCurrentPlayer(current_player_);
   } else {
     // Apply action to local state, then apply that move.

--- a/open_spiel/games/ultimate_tic_tac_toe/ultimate_tic_tac_toe_test.cc
+++ b/open_spiel/games/ultimate_tic_tac_toe/ultimate_tic_tac_toe_test.cc
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <string>
+#include <vector>
+
 #include "open_spiel/spiel.h"
+#include "open_spiel/spiel_utils.h"
 #include "open_spiel/tests/basic_tests.h"
 
 namespace open_spiel {
@@ -27,10 +31,40 @@ void BasicUltimateTicTacToeTests() {
   testing::RandomSimTest(*LoadGame("ultimate_tic_tac_toe"), 100);
 }
 
+// Regression test: when a player enters a previously-played local board
+// via a free-move `Choose local board`, the local board's internal
+// current player used to remain stale (opposite of the meta-game's
+// current player), so the subsequent cell placement was applied for the
+// wrong player. See `DoApplyAction` -- the `SetCurrentPlayer` call for
+// normal cell-redirected transitions was missing on the choose_subgrid
+// code path.
+//
+// This 15-action sequence has X free-move-choose board 2 and then place
+// at (0,1). Board 2 was last visited by X placing at (0,0), which left
+// board 2's internal current player as O. Without the fix, the (0,1)
+// cell becomes 'o' instead of 'x'.
+void FreeMoveUsesMetaCurrentPlayerRegression() {
+  std::shared_ptr<const Game> game = LoadGame("ultimate_tic_tac_toe");
+  std::unique_ptr<State> state = game->NewInitialState();
+  const std::vector<Action> actions = {0, 3, 3, 7, 5, 0, 2, 0,
+                                       1, 1, 3, 0, 0, 2, 1};
+  for (Action a : actions) {
+    state->ApplyAction(a);
+  }
+  // ToString() lays out the 9x9 board with sub-grids separated by spaces:
+  // the first line has the form "sub0row0 sub1row0 sub2row0", so byte
+  // index 9 is board 2 (top-right sub-grid) row 0 col 1 -- the cell the
+  // last action targeted.
+  const std::string s = state->ToString();
+  SPIEL_CHECK_GE(s.size(), 11u);
+  SPIEL_CHECK_EQ(s[9], 'x');
+}
+
 }  // namespace
 }  // namespace ultimate_tic_tac_toe
 }  // namespace open_spiel
 
 int main(int argc, char** argv) {
   open_spiel::ultimate_tic_tac_toe::BasicUltimateTicTacToeTests();
+  open_spiel::ultimate_tic_tac_toe::FreeMoveUsesMetaCurrentPlayerRegression();
 }

--- a/open_spiel/games/ultimate_tic_tac_toe/ultimate_tic_tac_toe_test.cc
+++ b/open_spiel/games/ultimate_tic_tac_toe/ultimate_tic_tac_toe_test.cc
@@ -31,18 +31,10 @@ void BasicUltimateTicTacToeTests() {
   testing::RandomSimTest(*LoadGame("ultimate_tic_tac_toe"), 100);
 }
 
-// Regression test: when a player enters a previously-played local board
-// via a free-move `Choose local board`, the local board's internal
-// current player used to remain stale (opposite of the meta-game's
-// current player), so the subsequent cell placement was applied for the
-// wrong player. See `DoApplyAction` -- the `SetCurrentPlayer` call for
-// normal cell-redirected transitions was missing on the choose_subgrid
-// code path.
-//
-// This 15-action sequence has X free-move-choose board 2 and then place
-// at (0,1). Board 2 was last visited by X placing at (0,0), which left
-// board 2's internal current player as O. Without the fix, the (0,1)
-// cell becomes 'o' instead of 'x'.
+// Regression: free-move `Choose local board` used to leave the target
+// board's internal current player stale, so the following cell was
+// placed for the wrong player. This 15-action sequence has X free-move
+// into board 2 and place at (0,1); without the fix the cell is 'o'.
 void FreeMoveUsesMetaCurrentPlayerRegression() {
   std::shared_ptr<const Game> game = LoadGame("ultimate_tic_tac_toe");
   std::unique_ptr<State> state = game->NewInitialState();
@@ -51,10 +43,8 @@ void FreeMoveUsesMetaCurrentPlayerRegression() {
   for (Action a : actions) {
     state->ApplyAction(a);
   }
-  // ToString() lays out the 9x9 board with sub-grids separated by spaces:
-  // the first line has the form "sub0row0 sub1row0 sub2row0", so byte
-  // index 9 is board 2 (top-right sub-grid) row 0 col 1 -- the cell the
-  // last action targeted.
+  // ToString()'s first line is "sub0row0 sub1row0 sub2row0"; index 9 is
+  // board 2 row 0 col 1 -- the cell the last action targeted.
   const std::string s = state->ToString();
   SPIEL_CHECK_GE(s.size(), 11u);
   SPIEL_CHECK_EQ(s[9], 'x');

--- a/open_spiel/integration_tests/playthroughs/ultimate_tic_tac_toe.txt
+++ b/open_spiel/integration_tests/playthroughs/ultimate_tic_tac_toe.txt
@@ -62,8 +62,8 @@ Returns() = [0, 0]
 LegalActions() = [0, 1, 2, 3, 4, 5, 6, 7, 8]
 StringLegalActions() = ["Choose local board 0", "Choose local board 1", "Choose local board 2", "Choose local board 3", "Choose local board 4", "Choose local board 5", "Choose local board 6", "Choose local board 7", "Choose local board 8"]
 
-# Apply action "Choose local board 5"
-action: 5
+# Apply action "Choose local board 7"
+action: 7
 
 # State 1
 # ... ... ...
@@ -79,319 +79,319 @@ action: 5
 # ... ... ...
 #
 # Current player: 0
-# Forced board: 5
+# Forced board: 7
 IsTerminal() = False
-History() = [5]
-HistoryString() = "5"
+History() = [7]
+HistoryString() = "7"
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = 0
-InformationStateString(0) = "5"
-InformationStateString(1) = "5"
-ObservationString(0) = "... ... ...\n... ... ...\n... ... ...\n\n... ... ...\n... ... ...\n... ... ...\n\n... ... ...\n... ... ...\n... ... ...\n\nCurrent player: 0\nForced board: 5"
-ObservationString(1) = "... ... ...\n... ... ...\n... ... ...\n\n... ... ...\n... ... ...\n... ... ...\n\n... ... ...\n... ... ...\n... ... ...\n\nCurrent player: 0\nForced board: 5"
-ObservationTensor(0): binvec(254, 0x3fffffffffffffffffffe0000000000000000000000000000000000000000010)
-ObservationTensor(1): binvec(254, 0x3fffffffffffffffffffe0000000000000000000000000000000000000000010)
+InformationStateString(0) = "7"
+InformationStateString(1) = "7"
+ObservationString(0) = "... ... ...\n... ... ...\n... ... ...\n\n... ... ...\n... ... ...\n... ... ...\n\n... ... ...\n... ... ...\n... ... ...\n\nCurrent player: 0\nForced board: 7"
+ObservationString(1) = "... ... ...\n... ... ...\n... ... ...\n\n... ... ...\n... ... ...\n... ... ...\n\n... ... ...\n... ... ...\n... ... ...\n\nCurrent player: 0\nForced board: 7"
+ObservationTensor(0): binvec(254, 0x3fffffffffffffffffffe0000000000000000000000000000000000000000004)
+ObservationTensor(1): binvec(254, 0x3fffffffffffffffffffe0000000000000000000000000000000000000000004)
 Rewards() = [0, 0]
 Returns() = [0, 0]
 LegalActions() = [0, 1, 2, 3, 4, 5, 6, 7, 8]
-StringLegalActions() = ["Local board 5: x(0,0)", "Local board 5: x(0,1)", "Local board 5: x(0,2)", "Local board 5: x(1,0)", "Local board 5: x(1,1)", "Local board 5: x(1,2)", "Local board 5: x(2,0)", "Local board 5: x(2,1)", "Local board 5: x(2,2)"]
+StringLegalActions() = ["Local board 7: x(0,0)", "Local board 7: x(0,1)", "Local board 7: x(0,2)", "Local board 7: x(1,0)", "Local board 7: x(1,1)", "Local board 7: x(1,2)", "Local board 7: x(2,0)", "Local board 7: x(2,1)", "Local board 7: x(2,2)"]
 
-# Apply action "Local board 5: x(0,2)"
-action: 2
+# Apply action "Local board 7: x(2,0)"
+action: 6
 
 # State 2
 # ... ... ...
 # ... ... ...
 # ... ... ...
 #
-# ... ... ..x
+# ... ... ...
 # ... ... ...
 # ... ... ...
 #
 # ... ... ...
 # ... ... ...
-# ... ... ...
+# ... x.. ...
 #
 # Current player: 1
-# Forced board: 2
+# Forced board: 6
 IsTerminal() = False
-History() = [5, 2]
-HistoryString() = "5, 2"
+History() = [7, 6]
+HistoryString() = "7, 6"
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = 1
-InformationStateString(0) = "5, 2"
-InformationStateString(1) = "5, 2"
-ObservationString(0) = "... ... ...\n... ... ...\n... ... ...\n\n... ... ..x\n... ... ...\n... ... ...\n\n... ... ...\n... ... ...\n... ... ...\n\nCurrent player: 1\nForced board: 2"
-ObservationString(1) = "... ... ...\n... ... ...\n... ... ...\n\n... ... ..x\n... ... ...\n... ... ...\n\n... ... ...\n... ... ...\n... ... ...\n\nCurrent player: 1\nForced board: 2"
-ObservationTensor(0): binvec(254, 0x3fffffffffffbfffffffe0000000000000000000000000000000100000000480)
-ObservationTensor(1): binvec(254, 0x3fffffffffffbfffffffe0000000000000000000000000000000100000000480)
+InformationStateString(0) = "7, 6"
+InformationStateString(1) = "7, 6"
+ObservationString(0) = "... ... ...\n... ... ...\n... ... ...\n\n... ... ...\n... ... ...\n... ... ...\n\n... ... ...\n... ... ...\n... x.. ...\n\nCurrent player: 1\nForced board: 6"
+ObservationString(1) = "... ... ...\n... ... ...\n... ... ...\n\n... ... ...\n... ... ...\n... ... ...\n\n... ... ...\n... ... ...\n... x.. ...\n\nCurrent player: 1\nForced board: 6"
+ObservationTensor(0): binvec(254, 0x3ffffffffffffffffeffe0000000000000000000000000000000000000400408)
+ObservationTensor(1): binvec(254, 0x3ffffffffffffffffeffe0000000000000000000000000000000000000400408)
 Rewards() = [0, 0]
 Returns() = [0, 0]
 LegalActions() = [0, 1, 2, 3, 4, 5, 6, 7, 8]
-StringLegalActions() = ["Local board 2: o(0,0)", "Local board 2: o(0,1)", "Local board 2: o(0,2)", "Local board 2: o(1,0)", "Local board 2: o(1,1)", "Local board 2: o(1,2)", "Local board 2: o(2,0)", "Local board 2: o(2,1)", "Local board 2: o(2,2)"]
+StringLegalActions() = ["Local board 6: o(0,0)", "Local board 6: o(0,1)", "Local board 6: o(0,2)", "Local board 6: o(1,0)", "Local board 6: o(1,1)", "Local board 6: o(1,2)", "Local board 6: o(2,0)", "Local board 6: o(2,1)", "Local board 6: o(2,2)"]
 
-# Apply action "Local board 2: o(1,1)"
-action: 4
+# Apply action "Local board 6: o(1,0)"
+action: 3
 
 # State 3
 # ... ... ...
-# ... ... .o.
-# ... ... ...
-#
-# ... ... ..x
 # ... ... ...
 # ... ... ...
 #
 # ... ... ...
 # ... ... ...
 # ... ... ...
+#
+# ... ... ...
+# o.. ... ...
+# ... x.. ...
 #
 # Current player: 0
-# Forced board: 4
+# Forced board: 3
 IsTerminal() = False
-History() = [5, 2, 4]
-HistoryString() = "5, 2, 4"
+History() = [7, 6, 3]
+HistoryString() = "7, 6, 3"
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = 0
-InformationStateString(0) = "5, 2, 4"
-InformationStateString(1) = "5, 2, 4"
-ObservationString(0) = "... ... ...\n... ... .o.\n... ... ...\n\n... ... ..x\n... ... ...\n... ... ...\n\n... ... ...\n... ... ...\n... ... ...\n\nCurrent player: 0\nForced board: 4"
-ObservationString(1) = "... ... ...\n... ... .o.\n... ... ...\n\n... ... ..x\n... ... ...\n... ... ...\n\n... ... ...\n... ... ...\n... ... ...\n\nCurrent player: 0\nForced board: 4"
-ObservationTensor(0): binvec(254, 0x3fffff7fffffbfffffffe0000040000000000000000000000000100000000020)
-ObservationTensor(1): binvec(254, 0x3fffff7fffffbfffffffe0000040000000000000000000000000100000000020)
+InformationStateString(0) = "7, 6, 3"
+InformationStateString(1) = "7, 6, 3"
+ObservationString(0) = "... ... ...\n... ... ...\n... ... ...\n\n... ... ...\n... ... ...\n... ... ...\n\n... ... ...\no.. ... ...\n... x.. ...\n\nCurrent player: 0\nForced board: 3"
+ObservationString(1) = "... ... ...\n... ... ...\n... ... ...\n\n... ... ...\n... ... ...\n... ... ...\n\n... ... ...\no.. ... ...\n... x.. ...\n\nCurrent player: 0\nForced board: 3"
+ObservationTensor(0): binvec(254, 0x3fffffffffffffeffeffe0000000000000080000000000000000000000400040)
+ObservationTensor(1): binvec(254, 0x3fffffffffffffeffeffe0000000000000080000000000000000000000400040)
 Rewards() = [0, 0]
 Returns() = [0, 0]
 LegalActions() = [0, 1, 2, 3, 4, 5, 6, 7, 8]
-StringLegalActions() = ["Local board 4: x(0,0)", "Local board 4: x(0,1)", "Local board 4: x(0,2)", "Local board 4: x(1,0)", "Local board 4: x(1,1)", "Local board 4: x(1,2)", "Local board 4: x(2,0)", "Local board 4: x(2,1)", "Local board 4: x(2,2)"]
+StringLegalActions() = ["Local board 3: x(0,0)", "Local board 3: x(0,1)", "Local board 3: x(0,2)", "Local board 3: x(1,0)", "Local board 3: x(1,1)", "Local board 3: x(1,2)", "Local board 3: x(2,0)", "Local board 3: x(2,1)", "Local board 3: x(2,2)"]
 
-# Apply action "Local board 4: x(0,1)"
-action: 1
+# Apply action "Local board 3: x(2,2)"
+action: 8
 
 # State 4
 # ... ... ...
-# ... ... .o.
-# ... ... ...
-#
-# ... .x. ..x
 # ... ... ...
 # ... ... ...
 #
 # ... ... ...
 # ... ... ...
+# ..x ... ...
+#
 # ... ... ...
+# o.. ... ...
+# ... x.. ...
+#
+# Current player: 1
+# Forced board: 8
+IsTerminal() = False
+History() = [7, 6, 3, 8]
+HistoryString() = "7, 6, 3, 8"
+IsChanceNode() = False
+IsSimultaneousNode() = False
+CurrentPlayer() = 1
+InformationStateString(0) = "7, 6, 3, 8"
+InformationStateString(1) = "7, 6, 3, 8"
+ObservationString(0) = "... ... ...\n... ... ...\n... ... ...\n\n... ... ...\n... ... ...\n..x ... ...\n\n... ... ...\no.. ... ...\n... x.. ...\n\nCurrent player: 1\nForced board: 8"
+ObservationString(1) = "... ... ...\n... ... ...\n... ... ...\n\n... ... ...\n... ... ...\n..x ... ...\n\n... ... ...\no.. ... ...\n... x.. ...\n\nCurrent player: 1\nForced board: 8"
+ObservationTensor(0): binvec(254, 0x3ffffffffbffffeffeffe0000000000000080000000000000100000000400402)
+ObservationTensor(1): binvec(254, 0x3ffffffffbffffeffeffe0000000000000080000000000000100000000400402)
+Rewards() = [0, 0]
+Returns() = [0, 0]
+LegalActions() = [0, 1, 2, 3, 4, 5, 6, 7, 8]
+StringLegalActions() = ["Local board 8: o(0,0)", "Local board 8: o(0,1)", "Local board 8: o(0,2)", "Local board 8: o(1,0)", "Local board 8: o(1,1)", "Local board 8: o(1,2)", "Local board 8: o(2,0)", "Local board 8: o(2,1)", "Local board 8: o(2,2)"]
+
+# Apply action "Local board 8: o(2,2)"
+action: 8
+
+# State 5
+# Apply action "Local board 8: x(0,1)"
+action: 1
+
+# State 6
+# ... ... ...
+# ... ... ...
+# ... ... ...
+#
+# ... ... ...
+# ... ... ...
+# ..x ... ...
+#
+# ... ... .x.
+# o.. ... ...
+# ... x.. ..o
 #
 # Current player: 1
 # Forced board: 1
 IsTerminal() = False
-History() = [5, 2, 4, 1]
-HistoryString() = "5, 2, 4, 1"
+History() = [7, 6, 3, 8, 8, 1]
+HistoryString() = "7, 6, 3, 8, 8, 1"
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = 1
-InformationStateString(0) = "5, 2, 4, 1"
-InformationStateString(1) = "5, 2, 4, 1"
-ObservationString(0) = "... ... ...\n... ... .o.\n... ... ...\n\n... .x. ..x\n... ... ...\n... ... ...\n\n... ... ...\n... ... ...\n... ... ...\n\nCurrent player: 1\nForced board: 1"
-ObservationString(1) = "... ... ...\n... ... .o.\n... ... ...\n\n... .x. ..x\n... ... ...\n... ... ...\n\n... ... ...\n... ... ...\n... ... ...\n\nCurrent player: 1\nForced board: 1"
-ObservationTensor(0): binvec(254, 0x3fffff7ffeffbfffffffe0000040000000000000000000000040100000000500)
-ObservationTensor(1): binvec(254, 0x3fffff7ffeffbfffffffe0000040000000000000000000000040100000000500)
+InformationStateString(0) = "7, 6, 3, 8, 8, 1"
+InformationStateString(1) = "7, 6, 3, 8, 8, 1"
+ObservationString(0) = "... ... ...\n... ... ...\n... ... ...\n\n... ... ...\n... ... ...\n..x ... ...\n\n... ... .x.\no.. ... ...\n... x.. ..o\n\nCurrent player: 1\nForced board: 1"
+ObservationString(1) = "... ... ...\n... ... ...\n... ... ...\n\n... ... ...\n... ... ...\n..x ... ...\n\n... ... .x.\no.. ... ...\n... x.. ..o\n\nCurrent player: 1\nForced board: 1"
+ObservationTensor(0): binvec(254, 0x3ffffffffbffffeffeefc0000000000000080000100000000100000000440500)
+ObservationTensor(1): binvec(254, 0x3ffffffffbffffeffeefc0000000000000080000100000000100000000440500)
 Rewards() = [0, 0]
 Returns() = [0, 0]
 LegalActions() = [0, 1, 2, 3, 4, 5, 6, 7, 8]
 StringLegalActions() = ["Local board 1: o(0,0)", "Local board 1: o(0,1)", "Local board 1: o(0,2)", "Local board 1: o(1,0)", "Local board 1: o(1,1)", "Local board 1: o(1,2)", "Local board 1: o(2,0)", "Local board 1: o(2,1)", "Local board 1: o(2,2)"]
 
-# Apply action "Local board 1: o(0,2)"
-action: 2
-
-# State 5
-# Apply action "Local board 2: x(0,2)"
-action: 2
-
-# State 6
-# ... ..o ..x
-# ... ... .o.
-# ... ... ...
-#
-# ... .x. ..x
-# ... ... ...
-# ... ... ...
-#
-# ... ... ...
-# ... ... ...
-# ... ... ...
-#
-# Current player: 1
-# Forced board: 2
-IsTerminal() = False
-History() = [5, 2, 4, 1, 2, 2]
-HistoryString() = "5, 2, 4, 1, 2, 2"
-IsChanceNode() = False
-IsSimultaneousNode() = False
-CurrentPlayer() = 1
-InformationStateString(0) = "5, 2, 4, 1, 2, 2"
-InformationStateString(1) = "5, 2, 4, 1, 2, 2"
-ObservationString(0) = "... ..o ..x\n... ... .o.\n... ... ...\n\n... .x. ..x\n... ... ...\n... ... ...\n\n... ... ...\n... ... ...\n... ... ...\n\nCurrent player: 1\nForced board: 2"
-ObservationString(1) = "... ..o ..x\n... ... .o.\n... ... ...\n\n... .x. ..x\n... ... ...\n... ... ...\n\n... ... ...\n... ... ...\n... ... ...\n\nCurrent player: 1\nForced board: 2"
-ObservationTensor(0): binvec(254, 0x3ffbfd7ffeffbfffffffe0020040000000000000000000800040100000000480)
-ObservationTensor(1): binvec(254, 0x3ffbfd7ffeffbfffffffe0020040000000000000000000800040100000000480)
-Rewards() = [0, 0]
-Returns() = [0, 0]
-LegalActions() = [0, 1, 3, 5, 6, 7, 8]
-StringLegalActions() = ["Local board 2: o(0,0)", "Local board 2: o(0,1)", "Local board 2: o(1,0)", "Local board 2: o(1,2)", "Local board 2: o(2,0)", "Local board 2: o(2,1)", "Local board 2: o(2,2)"]
-
-# Apply action "Local board 2: o(2,0)"
-action: 6
+# Apply action "Local board 1: o(1,0)"
+action: 3
 
 # State 7
-# Apply action "Local board 6: x(0,0)"
-action: 0
-
-# State 8
-# Apply action "Local board 0: o(0,2)"
-action: 2
-
-# State 9
-# Apply action "Local board 2: x(2,1)"
-action: 7
-
-# State 10
-# Apply action "Local board 7: o(2,0)"
-action: 6
-
-# State 11
-# Apply action "Local board 6: x(1,2)"
+# Apply action "Local board 3: x(1,2)"
 action: 5
 
-# State 12
-# Apply action "Local board 5: o(1,0)"
-action: 3
-
-# State 13
-# Apply action "Local board 3: x(0,2)"
-action: 2
-
-# State 14
-# Apply action "Local board 2: o(0,0)"
-action: 0
-
-# State 15
-# Apply action "Local board 0: x(2,2)"
-action: 8
-
-# State 16
-# Apply action "Local board 8: o(0,1)"
+# State 8
+# Apply action "Local board 5: o(0,1)"
 action: 1
 
+# State 9
+# Apply action "Local board 1: x(1,2)"
+action: 5
+
+# State 10
+# Apply action "Local board 5: o(1,2)"
+action: 5
+
+# State 11
+# Apply action "Local board 5: x(2,1)"
+action: 7
+
+# State 12
+# Apply action "Local board 7: o(1,2)"
+action: 5
+
+# State 13
+# Apply action "Local board 5: x(1,1)"
+action: 4
+
+# State 14
+# Apply action "Local board 4: o(1,1)"
+action: 4
+
+# State 15
+# Apply action "Local board 4: x(2,1)"
+action: 7
+
+# State 16
+# Apply action "Local board 7: o(2,2)"
+action: 8
+
 # State 17
-# Apply action "Local board 1: x(2,0)"
-action: 6
+# Apply action "Local board 8: x(1,2)"
+action: 5
 
 # State 18
-# Apply action "Local board 6: o(1,0)"
-action: 3
+# Apply action "Local board 5: o(0,0)"
+action: 0
 
 # State 19
-# ..o ..o o.x
-# ... ... .o.
-# ..x x.. ox.
-#
-# ..x .x. ..x
-# ... ... o..
+# ... ... ...
+# ... o.x ...
 # ... ... ...
 #
-# x.. ... .o.
-# o.x ... ...
-# ... o.. ...
+# ... ... oo.
+# ..x .o. .xo
+# ..x .x. .x.
+#
+# ... ... .x.
+# o.. ..o ..x
+# ... x.o ..o
 #
 # Current player: 0
-# Forced board: 3
+# Forced board: 0
 IsTerminal() = False
-History() = [5, 2, 4, 1, 2, 2, 6, 0, 2, 7, 6, 5, 3, 2, 0, 8, 1, 6, 3]
-HistoryString() = "5, 2, 4, 1, 2, 2, 6, 0, 2, 7, 6, 5, 3, 2, 0, 8, 1, 6, 3"
+History() = [7, 6, 3, 8, 8, 1, 3, 5, 1, 5, 5, 7, 5, 4, 4, 7, 8, 5, 0]
+HistoryString() = "7, 6, 3, 8, 8, 1, 3, 5, 1, 5, 5, 7, 5, 4, 4, 7, 8, 5, 0"
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = 0
-InformationStateString(0) = "5, 2, 4, 1, 2, 2, 6, 0, 2, 7, 6, 5, 3, 2, 0, 8, 1, 6, 3"
-InformationStateString(1) = "5, 2, 4, 1, 2, 2, 6, 0, 2, 7, 6, 5, 3, 2, 0, 8, 1, 6, 3"
-ObservationString(0) = "..o ..o o.x\n... ... .o.\n..x x.. ox.\n\n..x .x. ..x\n... ... o..\n... ... ...\n\nx.. ... .o.\no.x ... ...\n... o.. ...\n\nCurrent player: 0\nForced board: 3"
-ObservationString(1) = "..o ..o o.x\n... ... .o.\n..x x.. ox.\n\n..x .x. ..x\n... ... o..\n... ... ...\n\nx.. ... .o.\no.x ... ...\n... o.. ...\n\nCurrent player: 0\nForced board: 3"
-ObservationTensor(0): binvec(254, 0x37dbb54efeff9f6bfeefe4020450000010080088000810844040102100000040)
-ObservationTensor(1): binvec(254, 0x37dbb54efeff9f6bfeefe4020450000010080088000810844040102100000040)
+InformationStateString(0) = "7, 6, 3, 8, 8, 1, 3, 5, 1, 5, 5, 7, 5, 4, 4, 7, 8, 5, 0"
+InformationStateString(1) = "7, 6, 3, 8, 8, 1, 3, 5, 1, 5, 5, 7, 5, 4, 4, 7, 8, 5, 0"
+ObservationString(0) = "... ... ...\n... o.x ...\n... ... ...\n\n... ... oo.\n..x .o. .xo\n..x .x. .x.\n\n... ... .x.\no.. ..o ..x\n... x.o ..o\n\nCurrent player: 0\nForced board: 0"
+ObservationString(1) = "... ... ...\n... o.x ...\n... ... ...\n\n... ... oo.\n..x .o. .xo\n..x .x. .x.\n\n... ... .x.\no.. ..o ..x\n... x.o ..o\n\nCurrent player: 0\nForced board: 0"
+ObservationTensor(0): binvec(254, 0x3ffd7fffdbda65effcaec00100000010c4080120100020000901048000444200)
+ObservationTensor(1): binvec(254, 0x3ffd7fffdbda65effcaec00100000010c4080120100020000901048000444200)
 Rewards() = [0, 0]
 Returns() = [0, 0]
-LegalActions() = [0, 1, 3, 4, 5, 6, 7, 8]
-StringLegalActions() = ["Local board 3: x(0,0)", "Local board 3: x(0,1)", "Local board 3: x(1,0)", "Local board 3: x(1,1)", "Local board 3: x(1,2)", "Local board 3: x(2,0)", "Local board 3: x(2,1)", "Local board 3: x(2,2)"]
+LegalActions() = [0, 1, 2, 3, 4, 5, 6, 7, 8]
+StringLegalActions() = ["Local board 0: x(0,0)", "Local board 0: x(0,1)", "Local board 0: x(0,2)", "Local board 0: x(1,0)", "Local board 0: x(1,1)", "Local board 0: x(1,2)", "Local board 0: x(2,0)", "Local board 0: x(2,1)", "Local board 0: x(2,2)"]
 
-# Apply action "Local board 3: x(2,2)"
-action: 8
+# Apply action "Local board 0: x(0,0)"
+action: 0
 
 # State 20
-# Apply action "Local board 8: o(1,1)"
-action: 4
+# Apply action "Local board 0: o(1,0)"
+action: 3
 
 # State 21
-# Apply action "Local board 4: x(2,0)"
-action: 6
+# Apply action "Local board 3: x(0,1)"
+action: 1
 
 # State 22
-# ..o ..o o.x
-# ... ... .o.
-# ..x x.. ox.
+# x.. ... ...
+# o.. o.x ...
+# ... ... ...
 #
-# ..x .x. ..x
-# ... ... o..
-# ..x x.. ...
+# .x. ... oo.
+# ..x .o. .xo
+# ..x .x. .x.
 #
-# x.. ... .o.
-# o.x ... .o.
-# ... o.. ...
+# ... ... .x.
+# o.. ..o ..x
+# ... x.o ..o
 #
 # Current player: 1
-# Forced board: 6
+# Forced board: 1
 IsTerminal() = False
-History() = [5, 2, 4, 1, 2, 2, 6, 0, 2, 7, 6, 5, 3, 2, 0, 8, 1, 6, 3, 8, 4, 6]
-HistoryString() = "5, 2, 4, 1, 2, 2, 6, 0, 2, 7, 6, 5, 3, 2, 0, 8, 1, 6, 3, 8, 4, 6"
+History() = [7, 6, 3, 8, 8, 1, 3, 5, 1, 5, 5, 7, 5, 4, 4, 7, 8, 5, 0, 0, 3, 1]
+HistoryString() = "7, 6, 3, 8, 8, 1, 3, 5, 1, 5, 5, 7, 5, 4, 4, 7, 8, 5, 0, 0, 3, 1"
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = 1
-InformationStateString(0) = "5, 2, 4, 1, 2, 2, 6, 0, 2, 7, 6, 5, 3, 2, 0, 8, 1, 6, 3, 8, 4, 6"
-InformationStateString(1) = "5, 2, 4, 1, 2, 2, 6, 0, 2, 7, 6, 5, 3, 2, 0, 8, 1, 6, 3, 8, 4, 6"
-ObservationString(0) = "..o ..o o.x\n... ... .o.\n..x x.. ox.\n\n..x .x. ..x\n... ... o..\n..x x.. ...\n\nx.. ... .o.\no.x ... .o.\n... o.. ...\n\nCurrent player: 1\nForced board: 6"
-ObservationString(1) = "..o ..o o.x\n... ... .o.\n..x x.. ox.\n\n..x .x. ..x\n... ... o..\n..x x.. ...\n\nx.. ... .o.\no.x ... .o.\n... o.. ...\n\nCurrent player: 1\nForced board: 6"
-ObservationTensor(0): binvec(254, 0x37dbb54efaf79f6bfeede4020450000010080089000810844142102100000408)
-ObservationTensor(1): binvec(254, 0x37dbb54efaf79f6bfeede4020450000010080089000810844142102100000408)
+InformationStateString(0) = "7, 6, 3, 8, 8, 1, 3, 5, 1, 5, 5, 7, 5, 4, 4, 7, 8, 5, 0, 0, 3, 1"
+InformationStateString(1) = "7, 6, 3, 8, 8, 1, 3, 5, 1, 5, 5, 7, 5, 4, 4, 7, 8, 5, 0, 0, 3, 1"
+ObservationString(0) = "x.. ... ...\no.. o.x ...\n... ... ...\n\n.x. ... oo.\n..x .o. .xo\n..x .x. .x.\n\n... ... .x.\no.. ..o ..x\n... x.o ..o\n\nCurrent player: 1\nForced board: 1"
+ObservationString(1) = "x.. ... ...\no.. o.x ...\n... ... ...\n\n.x. ... oo.\n..x .o. .xo\n..x .x. .x.\n\n... ... .x.\no.. ..o ..x\n... x.o ..o\n\nCurrent player: 1\nForced board: 1"
+ObservationTensor(0): binvec(254, 0x1bfd7ffddbda65effcaec20100000010c4080120180020008901048000444500)
+ObservationTensor(1): binvec(254, 0x1bfd7ffddbda65effcaec20100000010c4080120180020008901048000444500)
 Rewards() = [0, 0]
 Returns() = [0, 0]
-LegalActions() = [1, 2, 4, 6, 7, 8]
-StringLegalActions() = ["Local board 6: o(0,1)", "Local board 6: o(0,2)", "Local board 6: o(1,1)", "Local board 6: o(2,0)", "Local board 6: o(2,1)", "Local board 6: o(2,2)"]
+LegalActions() = [0, 1, 2, 4, 6, 7, 8]
+StringLegalActions() = ["Local board 1: o(0,0)", "Local board 1: o(0,1)", "Local board 1: o(0,2)", "Local board 1: o(1,1)", "Local board 1: o(2,0)", "Local board 1: o(2,1)", "Local board 1: o(2,2)"]
 
-# Apply action "Local board 6: o(1,1)"
-action: 4
+# Apply action "Local board 1: o(0,1)"
+action: 1
 
 # State 23
-# Apply action "Local board 4: x(1,1)"
+# Apply action "Local board 1: x(1,1)"
 action: 4
 
 # State 24
-# Apply action "Local board 4: o(1,0)"
-action: 3
-
-# State 25
-# Apply action "Local board 3: x(1,0)"
-action: 3
-
-# State 26
-# Apply action "Local board 3: o(1,2)"
-action: 5
-
-# State 27
-# Apply action "Local board 5: x(2,0)"
+# Apply action "Local board 4: o(2,0)"
 action: 6
 
+# State 25
+# Apply action "Local board 6: x(2,1)"
+action: 7
+
+# State 26
+# Apply action "Local board 7: o(1,0)"
+action: 3
+
+# State 27
+# Apply action "Local board 3: x(0,0)"
+action: 0
+
 # State 28
-# Apply action "Local board 6: o(2,0)"
+# Apply action "Local board 0: o(2,0)"
 action: 6
 
 # State 29
@@ -403,343 +403,209 @@ action: 2
 action: 1
 
 # State 31
-# Apply action "Local board 1: x(2,2)"
-action: 8
-
-# State 32
-# Apply action "Local board 8: o(2,2)"
-action: 8
-
-# State 33
-# Apply action "Local board 8: x(2,0)"
-action: 6
-
-# State 34
-# Apply action "Local board 6: o(2,1)"
-action: 7
-
-# State 35
-# Apply action "Local board 7: x(1,2)"
-action: 5
-
-# State 36
-# Apply action "Local board 5: o(0,0)"
-action: 0
-
-# State 37
-# Apply action "Local board 0: x(2,1)"
-action: 7
-
-# State 38
-# Apply action "Local board 7: o(2,2)"
-action: 8
-
-# State 39
-# ..o ..o oox
-# ... ... .o.
-# .xx x.x ox.
-#
-# ..x .x. o.x
-# x.o ox. o..
-# ..x x.. x..
-#
-# x.x ... .o.
-# oox ..x .o.
-# oo. o.o x.o
-#
-# Current player: 0
-# Forced board: 8
-IsTerminal() = False
-History() = [5, 2, 4, 1, 2, 2, 6, 0, 2, 7, 6, 5, 3, 2, 0, 8, 1, 6, 3, 8, 4, 6, 4, 4, 3, 3, 5, 6, 6, 2, 1, 8, 8, 6, 7, 5, 0, 7, 8]
-HistoryString() = "5, 2, 4, 1, 2, 2, 6, 0, 2, 7, 6, 5, 3, 2, 0, 8, 1, 6, 3, 8, 4, 6, 4, 4, 3, 3, 5, 6, 6, 2, 1, 8, 8, 6, 7, 5, 0, 7, 8"
-IsChanceNode() = False
-IsSimultaneousNode() = False
-CurrentPlayer() = 0
-InformationStateString(0) = "5, 2, 4, 1, 2, 2, 6, 0, 2, 7, 6, 5, 3, 2, 0, 8, 1, 6, 3, 8, 4, 6, 4, 4, 3, 3, 5, 6, 6, 2, 1, 8, 8, 6, 7, 5, 0, 7, 8"
-InformationStateString(1) = "5, 2, 4, 1, 2, 2, 6, 0, 2, 7, 6, 5, 3, 2, 0, 8, 1, 6, 3, 8, 4, 6, 4, 4, 3, 3, 5, 6, 6, 2, 1, 8, 8, 6, 7, 5, 0, 7, 8"
-ObservationString(0) = "..o ..o oox\n... ... .o.\n.xx x.x ox.\n\n..x .x. o.x\nx.o ox. o..\n..x x.. x..\n\nx.x ... .o.\noox ..x .o.\noo. o.o x.o\n\nCurrent player: 0\nForced board: 8"
-ObservationString(1) = "..o ..o oox\n... ... .o.\n.xx x.x ox.\n\n..x .x. o.x\nx.o ox. o..\n..x x.. x..\n\nx.x ... .o.\noox ..x .o.\noo. o.o x.o\n\nCurrent player: 0\nForced board: 8"
-ObservationTensor(0): binvec(254, 0x379ba14e5a969b40fcad440206501020900d80a910181484614a112900802002)
-ObservationTensor(1): binvec(254, 0x379ba14e5a969b40fcad440206501020900d80a910181484614a112900802002)
-Rewards() = [0, 0]
-Returns() = [0, 0]
-LegalActions() = [0, 2, 3, 5, 7]
-StringLegalActions() = ["Local board 8: x(0,0)", "Local board 8: x(0,2)", "Local board 8: x(1,0)", "Local board 8: x(1,2)", "Local board 8: x(2,1)"]
-
-# Apply action "Local board 8: x(1,2)"
-action: 5
-
-# State 40
-# Apply action "Local board 5: o(2,2)"
-action: 8
-
-# State 41
-# Apply action "Local board 8: x(1,0)"
-action: 3
-
-# State 42
-# ..o ..o oox
-# ... ... .o.
-# .xx x.x ox.
-#
-# ..x .x. o.x
-# x.o ox. o..
-# ..x x.. x.o
-#
-# x.x ... .o.
-# oox ..x xox
-# oo. o.o x.o
-#
-# Current player: 1
-# Forced board: 3
-IsTerminal() = False
-History() = [5, 2, 4, 1, 2, 2, 6, 0, 2, 7, 6, 5, 3, 2, 0, 8, 1, 6, 3, 8, 4, 6, 4, 4, 3, 3, 5, 6, 6, 2, 1, 8, 8, 6, 7, 5, 0, 7, 8, 5, 8, 3]
-HistoryString() = "5, 2, 4, 1, 2, 2, 6, 0, 2, 7, 6, 5, 3, 2, 0, 8, 1, 6, 3, 8, 4, 6, 4, 4, 3, 3, 5, 6, 6, 2, 1, 8, 8, 6, 7, 5, 0, 7, 8, 5, 8, 3"
-IsChanceNode() = False
-IsSimultaneousNode() = False
-CurrentPlayer() = 1
-InformationStateString(0) = "5, 2, 4, 1, 2, 2, 6, 0, 2, 7, 6, 5, 3, 2, 0, 8, 1, 6, 3, 8, 4, 6, 4, 4, 3, 3, 5, 6, 6, 2, 1, 8, 8, 6, 7, 5, 0, 7, 8, 5, 8, 3"
-InformationStateString(1) = "5, 2, 4, 1, 2, 2, 6, 0, 2, 7, 6, 5, 3, 2, 0, 8, 1, 6, 3, 8, 4, 6, 4, 4, 3, 3, 5, 6, 6, 2, 1, 8, 8, 6, 7, 5, 0, 7, 8, 5, 8, 3"
-ObservationString(0) = "..o ..o oox\n... ... .o.\n.xx x.x ox.\n\n..x .x. o.x\nx.o ox. o..\n..x x.. x.o\n\nx.x ... .o.\noox ..x xox\noo. o.o x.o\n\nCurrent player: 1\nForced board: 3"
-ObservationString(1) = "..o ..o oox\n... ... .o.\n.xx x.x ox.\n\n..x .x. o.x\nx.o ox. o..\n..x x.. x.o\n\nx.x ... .o.\noox ..x xox\noo. o.o x.o\n\nCurrent player: 1\nForced board: 3"
-ObservationTensor(0): binvec(254, 0x379ba14e5a969a40fca8440206501020908d80a910181484614a112900816440)
-ObservationTensor(1): binvec(254, 0x379ba14e5a969a40fca8440206501020908d80a910181484614a112900816440)
-Rewards() = [0, 0]
-Returns() = [0, 0]
-LegalActions() = [0, 1, 4, 6, 7]
-StringLegalActions() = ["Local board 3: o(0,0)", "Local board 3: o(0,1)", "Local board 3: o(1,1)", "Local board 3: o(2,0)", "Local board 3: o(2,1)"]
-
-# Apply action "Local board 3: o(1,1)"
-action: 4
-
-# State 43
-# Apply action "Local board 4: x(0,2)"
-action: 2
-
-# State 44
-# Apply action "Local board 2: o(2,2)"
-action: 8
-
-# State 45
-# Apply action "Local board 8: x(0,2)"
-action: 2
-
-# State 46
-# Apply action "Choose local board 3"
-action: 3
-
-# State 47
-# Apply action "Local board 3: o(0,1)"
-action: 1
-
-# State 48
 # Apply action "Local board 1: x(0,0)"
 action: 0
 
-# State 49
+# State 32
 # Apply action "Local board 0: o(0,1)"
 action: 1
 
-# State 50
-# Apply action "Local board 1: x(0,1)"
-action: 1
-
-# State 51
-# Apply action "Local board 1: o(1,1)"
-action: 4
-
-# State 52
-# Apply action "Choose local board 7"
-action: 7
-
-# State 53
-# Apply action "Local board 7: x(1,0)"
-action: 3
-
-# State 54
-# Apply action "Local board 3: o(2,1)"
-action: 7
-
-# State 55
-# Apply action "Local board 7: x(0,2)"
-action: 2
-
-# State 56
-# Apply action "Choose local board 0"
-action: 0
-
-# State 57
-# Apply action "Local board 0: o(1,0)"
-action: 3
-
-# State 58
-# Apply action "Local board 3: x(0,0)"
-action: 0
-
-# State 59
-# Apply action "Local board 0: o(2,0)"
-action: 6
-
-# State 60
-# .oo xxo oox
-# x.. .o. .o.
-# oxx x.x oxo
-#
-# xxx .xx o.x
-# xoo ox. o..
-# .ox x.. x.o
-#
-# x.x ..x .ox
-# oox x.x xox
-# oo. o.o x.o
-#
-# Current player: 0
-# Forced board: 6
-IsTerminal() = False
-History() = [5, 2, 4, 1, 2, 2, 6, 0, 2, 7, 6, 5, 3, 2, 0, 8, 1, 6, 3, 8, 4, 6, 4, 4, 3, 3, 5, 6, 6, 2, 1, 8, 8, 6, 7, 5, 0, 7, 8, 5, 8, 3, 4, 2, 8, 2, 3, 1, 0, 1, 1, 4, 7, 3, 7, 2, 0, 3, 0, 6]
-HistoryString() = "5, 2, 4, 1, 2, 2, 6, 0, 2, 7, 6, 5, 3, 2, 0, 8, 1, 6, 3, 8, 4, 6, 4, 4, 3, 3, 5, 6, 6, 2, 1, 8, 8, 6, 7, 5, 0, 7, 8, 5, 8, 3, 4, 2, 8, 2, 3, 1, 0, 1, 1, 4, 7, 3, 7, 2, 0, 3, 0, 6"
-IsChanceNode() = False
-IsSimultaneousNode() = False
-CurrentPlayer() = 0
-InformationStateString(0) = "5, 2, 4, 1, 2, 2, 6, 0, 2, 7, 6, 5, 3, 2, 0, 8, 1, 6, 3, 8, 4, 6, 4, 4, 3, 3, 5, 6, 6, 2, 1, 8, 8, 6, 7, 5, 0, 7, 8, 5, 8, 3, 4, 2, 8, 2, 3, 1, 0, 1, 1, 4, 7, 3, 7, 2, 0, 3, 0, 6"
-InformationStateString(1) = "5, 2, 4, 1, 2, 2, 6, 0, 2, 7, 6, 5, 3, 2, 0, 8, 1, 6, 3, 8, 4, 6, 4, 4, 3, 3, 5, 6, 6, 2, 1, 8, 8, 6, 7, 5, 0, 7, 8, 5, 8, 3, 4, 2, 8, 2, 3, 1, 0, 1, 1, 4, 7, 3, 7, 2, 0, 3, 0, 6"
-ObservationString(0) = ".oo xxo oox\nx.. .o. .o.\noxx x.x oxo\n\nxxx .xx o.x\nxoo ox. o..\n.ox x.. x.o\n\nx.x ..x .ox\noox x.x xox\noo. o.o x.o\n\nCurrent player: 0\nForced board: 6"
-ObservationString(1) = ".oo xxo oox\nx.. .o. .o.\noxx x.x oxo\n\nxxx .xx o.x\nxoo ox. o..\n.ox x.. x.o\n\nx.x ..x .ox\noox x.x xox\noo. o.o x.o\n\nCurrent player: 0\nForced board: 6"
-ObservationTensor(0): binvec(254, 0x2302a14012169a40e4a04c4286543420908d80a9111e1485e16a112906836008)
-ObservationTensor(1): binvec(254, 0x2302a14012169a40e4a04c4286543420908d80a9111e1485e16a112906836008)
-Rewards() = [0, 0]
-Returns() = [0, 0]
-LegalActions() = [1, 8]
-StringLegalActions() = ["Local board 6: x(0,1)", "Local board 6: x(2,2)"]
-
-# Apply action "Local board 6: x(0,1)"
-action: 1
-
-# State 61
-# .oo xxo oox
-# x.. .o. .o.
-# oxx x.x oxo
-#
-# xxx .xx o.x
-# xoo ox. o..
-# .ox x.. x.o
-#
-# xxx ..x .ox
-# oox x.x xox
-# oo. o.o x.o
-#
-# Current player: 1
-# Forced board: 1
-IsTerminal() = False
-History() = [5, 2, 4, 1, 2, 2, 6, 0, 2, 7, 6, 5, 3, 2, 0, 8, 1, 6, 3, 8, 4, 6, 4, 4, 3, 3, 5, 6, 6, 2, 1, 8, 8, 6, 7, 5, 0, 7, 8, 5, 8, 3, 4, 2, 8, 2, 3, 1, 0, 1, 1, 4, 7, 3, 7, 2, 0, 3, 0, 6, 1]
-HistoryString() = "5, 2, 4, 1, 2, 2, 6, 0, 2, 7, 6, 5, 3, 2, 0, 8, 1, 6, 3, 8, 4, 6, 4, 4, 3, 3, 5, 6, 6, 2, 1, 8, 8, 6, 7, 5, 0, 7, 8, 5, 8, 3, 4, 2, 8, 2, 3, 1, 0, 1, 1, 4, 7, 3, 7, 2, 0, 3, 0, 6, 1"
-IsChanceNode() = False
-IsSimultaneousNode() = False
-CurrentPlayer() = 1
-InformationStateString(0) = "5, 2, 4, 1, 2, 2, 6, 0, 2, 7, 6, 5, 3, 2, 0, 8, 1, 6, 3, 8, 4, 6, 4, 4, 3, 3, 5, 6, 6, 2, 1, 8, 8, 6, 7, 5, 0, 7, 8, 5, 8, 3, 4, 2, 8, 2, 3, 1, 0, 1, 1, 4, 7, 3, 7, 2, 0, 3, 0, 6, 1"
-InformationStateString(1) = "5, 2, 4, 1, 2, 2, 6, 0, 2, 7, 6, 5, 3, 2, 0, 8, 1, 6, 3, 8, 4, 6, 4, 4, 3, 3, 5, 6, 6, 2, 1, 8, 8, 6, 7, 5, 0, 7, 8, 5, 8, 3, 4, 2, 8, 2, 3, 1, 0, 1, 1, 4, 7, 3, 7, 2, 0, 3, 0, 6, 1"
-ObservationString(0) = ".oo xxo oox\nx.. .o. .o.\noxx x.x oxo\n\nxxx .xx o.x\nxoo ox. o..\n.ox x.. x.o\n\nxxx ..x .ox\noox x.x xox\noo. o.o x.o\n\nCurrent player: 1\nForced board: 1"
-ObservationString(1) = ".oo xxo oox\nx.. .o. .o.\noxx x.x oxo\n\nxxx .xx o.x\nxoo ox. o..\n.ox x.. x.o\n\nxxx ..x .ox\noox x.x xox\noo. o.o x.o\n\nCurrent player: 1\nForced board: 1"
-ObservationTensor(0): binvec(254, 0x2302a14012169a00e4a04c4286543420908d80a9111e1485e16a113906836500)
-ObservationTensor(1): binvec(254, 0x2302a14012169a00e4a04c4286543420908d80a9111e1485e16a113906836500)
-Rewards() = [0, 0]
-Returns() = [0, 0]
-LegalActions() = [3, 5, 7]
-StringLegalActions() = ["Local board 1: o(1,0)", "Local board 1: o(1,2)", "Local board 1: o(2,1)"]
-
-# Apply action "Local board 1: o(1,0)"
-action: 3
-
-# State 62
-# Apply action "Choose local board 5"
-action: 5
-
-# State 63
-# Apply action "Local board 5: x(2,1)"
-action: 7
-
-# State 64
-# Apply action "Local board 7: o(0,0)"
-action: 0
-
-# State 65
-# Apply action "Local board 0: x(1,2)"
-action: 5
-
-# State 66
-# Apply action "Local board 5: o(1,1)"
-action: 4
-
-# State 67
-# Apply action "Choose local board 0"
-action: 0
-
-# State 68
-# Apply action "Local board 0: x(0,0)"
-action: 0
-
-# State 69
-# Apply action "Choose local board 7"
-action: 7
-
-# State 70
-# Apply action "Local board 7: o(0,1)"
-action: 1
-
-# State 71
-# Apply action "Local board 1: x(1,2)"
-action: 5
-
-# State 72
-# Apply action "Choose local board 7"
-action: 7
-
-# State 73
-# Apply action "Local board 7: o(1,1)"
-action: 4
-
-# State 74
-# Apply action "Choose local board 1"
-action: 1
-
-# State 75
-# Apply action "Local board 1: x(2,1)"
-action: 7
-
-# State 76
-# Apply action "Choose local board 8"
+# State 33
+# Apply action "Local board 1: x(2,2)"
 action: 8
 
-# State 77
+# State 34
+# Apply action "Local board 8: o(2,0)"
+action: 6
+
+# State 35
+# Apply action "Local board 6: x(2,2)"
+action: 8
+
+# State 36
 # Apply action "Local board 8: o(2,1)"
 action: 7
 
-# State 78
-# ooo xxo oox
-# x.x oox .o.
-# oxx xox oxo
+# State 37
+# Apply action "Local board 7: x(0,0)"
+action: 0
+
+# State 38
+# Apply action "Local board 0: o(1,1)"
+action: 4
+
+# State 39
+# xo. xo. .o.
+# oo. oxx ...
+# o.. ..x ...
 #
-# xxx .xx o.x
-# xoo ox. oo.
-# .ox x.. xxo
+# xx. ... oo.
+# ..x .o. .xo
+# ..x ox. .x.
 #
-# xxx oxx .ox
-# oox xox xox
-# oo. o.o xoo
+# ..x x.. .x.
+# o.. o.o ..x
+# .xx x.o ooo
+#
+# Current player: 0
+# Forced board: 4
+IsTerminal() = False
+History() = [7, 6, 3, 8, 8, 1, 3, 5, 1, 5, 5, 7, 5, 4, 4, 7, 8, 5, 0, 0, 3, 1, 1, 4, 6, 7, 3, 0, 6, 2, 1, 0, 1, 8, 6, 8, 7, 0, 4]
+HistoryString() = "7, 6, 3, 8, 8, 1, 3, 5, 1, 5, 5, 7, 5, 4, 4, 7, 8, 5, 0, 0, 3, 1, 1, 4, 6, 7, 3, 0, 6, 2, 1, 0, 1, 8, 6, 8, 7, 0, 4"
+IsChanceNode() = False
+IsSimultaneousNode() = False
+CurrentPlayer() = 0
+InformationStateString(0) = "7, 6, 3, 8, 8, 1, 3, 5, 1, 5, 5, 7, 5, 4, 4, 7, 8, 5, 0, 0, 3, 1, 1, 4, 6, 7, 3, 0, 6, 2, 1, 0, 1, 8, 6, 8, 7, 0, 4"
+InformationStateString(1) = "7, 6, 3, 8, 8, 1, 3, 5, 1, 5, 5, 7, 5, 4, 4, 7, 8, 5, 0, 0, 3, 1, 1, 4, 6, 7, 3, 0, 6, 2, 1, 0, 1, 8, 6, 8, 7, 0, 4"
+ObservationString(0) = "xo. xo. .o.\noo. oxx ...\no.. ..x ...\n\nxx. ... oo.\n..x .o. .xo\n..x ox. .x.\n\n..x x.. .x.\no.. o.o ..x\n.xx x.o ooo\n\nCurrent player: 0\nForced board: 4"
+ObservationString(1) = "xo. xo. .o.\noo. oxx ...\no.. ..x ...\n\nxx. ... oo.\n..x .o. .xo\n..x ox. .x.\n\n..x x.. .x.\no.. o.o ..x\n.xx x.o ooo\n\nCurrent player: 0\nForced board: 4"
+ObservationTensor(0): binvec(254, 0x9646bf9dbd265ce34ae0b4502000014c4080520780464018901048870444020)
+ObservationTensor(1): binvec(254, 0x9646bf9dbd265ce34ae0b4502000014c4080520780464018901048870444020)
+Rewards() = [0, 0]
+Returns() = [0, 0]
+LegalActions() = [0, 1, 2, 3, 5, 8]
+StringLegalActions() = ["Local board 4: x(0,0)", "Local board 4: x(0,1)", "Local board 4: x(0,2)", "Local board 4: x(1,0)", "Local board 4: x(1,2)", "Local board 4: x(2,2)"]
+
+# Apply action "Local board 4: x(0,0)"
+action: 0
+
+# State 40
+# Apply action "Local board 0: o(2,1)"
+action: 7
+
+# State 41
+# Apply action "Local board 7: x(0,2)"
+action: 2
+
+# State 42
+# xo. xo. .o.
+# oo. oxx ...
+# oo. ..x ...
+#
+# xx. x.. oo.
+# ..x .o. .xo
+# ..x ox. .x.
+#
+# ..x x.x .x.
+# o.. o.o ..x
+# .xx x.o ooo
 #
 # Current player: 1
-# Forced board: 7
+# Forced board: 2
+IsTerminal() = False
+History() = [7, 6, 3, 8, 8, 1, 3, 5, 1, 5, 5, 7, 5, 4, 4, 7, 8, 5, 0, 0, 3, 1, 1, 4, 6, 7, 3, 0, 6, 2, 1, 0, 1, 8, 6, 8, 7, 0, 4, 0, 7, 2]
+HistoryString() = "7, 6, 3, 8, 8, 1, 3, 5, 1, 5, 5, 7, 5, 4, 4, 7, 8, 5, 0, 0, 3, 1, 1, 4, 6, 7, 3, 0, 6, 2, 1, 0, 1, 8, 6, 8, 7, 0, 4, 0, 7, 2"
+IsChanceNode() = False
+IsSimultaneousNode() = False
+CurrentPlayer() = 1
+InformationStateString(0) = "7, 6, 3, 8, 8, 1, 3, 5, 1, 5, 5, 7, 5, 4, 4, 7, 8, 5, 0, 0, 3, 1, 1, 4, 6, 7, 3, 0, 6, 2, 1, 0, 1, 8, 6, 8, 7, 0, 4, 0, 7, 2"
+InformationStateString(1) = "7, 6, 3, 8, 8, 1, 3, 5, 1, 5, 5, 7, 5, 4, 4, 7, 8, 5, 0, 0, 3, 1, 1, 4, 6, 7, 3, 0, 6, 2, 1, 0, 1, 8, 6, 8, 7, 0, 4, 0, 7, 2"
+ObservationString(0) = "xo. xo. .o.\noo. oxx ...\noo. ..x ...\n\nxx. x.. oo.\n..x .o. .xo\n..x ox. .x.\n\n..x x.x .x.\no.. o.o ..x\n.xx x.o ooo\n\nCurrent player: 1\nForced board: 2"
+ObservationString(1) = "xo. xo. .o.\noo. oxx ...\noo. ..x ...\n\nxx. x.. oo.\n..x .o. .xo\n..x ox. .x.\n\n..x x.x .x.\no.. o.o ..x\n.xx x.o ooo\n\nCurrent player: 1\nForced board: 2"
+ObservationTensor(0): binvec(254, 0x9246bf9d9d265ce24ae0b6502000014c4080520780464018981048874444480)
+ObservationTensor(1): binvec(254, 0x9246bf9d9d265ce24ae0b6502000014c4080520780464018981048874444480)
+Rewards() = [0, 0]
+Returns() = [0, 0]
+LegalActions() = [0, 2, 3, 4, 5, 6, 7, 8]
+StringLegalActions() = ["Local board 2: o(0,0)", "Local board 2: o(0,2)", "Local board 2: o(1,0)", "Local board 2: o(1,1)", "Local board 2: o(1,2)", "Local board 2: o(2,0)", "Local board 2: o(2,1)", "Local board 2: o(2,2)"]
+
+# Apply action "Local board 2: o(1,0)"
+action: 3
+
+# State 43
+# Apply action "Local board 3: x(1,0)"
+action: 3
+
+# State 44
+# Apply action "Local board 3: o(1,1)"
+action: 4
+
+# State 45
+# Apply action "Local board 4: x(1,2)"
+action: 5
+
+# State 46
+# Apply action "Local board 5: o(0,2)"
+action: 2
+
+# State 47
+# Apply action "Local board 2: x(1,1)"
+action: 4
+
+# State 48
+# Apply action "Local board 4: o(0,1)"
+action: 1
+
+# State 49
+# Apply action "Choose local board 2"
+action: 2
+
+# State 50
+# Apply action "Local board 2: x(1,2)"
+action: 5
+
+# State 51
+# Apply action "Choose local board 4"
+action: 4
+
+# State 52
+# Apply action "Local board 4: o(1,0)"
+action: 3
+
+# State 53
+# Apply action "Local board 3: x(0,2)"
+action: 2
+
+# State 54
+# Apply action "Local board 2: o(0,2)"
+action: 2
+
+# State 55
+# Apply action "Local board 2: x(2,2)"
+action: 8
+
+# State 56
+# Apply action "Choose local board 6"
+action: 6
+
+# State 57
+# Apply action "Local board 6: o(1,1)"
+action: 4
+
+# State 58
+# Apply action "Local board 4: x(0,2)"
+action: 2
+
+# State 59
+# Apply action "Local board 2: o(0,0)"
+action: 0
+
+# State 60
+# xo. xo. ooo
+# oo. oxx oxx
+# oo. ..x ..x
+#
+# xxx xox ooo
+# xox oox .xo
+# ..x ox. .x.
+#
+# ..x x.x .x.
+# oo. o.o ..x
+# .xx x.o ooo
+#
+# Current player: 1
+# Forced board: 0
 IsTerminal() = True
-History() = [5, 2, 4, 1, 2, 2, 6, 0, 2, 7, 6, 5, 3, 2, 0, 8, 1, 6, 3, 8, 4, 6, 4, 4, 3, 3, 5, 6, 6, 2, 1, 8, 8, 6, 7, 5, 0, 7, 8, 5, 8, 3, 4, 2, 8, 2, 3, 1, 0, 1, 1, 4, 7, 3, 7, 2, 0, 3, 0, 6, 1, 3, 5, 7, 0, 5, 4, 0, 0, 7, 1, 5, 7, 4, 1, 7, 8, 7]
-HistoryString() = "5, 2, 4, 1, 2, 2, 6, 0, 2, 7, 6, 5, 3, 2, 0, 8, 1, 6, 3, 8, 4, 6, 4, 4, 3, 3, 5, 6, 6, 2, 1, 8, 8, 6, 7, 5, 0, 7, 8, 5, 8, 3, 4, 2, 8, 2, 3, 1, 0, 1, 1, 4, 7, 3, 7, 2, 0, 3, 0, 6, 1, 3, 5, 7, 0, 5, 4, 0, 0, 7, 1, 5, 7, 4, 1, 7, 8, 7"
+History() = [7, 6, 3, 8, 8, 1, 3, 5, 1, 5, 5, 7, 5, 4, 4, 7, 8, 5, 0, 0, 3, 1, 1, 4, 6, 7, 3, 0, 6, 2, 1, 0, 1, 8, 6, 8, 7, 0, 4, 0, 7, 2, 3, 3, 4, 5, 2, 4, 1, 2, 5, 4, 3, 2, 2, 8, 6, 4, 2, 0]
+HistoryString() = "7, 6, 3, 8, 8, 1, 3, 5, 1, 5, 5, 7, 5, 4, 4, 7, 8, 5, 0, 0, 3, 1, 1, 4, 6, 7, 3, 0, 6, 2, 1, 0, 1, 8, 6, 8, 7, 0, 4, 0, 7, 2, 3, 3, 4, 5, 2, 4, 1, 2, 5, 4, 3, 2, 2, 8, 6, 4, 2, 0"
 IsChanceNode() = False
 IsSimultaneousNode() = False
 CurrentPlayer() = -4
-InformationStateString(0) = "5, 2, 4, 1, 2, 2, 6, 0, 2, 7, 6, 5, 3, 2, 0, 8, 1, 6, 3, 8, 4, 6, 4, 4, 3, 3, 5, 6, 6, 2, 1, 8, 8, 6, 7, 5, 0, 7, 8, 5, 8, 3, 4, 2, 8, 2, 3, 1, 0, 1, 1, 4, 7, 3, 7, 2, 0, 3, 0, 6, 1, 3, 5, 7, 0, 5, 4, 0, 0, 7, 1, 5, 7, 4, 1, 7, 8, 7"
-InformationStateString(1) = "5, 2, 4, 1, 2, 2, 6, 0, 2, 7, 6, 5, 3, 2, 0, 8, 1, 6, 3, 8, 4, 6, 4, 4, 3, 3, 5, 6, 6, 2, 1, 8, 8, 6, 7, 5, 0, 7, 8, 5, 8, 3, 4, 2, 8, 2, 3, 1, 0, 1, 1, 4, 7, 3, 7, 2, 0, 3, 0, 6, 1, 3, 5, 7, 0, 5, 4, 0, 0, 7, 1, 5, 7, 4, 1, 7, 8, 7"
-ObservationString(0) = "ooo xxo oox\nx.x oox .o.\noxx xox oxo\n\nxxx .xx o.x\nxoo ox. oo.\n.ox x.. xxo\n\nxxx oxx .ox\noox xox xox\noo. o.o xoo\n\nCurrent player: 1\nForced board: 7"
-ObservationString(1) = "ooo xxo oox\nx.x oox .o.\noxx xox oxo\n\nxxx .xx o.x\nxoo ox. oo.\n.ox x.. xxo\n\nxxx oxx .ox\noox xox xox\noo. o.o xoo\n\nCurrent player: 1\nForced board: 7"
-ObservationTensor(0): binvec(254, 0x20001401216880080a01c4396543420988da2a9315e3485e16a11b90e836404)
-ObservationTensor(1): binvec(254, 0x20001401216880080a01c4396543420988da2a9315e3485e16a11b90e836404)
+InformationStateString(0) = "7, 6, 3, 8, 8, 1, 3, 5, 1, 5, 5, 7, 5, 4, 4, 7, 8, 5, 0, 0, 3, 1, 1, 4, 6, 7, 3, 0, 6, 2, 1, 0, 1, 8, 6, 8, 7, 0, 4, 0, 7, 2, 3, 3, 4, 5, 2, 4, 1, 2, 5, 4, 3, 2, 2, 8, 6, 4, 2, 0"
+InformationStateString(1) = "7, 6, 3, 8, 8, 1, 3, 5, 1, 5, 5, 7, 5, 4, 4, 7, 8, 5, 0, 0, 3, 1, 1, 4, 6, 7, 3, 0, 6, 2, 1, 0, 1, 8, 6, 8, 7, 0, 4, 0, 7, 2, 3, 3, 4, 5, 2, 4, 1, 2, 5, 4, 3, 2, 2, 8, 6, 4, 2, 0"
+ObservationString(0) = "xo. xo. ooo\noo. oxx oxx\noo. ..x ..x\n\nxxx xox ooo\nxox oox .xo\n..x ox. .x.\n\n..x x.x .x.\noo. o.o ..x\n.xx x.o ooo\n\nCurrent player: 1\nForced board: 0"
+ObservationString(1) = "xo. xo. ooo\noo. oxx oxx\noo. ..x ..x\n\nxxx xox ooo\nxox oox .xo\n..x ox. .x.\n\n..x x.x .x.\noo. o.o ..x\n.xx x.o ooo\n\nCurrent player: 1\nForced board: 0"
+ObservationTensor(0): binvec(254, 0x9246030180225c624ae0b65078020b4e40c052078046433e9a5048874444600)
+ObservationTensor(1): binvec(254, 0x9246030180225c624ae0b65078020b4e40c052078046433e9a5048874444600)
 Rewards() = [-1, 1]
 Returns() = [-1, 1]


### PR DESCRIPTION
## Summary

`UltimateTTTState::DoApplyAction` does not sync the newly-selected local board's `current_player_` when a player enters that board via a free-move `Choose local board` action. As a result, the following cell placement is applied for whichever player the local board was left on after its previous visit — often the opposite of the meta-game's `current_player_`.

## Repro (before this PR)

```python
import pyspiel
state = pyspiel.load_game('ultimate_tic_tac_toe').new_initial_state()
for a in [0, 3, 3, 7, 5, 0, 2, 0, 1, 1, 3, 0, 0, 2, 1]:
    state.apply_action(a)
```

- Action 13 is `Choose local board 2` — a free-move by player X (board 2's redirect target was terminal).
- Action 14's `action_to_string` reports `Local board 2: x(0,1)` and `state.current_player()` is `0` (X).
- But the resulting `to_string()` shows `xo.` at board 2 row 0, not `xx.` — the cell was filled with `'o'`.

The cause: after action 7 (`Local board 2: x(0,0)`) the local board's internal `current_player_` was flipped to O. Nothing resets it when action 13 selects board 2 via the choose_subgrid path, so action 14 places for O.

Downstream, `local_state->outcome()` reads the wrong pieces, so free-move sub-grid wins can be attributed to the wrong player.

## Fix

Add the missing `SetCurrentPlayer` call in the choose_subgrid branch of `DoApplyAction`. This mirrors what already happens on the normal choose_cell path (`if (current_state_ >= 0) local_state(current_state_)->SetCurrentPlayer(current_player_);`).

## Test

`ultimate_tic_tac_toe_test.cc` gains a regression test that replays the 15-action sequence above and asserts the target cell is `'x'`. Without the fix, it is `'o'`.